### PR TITLE
🔧 :: #91 Swift 6 전환 및 동시성 오류 수정

### DIFF
--- a/Project/App/Project.swift
+++ b/Project/App/Project.swift
@@ -16,7 +16,8 @@ let project = Project(
     settings: .settings(
         base: [
             "APP_MARKETING_VERSION": .string(AppVersion.marketingVersion),
-            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber)
+            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber),
+            "SWIFT_VERSION": .string("6.0")
         ],
         configurations: [
             .debug(name: "Debug", xcconfig: .relativeToRoot("XCConfig/Debug.xcconfig")),
@@ -78,7 +79,8 @@ let project = Project(
             settings: .settings(
                 base: [
                     "APP_MARKETING_VERSION": .string(AppVersion.marketingVersion),
-                    "APP_BUILD_NUMBER": .string(AppVersion.buildNumber)
+                    "APP_BUILD_NUMBER": .string(AppVersion.buildNumber),
+                    "SWIFT_VERSION": .string("6.0")
                 ],
                 configurations: [
                     .debug(name: "Debug"),

--- a/Project/Data/Project.swift
+++ b/Project/Data/Project.swift
@@ -16,7 +16,8 @@ let project = Project(
     settings: .settings(
         base: [
             "APP_MARKETING_VERSION": .string(AppVersion.marketingVersion),
-            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber)
+            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber),
+            "SWIFT_VERSION": .string("6.0")
         ],
         configurations: [
             .debug(name: "Debug"),

--- a/Project/Data/Sources/DataSource/AppleSignInDataSource.swift
+++ b/Project/Data/Sources/DataSource/AppleSignInDataSource.swift
@@ -10,7 +10,7 @@ import AuthenticationServices
 import Foundation
 
 // MARK: - DTO
-public struct AppleSignInCredential {
+public struct AppleSignInCredential: Sendable {
     public let userIdentifier: String
     public let identityToken: String?
     public let authorizationCode: String?
@@ -33,14 +33,16 @@ public struct AppleSignInCredential {
 }
 
 // MARK: - DataSource Protocol
-public protocol AppleSignInDataSource {
+public protocol AppleSignInDataSource: Sendable {
+    @MainActor
     func signIn(scopes: [String]) async throws -> AppleSignInCredential
 }
 
 // MARK: - Implementation
-public final class AppleSignInDataSourceImpl: AppleSignInDataSource {
+public final class AppleSignInDataSourceImpl: AppleSignInDataSource, @unchecked Sendable {
     public init() {}
     
+    @MainActor
     public func signIn(scopes: [String]) async throws -> AppleSignInCredential {
         let provider = ASAuthorizationAppleIDProvider()
         let request = provider.createRequest()

--- a/Project/Data/Sources/DataSource/AuthenticationNetworkDataSource.swift
+++ b/Project/Data/Sources/DataSource/AuthenticationNetworkDataSource.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 // MARK: - DTO
-public struct AuthTokens {
+public struct AuthTokens: Sendable {
     public let accessToken: String
     public let refreshToken: String
     public let expiresIn: Int
@@ -22,14 +22,14 @@ public struct AuthTokens {
 }
 
 // MARK: - DataSource Protocol
-public protocol AuthenticationNetworkDataSource {
+public protocol AuthenticationNetworkDataSource: Sendable {
     func authenticateWithApple(identityToken: String) async throws -> AuthTokens
     func authenticateWithGoogle(idToken: String) async throws -> AuthTokens
     func refreshToken(_ refreshToken: String) async throws -> AuthTokens
 }
 
 // MARK: - Implementation (향후 서버 통신 시 구현)
-public final class AuthenticationNetworkDataSourceImpl: AuthenticationNetworkDataSource {
+public final class AuthenticationNetworkDataSourceImpl: AuthenticationNetworkDataSource, @unchecked Sendable {
     public init() {}
 
     public func authenticateWithApple(identityToken: String) async throws -> AuthTokens {

--- a/Project/Data/Sources/DataSource/DrinkWaterDataSource.swift
+++ b/Project/Data/Sources/DataSource/DrinkWaterDataSource.swift
@@ -9,14 +9,14 @@
 import Foundation
 import Utils
 
-public protocol DrinkWaterDataSource {
+public protocol DrinkWaterDataSource: Sendable {
     var currentWater: Int { get }
     
     func drinkWater()
     func reset()
 }
 
-public struct DrinkWaterUserDefaultsDataSource: DrinkWaterDataSource {
+public struct DrinkWaterUserDefaultsDataSource: DrinkWaterDataSource, @unchecked Sendable {
     private let userDefaults: UserDefaults
     
     public init(userDefaults: UserDefaults) {

--- a/Project/Data/Sources/DataSource/HealthKitDataSource.swift
+++ b/Project/Data/Sources/DataSource/HealthKitDataSource.swift
@@ -10,7 +10,7 @@ import DomainLayerInterface
 import Foundation
 import HealthKit
 
-public protocol HealthKitDataSource {
+public protocol HealthKitDataSource: Sendable {
     var healthKitAuthorizationStatus: HealthKitAuthorizationStatus { get }
     
     func requestAuthorization() async throws
@@ -19,7 +19,7 @@ public protocol HealthKitDataSource {
     func resetWaterInTakeInToday() async throws
 }
 
-public final class HealthKitDataSourceImpl: HealthKitDataSource {
+public final class HealthKitDataSourceImpl: HealthKitDataSource, @unchecked Sendable {
     private enum Constant {
         static let aGlassOfWater: Double = 250
     }

--- a/Project/Data/Sources/DataSource/KeyChainDataSource.swift
+++ b/Project/Data/Sources/DataSource/KeyChainDataSource.swift
@@ -9,7 +9,7 @@
 import DomainLayerInterface
 import Foundation
 
-public protocol KeyChainDataSource {
+public protocol KeyChainDataSource: Sendable {
     func validateToken() -> Bool
     func save(property: TokenProperty, value: String)
     func load(property: TokenProperty) -> String

--- a/Project/Data/Sources/DataSource/UserPreferencesDataSource.swift
+++ b/Project/Data/Sources/DataSource/UserPreferencesDataSource.swift
@@ -10,14 +10,14 @@ import DomainLayerInterface
 import Foundation
 import Utils
 
-public protocol UserPreferencesDataSource {
+public protocol UserPreferencesDataSource: Sendable {
     func getMainAppearance() -> MainAppearance
     func setMainAppearance(_ appearance: MainAppearance)
     func getDailyWaterLimit() -> Double
     func setDailyWaterLimit(_ limit: Double)
 }
 
-public final class UserPreferencesDataSourceImpl: UserPreferencesDataSource {
+public final class UserPreferencesDataSourceImpl: UserPreferencesDataSource, @unchecked Sendable {
     private let userDefaults: UserDefaults
     
     public init(userDefaults: UserDefaults) {

--- a/Project/Domain/Interfaces/Entity/HydrationRecord.swift
+++ b/Project/Domain/Interfaces/Entity/HydrationRecord.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct HydrationRecord: Hashable, Identifiable {
+public struct HydrationRecord: Hashable, Identifiable, Sendable {
     public let id: UUID
     public let date: Date
     public let mililiter: Double

--- a/Project/Domain/Interfaces/Entity/MainAppearance.swift
+++ b/Project/Domain/Interfaces/Entity/MainAppearance.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum MainAppearance: CaseIterable, Identifiable {
+public enum MainAppearance: CaseIterable, Identifiable, Sendable {
     case drop
     case heart
     case cloud
@@ -60,5 +60,5 @@ public enum MainAppearance: CaseIterable, Identifiable {
     }
     
     // Default appearance
-    public static let `default`: MainAppearance = .drop
+    public static var `default`: MainAppearance { .drop }
 }

--- a/Project/Domain/Interfaces/Entity/UserCredential.swift
+++ b/Project/Domain/Interfaces/Entity/UserCredential.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct UserCredential {
+public struct UserCredential: Sendable {
     public let userIdentifier: String
     public let email: String?
     public let name: String?

--- a/Project/Domain/Interfaces/Repository/AuthenticationRepository.swift
+++ b/Project/Domain/Interfaces/Repository/AuthenticationRepository.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol AuthenticationRepository {
+public protocol AuthenticationRepository: Sendable {
     var isAuthenticated: Bool { get }
 
     func signInWithApple() async throws -> UserCredential

--- a/Project/Domain/Interfaces/Repository/DrinkWaterRepository.swift
+++ b/Project/Domain/Interfaces/Repository/DrinkWaterRepository.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol DrinkWaterRepository {
+public protocol DrinkWaterRepository: Sendable {
     var currentWater: Int { get }
     
     func drinkWater()

--- a/Project/Domain/Interfaces/Repository/HealthKitRepository.swift
+++ b/Project/Domain/Interfaces/Repository/HealthKitRepository.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol HealthKitRepository {
+public protocol HealthKitRepository: Sendable {
     var authorisationStatus: HealthKitAuthorizationStatus { get }
     
     func requestAuthorization() async throws

--- a/Project/Domain/Interfaces/Repository/UserPreferencesRepository.swift
+++ b/Project/Domain/Interfaces/Repository/UserPreferencesRepository.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol UserPreferencesRepository {
+public protocol UserPreferencesRepository: Sendable {
     func getMainAppearance() -> MainAppearance
     func setMainAppearance(_ appearance: MainAppearance)
     func getDailyWaterLimit() -> Double

--- a/Project/Domain/Interfaces/UseCase/DrinkWaterUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/DrinkWaterUseCase.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol DrinkWaterUseCase {
+public protocol DrinkWaterUseCase: Sendable {
     var currentWater: Int { get }
     
     func drinkWater()

--- a/Project/Domain/Interfaces/UseCase/HealthKitUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/HealthKitUseCase.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol HealthKitUseCase {
+public protocol HealthKitUseCase: Sendable {
     var authorisationStatus: HealthKitAuthorizationStatus { get }
     
     func requestAuthorization() async throws

--- a/Project/Domain/Interfaces/UseCase/SignInUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/SignInUseCase.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol SignInUseCase {
+public protocol SignInUseCase: Sendable {
     var isAuthenticated: Bool { get }
 
     func signInWithApple() async throws

--- a/Project/Domain/Interfaces/UseCase/UserPreferencesUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/UserPreferencesUseCase.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol UserPreferencesUseCase {
+public protocol UserPreferencesUseCase: Sendable {
     func getMainAppearance() -> MainAppearance
     func setMainAppearance(_ appearance: MainAppearance)
     func getDailyWaterLimit() -> Double

--- a/Project/Domain/Project.swift
+++ b/Project/Domain/Project.swift
@@ -9,7 +9,8 @@ let project = Project(
     settings: .settings(
         base: [
             "APP_MARKETING_VERSION": .string(AppVersion.marketingVersion),
-            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber)
+            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber),
+            "SWIFT_VERSION": .string("6.0")
         ],
         configurations: [
             .debug(name: "Debug"),

--- a/Project/Domain/Tests/Mock/MockDrinkWaterRepository.swift
+++ b/Project/Domain/Tests/Mock/MockDrinkWaterRepository.swift
@@ -8,7 +8,7 @@
 
 import DomainLayerInterface
 
-final class MockDrinkWaterRepository: DrinkWaterRepository {
+final class MockDrinkWaterRepository: DrinkWaterRepository, @unchecked Sendable {
     private var _currentWater: Int = 0
     
     // Call tracking properties

--- a/Project/Domain/Tests/Mock/MockHealthKitRepository.swift
+++ b/Project/Domain/Tests/Mock/MockHealthKitRepository.swift
@@ -9,7 +9,7 @@
 import DomainLayerInterface
 import Foundation
 
-final class MockHealthKitRepository: HealthKitRepository {
+final class MockHealthKitRepository: HealthKitRepository, @unchecked Sendable {
     private var _authorizationStatus: HealthKitAuthorizationStatus = .notDetermined
     private var _hydrationRecords: [HydrationRecord] = []
 

--- a/Project/Domain/Tests/Mock/MockUserPreferencesRepository.swift
+++ b/Project/Domain/Tests/Mock/MockUserPreferencesRepository.swift
@@ -8,7 +8,7 @@
 
 import DomainLayerInterface
 
-final class MockUserPreferencesRepository: UserPreferencesRepository {
+final class MockUserPreferencesRepository: UserPreferencesRepository, @unchecked Sendable {
     private var _mainAppearance: MainAppearance = .default
     private var _dailyWaterLimit: Double = 2000.0
 

--- a/Project/Presentation/Project.swift
+++ b/Project/Presentation/Project.swift
@@ -16,7 +16,8 @@ let project = Project(
     settings: .settings(
         base: [
             "APP_MARKETING_VERSION": .string(AppVersion.marketingVersion),
-            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber)
+            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber),
+            "SWIFT_VERSION": .string("6.0")
         ],
         configurations: [
             .debug(name: "Debug"),

--- a/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
+++ b/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
@@ -60,7 +60,9 @@ public struct DrinkWaterView: View {
                 
                 HStack {
                     Button {
-                        viewModel.drinkWater()
+                        Task {
+                            await viewModel.drinkWater()
+                        }
                     } label: {
                         Text(viewModel.isLimitReached ? "목표 달성!" : "마시기")
                             .font(.headline)
@@ -74,7 +76,9 @@ public struct DrinkWaterView: View {
                     
                     
                     Button {
-                        viewModel.reset()
+                        Task {
+                            await viewModel.reset()
+                        }
                     } label: {
                         Text("초기화")
                             .font(.headline)

--- a/Project/Presentation/Sources/ViewModel/AuthenticationViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/AuthenticationViewModel.swift
@@ -27,6 +27,7 @@ public final class AuthenticationViewModel {
         isAuthenticated = signInUseCase.isAuthenticated
     }
     
+    @MainActor
     public func signInWithApple() async {
         isLoading = true
         errorMessage = nil

--- a/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
@@ -13,6 +13,7 @@ import UIKit
 import Utils
 import WidgetKit
 
+@MainActor
 @Observable
 public final class DrinkWaterViewModel {
     // MARK: - Published State
@@ -66,24 +67,18 @@ public final class DrinkWaterViewModel {
         // Observe any UserDefaults changes, not just from specific instance
         NotificationCenter.default
             .publisher(for: UserDefaults.didChangeNotification)
+            .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                DispatchQueue.main.async {
-                    self?.updateMainAppearance()
-                    self?.updateWaterCount()
-                    self?.updateDailyLimit()
-                }
+                self?.refreshFromUserDefaults()
             }
             .store(in: &cancellables)
         
         // Also observe when app becomes active to catch Widget changes
         NotificationCenter.default
             .publisher(for: UIApplication.didBecomeActiveNotification)
+            .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                DispatchQueue.main.async {
-                    self?.updateMainAppearance()
-                    self?.updateWaterCount()
-                    self?.updateDailyLimit()
-                }
+                self?.refreshFromUserDefaults()
             }
             .store(in: &cancellables)
     }
@@ -116,7 +111,7 @@ public final class DrinkWaterViewModel {
         }
     }
     
-    func drinkWater() {
+    func drinkWater() async {
         // Check if adding one more glass would exceed daily limit
         let nextIntake = currentWaterIntakeInMl + 250.0
         print("🔍 DEBUG - drinkWater:")
@@ -139,28 +134,24 @@ public final class DrinkWaterViewModel {
         // Reload Widget timeline
         WidgetCenter.shared.reloadAllTimelines()
         
-        Task {
-            do {
-                try await healthKitUseCase.drinkWater()
-            } catch {
-                print("Failed to log water to HealthKit: \(error)")
-            }
+        do {
+            try await healthKitUseCase.drinkWater()
+        } catch {
+            print("Failed to log water to HealthKit: \(error)")
         }
     }
     
-    func reset() {
+    func reset() async {
         drinkWaterCount = 0
         waterUseCase.reset()
         
         // Reload Widget timeline
         WidgetCenter.shared.reloadAllTimelines()
         
-        Task {
-            do {
-                try await healthKitUseCase.reset()
-            } catch {
-                print("Failed to reset HealthKit data: \(error)")
-            }
+        do {
+            try await healthKitUseCase.reset()
+        } catch {
+            print("Failed to reset HealthKit data: \(error)")
         }
     }
     

--- a/Project/Presentation/Sources/ViewModel/HydrationRecordListViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationRecordListViewModel.swift
@@ -25,11 +25,13 @@ public final class HydrationRecordListViewModel {
         self.useCase = useCase
     }
     
+    @MainActor
     func onAppear() async {
         await requestAuthorization()
         authorizationStatus = useCase.authorisationStatus
     }
     
+    @MainActor
     private func requestAuthorization() async {
         do {
             try await useCase.requestAuthorization()
@@ -38,6 +40,7 @@ public final class HydrationRecordListViewModel {
         }
     }
     
+    @MainActor
     func fetchHydrationRecord() async {
         let (startDate, endDate) = getStartAndEndDate()
         

--- a/Project/Presentation/Sources/ViewModel/SettingsViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/SettingsViewModel.swift
@@ -117,6 +117,7 @@ public final class SettingsViewModel {
         showWithdrawalConfirmation = true
     }
 
+    @MainActor
     public func confirmWithdrawal() async {
         isWithdrawing = true
         withdrawalError = nil

--- a/Project/Shared/DependencyInjection/Project.swift
+++ b/Project/Shared/DependencyInjection/Project.swift
@@ -16,7 +16,8 @@ let project = Project(
     settings: .settings(
         base: [
             "APP_MARKETING_VERSION": .string(AppVersion.marketingVersion),
-            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber)
+            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber),
+            "SWIFT_VERSION": .string("6.0")
         ],
         configurations: [
             .debug(name: "Debug"),

--- a/Project/Shared/DependencyInjection/Sources/Core/DIContainer.swift
+++ b/Project/Shared/DependencyInjection/Sources/Core/DIContainer.swift
@@ -7,7 +7,7 @@
 
 import Swinject
 
-public final class DIContainer {
+public final class DIContainer: @unchecked Sendable {
     public static let shared = DIContainer()
 
     private let assembler: Assembler

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockDrinkWaterUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockDrinkWaterUseCase.swift
@@ -7,7 +7,7 @@
 
 import DomainLayerInterface
 
-public final class MockDrinkWaterUseCase: DrinkWaterUseCase {
+public final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable {
     public var currentWater: Int = 3
     
     public init() {}

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockHealthKitUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockHealthKitUseCase.swift
@@ -8,7 +8,7 @@
 import DomainLayerInterface
 import Foundation
 
-public final class MockHealthKitUseCase: HealthKitUseCase {
+public final class MockHealthKitUseCase: HealthKitUseCase, @unchecked Sendable {
     public init() {}
     
     public func requestAuthorization() async throws -> HealthKitAuthorizationStatus {

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockSignInUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockSignInUseCase.swift
@@ -8,7 +8,7 @@
 
 import DomainLayerInterface
 
-public final class MockSignInUseCase: SignInUseCase {
+public final class MockSignInUseCase: SignInUseCase, @unchecked Sendable {
     public var isAuthenticated: Bool = true
 
     public init() {}

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockUserPreferencesUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockUserPreferencesUseCase.swift
@@ -8,7 +8,7 @@
 
 import DomainLayerInterface
 
-public final class MockUserPreferencesUseCase: UserPreferencesUseCase {
+public final class MockUserPreferencesUseCase: UserPreferencesUseCase, @unchecked Sendable {
     private var mainAppearance: MainAppearance = .drop
     private var dailyWaterLimit: Double = 2000
     private var accentColor: String = "blue"

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -19,11 +19,17 @@ public final class PresentationAssembly: Assembly {
         
         // MARK: - DrinkWater
         container.register(DrinkWaterViewModel.self) { resolver in
-            DrinkWaterViewModel(
-                waterUseCase: resolver.resolve(DrinkWaterUseCase.self)!,
-                healthKitUseCase: resolver.resolve(HealthKitUseCase.self)!,
-                userPreferencesUseCase: resolver.resolve(UserPreferencesUseCase.self)!
-            )
+            let waterUseCase = resolver.resolve(DrinkWaterUseCase.self)!
+            let healthKitUseCase = resolver.resolve(HealthKitUseCase.self)!
+            let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
+
+            return MainActor.assumeIsolated {
+                DrinkWaterViewModel(
+                    waterUseCase: waterUseCase,
+                    healthKitUseCase: healthKitUseCase,
+                    userPreferencesUseCase: userPreferencesUseCase
+                )
+            }
         }
         
         // MARK: - HealthKit

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockDrinkWaterUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockDrinkWaterUseCaseForTesting.swift
@@ -7,7 +7,7 @@
 
 import DomainLayerInterface
 
-public final class MockDrinkWaterUseCaseForTesting: DrinkWaterUseCase {
+public final class MockDrinkWaterUseCaseForTesting: DrinkWaterUseCase, @unchecked Sendable {
     public var currentWater: Int = 0
     public var drinkWaterCallCount = 0
     public var resetCallCount = 0

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockHealthKitUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockHealthKitUseCaseForTesting.swift
@@ -8,7 +8,7 @@
 import DomainLayerInterface
 import Foundation
 
-public final class MockHealthKitUseCaseForTesting: HealthKitUseCase {
+public final class MockHealthKitUseCaseForTesting: HealthKitUseCase, @unchecked Sendable {
     public var requestAuthorizationResult: HealthKitAuthorizationStatus = .authorized
     public var shouldThrowError = false
     public var fetchRecordsResult: [HydrationRecord] = []

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockUserPreferencesUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockUserPreferencesUseCaseForTesting.swift
@@ -8,7 +8,7 @@
 
 import DomainLayerInterface
 
-public final class MockUserPreferencesUseCaseForTesting: UserPreferencesUseCase {
+public final class MockUserPreferencesUseCaseForTesting: UserPreferencesUseCase, @unchecked Sendable {
     public var mainAppearance: MainAppearance = .drop
     public var dailyWaterLimit: Double = 2000
     public var accentColor: String = "blue"

--- a/Project/Shared/DesignSystem/Project.swift
+++ b/Project/Shared/DesignSystem/Project.swift
@@ -16,7 +16,8 @@ let project = Project(
     settings: .settings(
         base: [
             "APP_MARKETING_VERSION": .string(AppVersion.marketingVersion),
-            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber)
+            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber),
+            "SWIFT_VERSION": .string("6.0")
         ],
         configurations: [
             .debug(name: "Debug"),

--- a/Project/Shared/Utils/Project.swift
+++ b/Project/Shared/Utils/Project.swift
@@ -16,7 +16,8 @@ let project = Project(
     settings: .settings(
         base: [
             "APP_MARKETING_VERSION": .string(AppVersion.marketingVersion),
-            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber)
+            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber),
+            "SWIFT_VERSION": .string("6.0")
         ],
         configurations: [
             .debug(name: "Debug"),

--- a/Project/Shared/Utils/Sources/UserDefaults+Extensions.swift
+++ b/Project/Shared/Utils/Sources/UserDefaults+Extensions.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 public extension UserDefaults {
-    static let appGroup: UserDefaults = {
+    static var appGroup: UserDefaults {
         guard let appGroupUserDefaults = UserDefaults(suiteName: .appGroupId) else {
             fatalError("Undefined App Group, Please check capabilities")
         }
         return appGroupUserDefaults
-    }()
+    }
     
     @objc dynamic var glassesOfToday: Int {
         get { self.integer(forKey: .glassesOfToday) }

--- a/Project/Widget/Sources/AppIntent.swift
+++ b/Project/Widget/Sources/AppIntent.swift
@@ -13,8 +13,8 @@ import DependencyInjection
 import DomainLayerInterface
 
 struct ConfigurationAppIntent: WidgetConfigurationIntent {
-    static var title: LocalizedStringResource = "Configuration"
-    static var description = IntentDescription("This is an example widget.")
+    static let title: LocalizedStringResource = "Configuration"
+    static let description = IntentDescription("This is an example widget.")
     
     // An example configurable parameter.
     @Parameter(title: "Favorite Emoji", default: "😃")


### PR DESCRIPTION
## 📝 Summary
- 프로젝트 모듈들의 `SWIFT_VERSION`를 6.0으로 통일했습니다.
- Swift 6 strict concurrency 진단으로 발생하던 컴파일 오류를 Domain/Data/Presentation/DependencyInjection/Widget 전반에서 정리했습니다.
- `AppleSignInDataSource`의 actor 격리를 프로토콜 전체가 아닌 메서드 단위로 조정해 DI 초기화 오류를 해결했습니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [x] 🐛 Bug fix (버그 수정)
- [x] 🔧 Configuration (설정 변경)
- [x] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [ ] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #91

## 📋 Changes Made
### Added
- `Sendable` / `@unchecked Sendable` 적합성 선언 (UseCase/Repository/DataSource 인터페이스 및 일부 구현/Mock)

### Changed
- 모듈별 `Project.swift`의 Swift 버전을 6.0으로 상향
- `MainAppearance.default`, `UserDefaults.appGroup` 등 static shared state 접근 방식 조정
- Presentation ViewModel의 actor 경계 정리 (`@MainActor` 메서드 적용, 비동기 호출 구조 보정)
- DI 구성 정리 (`DIContainer` Sendable 선언, `PresentationAssembly` 생성 경로 보정)
- Widget `AppIntent`의 static 프로퍼티를 immutable(`let`)로 변경

### Fixed
- `Static property 'appGroup' is not concurrency-safe ...`
- `Static property 'default' is not concurrency-safe ...`
- `Main actor-isolated initializer 'init()' cannot be called from outside of the actor`
- `Sending 'self' risks causing data races` 계열 오류

### Removed
- 불필요한 내부 `Task {}` 래핑 및 동시성 경고를 유발하던 일부 접근 패턴

## 🔍 Technical Details
- `AppleSignInDataSource`는 프로토콜 전체 `@MainActor`를 제거하고 `signIn(scopes:)` 요구사항에만 `@MainActor`를 적용했습니다.
- `DrinkWaterViewModel` 생성은 DI에서 `MainActor.assumeIsolated`로 경계를 명시했습니다.

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [x] Debug 모드 정상 작동 (컴파일 기준)
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음 (컴파일 기준)
- [x] Widget Extension 정상 작동 (빌드 기준)

### Test Environment
- iOS Version: iPhoneOS SDK 26.2
- Device: Any iOS Device (xcodebuild)
- Xcode Version: 17C529

### Test Results
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -sdk iphoneos CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` 성공

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- 런타임 동작(특히 Widget/App 간 데이터 동기화, Sign In/Withdrawal 흐름)은 QA 시나리오로 추가 검증 권장
