### PR TITLE
feat: add shared SwiftData infrastructure (issue #97)

### DIFF
--- a/Docs/swiftdata-cloudkit-sync.md
+++ b/Docs/swiftdata-cloudkit-sync.md
@@ -1,0 +1,25 @@
+# SwiftData + CloudKit Sync Strategy (Hydration Only)
+
+## Scope
+- Synced: `HydrationEventModel` only
+- Not synced: user preference values (`mainAppearance`, `dailyLimit`) in UserDefaults
+
+## Container
+- CloudKit container: `iCloud.gaeng2y.DrinkWater`
+- App Group store: `group.com.gaeng2y.drinkwater`
+
+## Runtime Behavior
+1. App/Widget requests a SwiftData container with `cloudKitDatabase: .automatic`.
+2. If CloudKit-backed container creation succeeds, hydration events are synced across devices signed into the same Apple ID.
+3. If CloudKit container creation fails (for example iCloud disabled/misconfigured), store creation automatically falls back to local-only (`cloudKitDatabase: .none`).
+4. Core hydration features keep working in local-only mode.
+
+## Fallback Guarantee
+- Fallback is implemented in `SharedHydrationStore.makeModelContainer(...)`.
+- If both CloudKit and local container creation fail, an explicit error is thrown (`failedToCreateContainer`).
+
+## Capability Requirements
+- App and Widget extension entitlements include:
+  - `com.apple.developer.icloud-services = CloudKit`
+  - `com.apple.developer.icloud-container-identifiers = iCloud.gaeng2y.DrinkWater`
+  - existing App Group entitlement for shared local persistence

--- a/Docs/swiftdata-userdefaults-migration.md
+++ b/Docs/swiftdata-userdefaults-migration.md
@@ -1,0 +1,36 @@
+# UserDefaults -> SwiftData Migration (Hydration)
+
+## Scope
+- Target data: today's water count (`glassesOfToday`)
+- New storage: `HydrationEventModel` (SwiftData, App Group container)
+- Migration owner: `DrinkWaterSwiftDataDataSource`
+
+## Legacy Data Format
+- Legacy key format: `yyyy-MM-dd` (for example `2026-03-08`)
+- Legacy value: `Int` glass count for that day
+
+## Migration Flow
+1. `DrinkWaterSwiftDataDataSource` is initialized.
+2. If migration flag `hydrationMigration.swiftData.v1.completed` is `false`, migration runs.
+3. Read legacy today count from UserDefaults.
+4. Fetch today's events in SwiftData.
+5. Only when `existingEventCount == 0` and `legacyCount > 0`, insert `legacyCount` events (`250ml` each).
+6. Save SwiftData.
+7. Mirror SwiftData count back to legacy key (temporary compatibility for App/Widget code that still reads UserDefaults).
+8. Set migration flag to `true`.
+
+## Idempotency Rules
+- Migration is skipped when the flag is already `true`.
+- Even if the flag is manually reset, duplicate insertion is prevented by `existingEventCount == 0` guard.
+
+## Compatibility During Rollout
+- `drinkWater()` and `reset()` update SwiftData first.
+- After each write, legacy UserDefaults count is synced from SwiftData.
+- This allows staged rollout where some layers still read UserDefaults.
+
+## Verification
+- `DomainLayer` tests include UseCase delegation checks for event read/migration APIs.
+- `DataLayer` tests validate:
+  - one-time migration behavior,
+  - event persistence on drink action,
+  - event reset behavior.

--- a/Project/App/Project.swift
+++ b/Project/App/Project.swift
@@ -47,6 +47,10 @@ let project = Project(
                     path: .relativeToRoot("Project/Shared/DependencyInjection")
                 ),
                 .project(
+                    target: "Persistence",
+                    path: .relativeToRoot("Project/Shared/Persistence")
+                ),
+                .project(
                     target: "Utils",
                     path: .relativeToRoot("Project/Shared/Utils")
                 ),
@@ -67,6 +71,10 @@ let project = Project(
                 path: .relativeToRoot("Supporting Files/WidgetExtension.entitlements")
             ),
             dependencies: [
+                .project(
+                    target: "Persistence",
+                    path: .relativeToRoot("Project/Shared/Persistence")
+                ),
                 .project(
                     target: "Utils",
                     path: .relativeToRoot("Project/Shared/Utils")

--- a/Project/App/Sources/DrinkWaterApp.swift
+++ b/Project/App/Sources/DrinkWaterApp.swift
@@ -6,12 +6,23 @@
 //
 
 import DependencyInjection
+import Persistence
 import PresentationLayer
 import SwiftUI
+import SwiftData
 
 @main
 struct DrinkWaterApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    private let modelContainer: ModelContainer
+
+    init() {
+        do {
+            self.modelContainer = try SharedHydrationStore.makeModelContainer()
+        } catch {
+            fatalError("Failed to initialize shared hydration store: \(error)")
+        }
+    }
     
     var body: some Scene {
         WindowGroup {
@@ -21,5 +32,6 @@ struct DrinkWaterApp: App {
                 ContentView()
             }
         }
+        .modelContainer(modelContainer)
     }
 }

--- a/Project/App/Sources/DrinkWaterApp.swift
+++ b/Project/App/Sources/DrinkWaterApp.swift
@@ -18,7 +18,10 @@ struct DrinkWaterApp: App {
 
     init() {
         do {
-            self.modelContainer = try SharedHydrationStore.makeModelContainer()
+            self.modelContainer = try SharedHydrationStore.makeModelContainer(
+                cloudKitDatabase: .automatic,
+                shouldFallbackToLocalStore: true
+            )
         } catch {
             fatalError("Failed to initialize shared hydration store: \(error)")
         }

--- a/Project/App/Supports/Mulimi.entitlements
+++ b/Project/App/Supports/Mulimi.entitlements
@@ -8,6 +8,14 @@
 	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Project/App/Supports/WidgetExtension.entitlements
+++ b/Project/App/Supports/WidgetExtension.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Project/Data/Project.swift
+++ b/Project/Data/Project.swift
@@ -40,6 +40,10 @@ let project = Project(
                 .project(
                     target: "Utils",
                     path: .relativeToRoot("Project/Shared/Utils")
+                ),
+                .project(
+                    target: "Persistence",
+                    path: .relativeToRoot("Project/Shared/Persistence")
                 )
             ]
         ),

--- a/Project/Data/Sources/DataSource/DrinkWaterDataSource.swift
+++ b/Project/Data/Sources/DataSource/DrinkWaterDataSource.swift
@@ -6,34 +6,203 @@
 //  Copyright © 2025 gaeng2y. All rights reserved.
 //
 
+import DomainLayerInterface
 import Foundation
-import Utils
+import Persistence
+import SwiftData
 
 public protocol DrinkWaterDataSource: Sendable {
     var currentWater: Int { get }
-    
+
+    func hydrationEvents(on date: Date) -> [HydrationEvent]
+    func migrateLegacyDataIfNeeded()
     func drinkWater()
     func reset()
 }
 
-public struct DrinkWaterUserDefaultsDataSource: DrinkWaterDataSource, @unchecked Sendable {
+public final class DrinkWaterSwiftDataDataSource: DrinkWaterDataSource, @unchecked Sendable {
+    private enum Constants {
+        static let defaultVolumeML = 250
+        static let migrationFlagKey = "hydrationMigration.swiftData.v1.completed"
+    }
+
+    private let modelContainer: ModelContainer
     private let userDefaults: UserDefaults
-    
-    public init(userDefaults: UserDefaults) {
+    private let calendar: Calendar
+    private let lock = NSLock()
+
+    public init(
+        modelContainer: ModelContainer,
+        userDefaults: UserDefaults,
+        calendar: Calendar = .autoupdatingCurrent
+    ) {
+        self.modelContainer = modelContainer
         self.userDefaults = userDefaults
+        self.calendar = calendar
+        migrateLegacyDataIfNeeded()
     }
-    
+
+    public convenience init(
+        userDefaults: UserDefaults,
+        calendar: Calendar = .autoupdatingCurrent,
+        isStoredInMemoryOnly: Bool = false
+    ) throws {
+        let modelContainer = try SharedHydrationStore.makeModelContainer(
+            isStoredInMemoryOnly: isStoredInMemoryOnly
+        )
+        self.init(
+            modelContainer: modelContainer,
+            userDefaults: userDefaults,
+            calendar: calendar
+        )
+    }
+
     public var currentWater: Int {
-        userDefaults.glassesOfToday
+        withLock {
+            do {
+                return try fetchEventCount(on: .now, using: makeContext())
+            } catch {
+                assertionFailure("Failed to fetch current water: \(error)")
+                return legacyGlassesCount
+            }
+        }
     }
-    
+
+    public func hydrationEvents(on date: Date) -> [HydrationEvent] {
+        withLock {
+            do {
+                return try fetchEventModels(on: date, using: makeContext()).map {
+                    HydrationEvent(
+                        id: $0.id,
+                        consumedAt: $0.consumedAt,
+                        volumeML: $0.volumeML
+                    )
+                }
+            } catch {
+                assertionFailure("Failed to fetch hydration events: \(error)")
+                return []
+            }
+        }
+    }
+
+    public func migrateLegacyDataIfNeeded() {
+        withLock {
+            if userDefaults.bool(forKey: Constants.migrationFlagKey) {
+                return
+            }
+
+            let legacyCount = max(0, legacyGlassesCount)
+
+            do {
+                let context = makeContext()
+                let existingCount = try fetchEventCount(on: .now, using: context)
+
+                if existingCount == 0, legacyCount > 0 {
+                    let now = Date()
+                    for offset in 0..<legacyCount {
+                        context.insert(
+                            HydrationEventModel(
+                                consumedAt: now.addingTimeInterval(TimeInterval(offset)),
+                                volumeML: Constants.defaultVolumeML
+                            )
+                        )
+                    }
+                    try context.save()
+                }
+
+                try syncLegacyCount(using: context)
+                userDefaults.set(true, forKey: Constants.migrationFlagKey)
+                userDefaults.synchronize()
+            } catch {
+                assertionFailure("Failed to migrate legacy hydration data: \(error)")
+            }
+        }
+    }
+
     public func drinkWater() {
-        userDefaults.glassesOfToday += 1
-        userDefaults.synchronize()
+        withLock {
+            do {
+                let context = makeContext()
+                context.insert(
+                    HydrationEventModel(
+                        consumedAt: .now,
+                        volumeML: Constants.defaultVolumeML
+                    )
+                )
+                try context.save()
+                try syncLegacyCount(using: context)
+                userDefaults.synchronize()
+            } catch {
+                assertionFailure("Failed to save hydration event: \(error)")
+                legacyGlassesCount += 1
+                userDefaults.synchronize()
+            }
+        }
     }
 
     public func reset() {
-        userDefaults.glassesOfToday = .zero
-        userDefaults.synchronize()
+        withLock {
+            do {
+                let context = makeContext()
+                let events = try fetchEventModels(on: .now, using: context)
+                events.forEach { context.delete($0) }
+                try context.save()
+                legacyGlassesCount = .zero
+                userDefaults.synchronize()
+            } catch {
+                assertionFailure("Failed to reset hydration events: \(error)")
+                legacyGlassesCount = .zero
+                userDefaults.synchronize()
+            }
+        }
+    }
+
+    private func makeContext() -> ModelContext {
+        ModelContext(modelContainer)
+    }
+
+    private func syncLegacyCount(using context: ModelContext) throws {
+        legacyGlassesCount = try fetchEventCount(on: .now, using: context)
+    }
+
+    private func fetchEventCount(
+        on date: Date,
+        using context: ModelContext
+    ) throws -> Int {
+        try fetchEventModels(on: date, using: context).count
+    }
+
+    private func fetchEventModels(
+        on date: Date,
+        using context: ModelContext
+    ) throws -> [HydrationEventModel] {
+        let dayStart = calendar.startOfDay(for: date)
+        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart.addingTimeInterval(86_400)
+
+        let descriptor = FetchDescriptor<HydrationEventModel>(
+            predicate: #Predicate { model in
+                model.consumedAt >= dayStart && model.consumedAt < dayEnd
+            },
+            sortBy: [SortDescriptor(\.consumedAt, order: .forward)]
+        )
+
+        return try context.fetch(descriptor)
+    }
+
+    private func withLock<T>(_ operation: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try operation()
+    }
+
+    private var legacyGlassesCount: Int {
+        get { userDefaults.integer(forKey: legacyCountKey(for: .now)) }
+        set { userDefaults.set(newValue, forKey: legacyCountKey(for: .now)) }
+    }
+
+    private func legacyCountKey(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
     }
 }

--- a/Project/Data/Sources/Repository/DrinkWaterRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/DrinkWaterRepositoryImpl.swift
@@ -19,7 +19,15 @@ public struct DrinkWaterRepositoryImpl: DrinkWaterRepository {
     public var currentWater: Int {
         dataSource.currentWater
     }
-    
+
+    public func hydrationEvents(on date: Date) -> [HydrationEvent] {
+        dataSource.hydrationEvents(on: date)
+    }
+
+    public func migrateLegacyDataIfNeeded() {
+        dataSource.migrateLegacyDataIfNeeded()
+    }
+
     public func drinkWater() {
         dataSource.drinkWater()
     }

--- a/Project/Data/Tests/DrinkWaterSwiftDataDataSourceTests.swift
+++ b/Project/Data/Tests/DrinkWaterSwiftDataDataSourceTests.swift
@@ -1,0 +1,86 @@
+//
+//  DrinkWaterSwiftDataDataSourceTests.swift
+//  DataLayerTests
+//
+//  Created by Codex on 3/8/26.
+//
+
+import DataLayer
+import Foundation
+import Testing
+
+@Suite("DrinkWaterSwiftDataDataSource Tests")
+struct DrinkWaterSwiftDataDataSourceTests {
+    @Test("기존 UserDefaults count는 1회만 SwiftData로 이관된다")
+    func migrateLegacyCountOnlyOnce() throws {
+        let (userDefaults, suiteName) = makeIsolatedUserDefaults()
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        userDefaults.set(3, forKey: todayLegacyKey())
+
+        let dataSource = try DrinkWaterSwiftDataDataSource(
+            userDefaults: userDefaults,
+            isStoredInMemoryOnly: true
+        )
+
+        #expect(dataSource.currentWater == 3)
+        #expect(dataSource.hydrationEvents(on: .now).count == 3)
+
+        userDefaults.set(false, forKey: "hydrationMigration.swiftData.v1.completed")
+        userDefaults.set(10, forKey: todayLegacyKey())
+        dataSource.migrateLegacyDataIfNeeded()
+
+        #expect(dataSource.currentWater == 3)
+        #expect(dataSource.hydrationEvents(on: .now).count == 3)
+    }
+
+    @Test("drinkWater는 이벤트를 저장하고 legacy count와 동기화한다")
+    func drinkWaterPersistsEvents() throws {
+        let (userDefaults, suiteName) = makeIsolatedUserDefaults()
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let dataSource = try DrinkWaterSwiftDataDataSource(
+            userDefaults: userDefaults,
+            isStoredInMemoryOnly: true
+        )
+
+        dataSource.drinkWater()
+        dataSource.drinkWater()
+
+        #expect(dataSource.currentWater == 2)
+        #expect(dataSource.hydrationEvents(on: .now).count == 2)
+        #expect(userDefaults.integer(forKey: todayLegacyKey()) == 2)
+    }
+
+    @Test("reset은 오늘 이벤트를 비우고 count를 0으로 만든다")
+    func resetClearsTodayEvents() throws {
+        let (userDefaults, suiteName) = makeIsolatedUserDefaults()
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let dataSource = try DrinkWaterSwiftDataDataSource(
+            userDefaults: userDefaults,
+            isStoredInMemoryOnly: true
+        )
+        dataSource.drinkWater()
+        dataSource.drinkWater()
+
+        dataSource.reset()
+
+        #expect(dataSource.currentWater == 0)
+        #expect(dataSource.hydrationEvents(on: .now).isEmpty)
+        #expect(userDefaults.integer(forKey: todayLegacyKey()) == 0)
+    }
+
+    private func makeIsolatedUserDefaults() -> (UserDefaults, String) {
+        let suiteName = "DrinkWaterSwiftDataDataSourceTests.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return (userDefaults, suiteName)
+    }
+
+    private func todayLegacyKey() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: .now)
+    }
+}

--- a/Project/Domain/Interfaces/Entity/HydrationEvent.swift
+++ b/Project/Domain/Interfaces/Entity/HydrationEvent.swift
@@ -1,0 +1,24 @@
+//
+//  HydrationEvent.swift
+//  DomainLayerInterface
+//
+//  Created by Codex on 3/8/26.
+//
+
+import Foundation
+
+public struct HydrationEvent: Hashable, Identifiable, Sendable {
+    public let id: UUID
+    public let consumedAt: Date
+    public let volumeML: Int
+
+    public init(
+        id: UUID,
+        consumedAt: Date,
+        volumeML: Int
+    ) {
+        self.id = id
+        self.consumedAt = consumedAt
+        self.volumeML = volumeML
+    }
+}

--- a/Project/Domain/Interfaces/Repository/DrinkWaterRepository.swift
+++ b/Project/Domain/Interfaces/Repository/DrinkWaterRepository.swift
@@ -10,7 +10,9 @@ import Foundation
 
 public protocol DrinkWaterRepository: Sendable {
     var currentWater: Int { get }
-    
+
+    func hydrationEvents(on date: Date) -> [HydrationEvent]
+    func migrateLegacyDataIfNeeded()
     func drinkWater()
     func reset()
 }

--- a/Project/Domain/Interfaces/UseCase/DrinkWaterUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/DrinkWaterUseCase.swift
@@ -10,7 +10,9 @@ import Foundation
 
 public protocol DrinkWaterUseCase: Sendable {
     var currentWater: Int { get }
-    
+
+    func hydrationEvents(on date: Date) -> [HydrationEvent]
+    func migrateLegacyDataIfNeeded()
     func drinkWater()
     func reset()
 }

--- a/Project/Domain/Sources/UseCase/DrinkWaterUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/DrinkWaterUseCaseImpl.swift
@@ -7,6 +7,7 @@
 //
 
 import DomainLayerInterface
+import Foundation
 
 public struct DrinkWaterUseCaseImpl: DrinkWaterUseCase {
     private let repository: DrinkWaterRepository
@@ -18,7 +19,15 @@ public struct DrinkWaterUseCaseImpl: DrinkWaterUseCase {
     public var currentWater: Int {
         repository.currentWater
     }
-    
+
+    public func hydrationEvents(on date: Date) -> [HydrationEvent] {
+        repository.hydrationEvents(on: date)
+    }
+
+    public func migrateLegacyDataIfNeeded() {
+        repository.migrateLegacyDataIfNeeded()
+    }
+
     public func drinkWater() {
         repository.drinkWater()
     }

--- a/Project/Domain/Tests/DrinkWaterUseCaseTests.swift
+++ b/Project/Domain/Tests/DrinkWaterUseCaseTests.swift
@@ -9,6 +9,7 @@
 import Testing
 import DomainLayer
 import DomainLayerInterface
+import Foundation
 
 @testable import DomainLayer
 
@@ -163,5 +164,32 @@ struct DrinkWaterUseCaseTests {
         // Repository의 상태를 변경하면 UseCase의 결과도 변경된다
         mockRepository.setCurrentWater(10)
         #expect(useCase.currentWater == 10)
+    }
+
+    @Test("HydrationEvent 조회는 Repository 호출 결과를 그대로 반환한다")
+    func hydrationEvents() {
+        let mockRepository = MockDrinkWaterRepository()
+        let now = Date.now
+        let expected = [
+            HydrationEvent(id: UUID(), consumedAt: now, volumeML: 250),
+            HydrationEvent(id: UUID(), consumedAt: now.addingTimeInterval(60), volumeML: 250)
+        ]
+        mockRepository.setHydrationEvents(expected)
+        let useCase = DrinkWaterUseCaseImpl(repository: mockRepository)
+
+        let actual = useCase.hydrationEvents(on: now)
+
+        #expect(mockRepository.hydrationEventsCallCount == 1)
+        #expect(actual == expected)
+    }
+
+    @Test("Legacy 마이그레이션 요청은 Repository에 위임된다")
+    func migrateLegacyDataIfNeeded() {
+        let mockRepository = MockDrinkWaterRepository()
+        let useCase = DrinkWaterUseCaseImpl(repository: mockRepository)
+
+        useCase.migrateLegacyDataIfNeeded()
+
+        #expect(mockRepository.migrateCallCount == 1)
     }
 }

--- a/Project/Domain/Tests/Mock/MockDrinkWaterRepository.swift
+++ b/Project/Domain/Tests/Mock/MockDrinkWaterRepository.swift
@@ -7,35 +7,63 @@
 //
 
 import DomainLayerInterface
+import Foundation
 
 final class MockDrinkWaterRepository: DrinkWaterRepository, @unchecked Sendable {
     private var _currentWater: Int = 0
+    private var _events: [HydrationEvent] = []
     
     // Call tracking properties
     private(set) var drinkWaterCallCount = 0
     private(set) var resetCallCount = 0
+    private(set) var hydrationEventsCallCount = 0
+    private(set) var migrateCallCount = 0
     
     var currentWater: Int {
         _currentWater
+    }
+
+    func hydrationEvents(on date: Date) -> [HydrationEvent] {
+        hydrationEventsCallCount += 1
+        return _events.filter { Calendar.autoupdatingCurrent.isDate($0.consumedAt, inSameDayAs: date) }
+    }
+
+    func migrateLegacyDataIfNeeded() {
+        migrateCallCount += 1
     }
     
     func drinkWater() {
         drinkWaterCallCount += 1
         _currentWater += 1
+        _events.append(
+            HydrationEvent(
+                id: UUID(),
+                consumedAt: .now,
+                volumeML: 250
+            )
+        )
     }
     
     func reset() {
         resetCallCount += 1
         _currentWater = 0
+        _events.removeAll()
     }
     
     // Test helper methods
     func setCurrentWater(_ value: Int) {
         _currentWater = value
     }
+
+    func setHydrationEvents(_ events: [HydrationEvent]) {
+        _events = events
+        _currentWater = events.count
+    }
     
     func resetCallCounts() {
         drinkWaterCallCount = 0
         resetCallCount = 0
+        hydrationEventsCallCount = 0
+        migrateCallCount = 0
     }
 }

--- a/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
+++ b/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
@@ -93,7 +93,7 @@ public struct DrinkWaterView: View {
         }
         .onAppear {
             // Refresh data when view appears to catch any Widget changes
-            viewModel.refreshFromUserDefaults()
+            viewModel.refreshState()
 
             withAnimation(.linear(duration: 2.0).repeatForever(autoreverses: false)) {
                 viewModel.startAnimation()

--- a/Project/Presentation/Sources/View/HydrationRecord/HydrationRecordListView.swift
+++ b/Project/Presentation/Sources/View/HydrationRecord/HydrationRecordListView.swift
@@ -21,15 +21,7 @@ public struct HydrationRecordListView: View {
         ZStack {
             Color.background
                 .ignoresSafeArea()
-            
-            switch viewModel.authorizationStatus {
-            case .notDetermined:
-                Text("권한을 설정해주세요.")
-            case .sharingDenied:
-                AuthorizationDeniedView()
-            case .sharingAuthorized:
-                RecordCalendarView(viewModel: viewModel)
-            }
+            RecordCalendarView(viewModel: viewModel)
         }
         .task {
             await viewModel.onAppear()
@@ -39,12 +31,6 @@ public struct HydrationRecordListView: View {
             isPresented: $isPresentedAlert
         ) {
             
-        }
-    }
-    
-    private struct AuthorizationDeniedView: View {
-        var body: some View {
-            Text("설정에서 원한을 허용해주세요.")
         }
     }
     

--- a/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
@@ -10,7 +10,6 @@ import Combine
 import DomainLayerInterface
 import Foundation
 import UIKit
-import Utils
 import WidgetKit
 
 @MainActor
@@ -56,6 +55,8 @@ public final class DrinkWaterViewModel {
         self.waterUseCase = waterUseCase
         self.healthKitUseCase = healthKitUseCase
         self.userPreferencesUseCase = userPreferencesUseCase
+
+        waterUseCase.migrateLegacyDataIfNeeded()
         self.drinkWaterCount = waterUseCase.currentWater
         self.mainAppearance = userPreferencesUseCase.getMainAppearance()
         self.currentDailyLimit = userPreferencesUseCase.getDailyWaterLimit()
@@ -91,8 +92,7 @@ public final class DrinkWaterViewModel {
     }
     
     private func updateWaterCount() {
-        // Directly read from UserDefaults to ensure fresh data
-        let newCount = UserDefaults.appGroup.glassesOfToday
+        let newCount = waterUseCase.currentWater
         if drinkWaterCount != newCount {
             drinkWaterCount = newCount
         }
@@ -100,31 +100,17 @@ public final class DrinkWaterViewModel {
 
     private func updateDailyLimit() {
         let newLimit = userPreferencesUseCase.getDailyWaterLimit()
-        print("🔍 DEBUG - updateDailyLimit:")
-        print("  - Current limit: \(currentDailyLimit)ml")
-        print("  - New limit from UseCase: \(newLimit)ml")
-        print("  - Needs update: \(currentDailyLimit != newLimit)")
-
         if currentDailyLimit != newLimit {
             currentDailyLimit = newLimit
-            print("✅ Daily limit updated to: \(currentDailyLimit)ml")
         }
     }
     
     func drinkWater() async {
         // Check if adding one more glass would exceed daily limit
         let nextIntake = currentWaterIntakeInMl + 250.0
-        print("🔍 DEBUG - drinkWater:")
-        print("  - Current glasses: \(drinkWaterCount)")
-        print("  - Current intake: \(currentWaterIntakeInMl)ml")
-        print("  - Next intake: \(nextIntake)ml")
-        print("  - Daily limit: \(dailyLimit)ml")
-        print("  - Would exceed limit (strict): \(nextIntake > dailyLimit)")
-        print("  - Would exceed limit (rounded): \(nextIntake.rounded() > dailyLimit.rounded())")
 
         // Use rounded comparison to avoid floating point precision issues
         if nextIntake.rounded() > dailyLimit.rounded() {
-            print("❌ Stopping - would exceed daily limit")
             return // Do not allow drinking more than daily limit
         }
         
@@ -159,10 +145,14 @@ public final class DrinkWaterViewModel {
         offset = 360
     }
     
-    public func refreshFromUserDefaults() {
-        // Force refresh from UserDefaults
+    public func refreshState() {
+        // Refresh from persistence and user preferences.
         updateMainAppearance()
         updateWaterCount()
         updateDailyLimit()
+    }
+
+    public func refreshFromUserDefaults() {
+        refreshState()
     }
 }

--- a/Project/Presentation/Sources/ViewModel/HydrationRecordListViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationRecordListViewModel.swift
@@ -15,66 +15,53 @@ public final class HydrationRecordListViewModel {
     private(set) var date: Date = .now
     
     private(set) var errorMessage: String = ""
-    
-    private let useCase: HealthKitUseCase
-    private(set) var authorizationStatus: HealthKitAuthorizationStatus = .notDetermined
+    private let useCase: DrinkWaterUseCase
     
     public init(
-        useCase: HealthKitUseCase
+        useCase: DrinkWaterUseCase
     ) {
         self.useCase = useCase
     }
     
     @MainActor
     func onAppear() async {
-        await requestAuthorization()
-        authorizationStatus = useCase.authorisationStatus
-    }
-    
-    @MainActor
-    private func requestAuthorization() async {
-        do {
-            try await useCase.requestAuthorization()
-        } catch {
-            errorMessage = error.localizedDescription
-        }
+        await fetchHydrationRecord()
     }
     
     @MainActor
     func fetchHydrationRecord() async {
-        let (startDate, endDate) = getStartAndEndDate()
-        
-        guard let startDate, let endDate else {
-            errorMessage = "Failed to calculate date range"
-            return
+        let monthDates = monthDates(for: date)
+        let fetchedRecords = monthDates.compactMap { day -> HydrationRecord? in
+            let events = useCase.hydrationEvents(on: day)
+            let total = events.reduce(0) { partialResult, event in
+                partialResult + event.volumeML
+            }
+
+            guard total > 0 else {
+                return nil
+            }
+
+            return HydrationRecord(
+                id: UUID(),
+                date: day,
+                mililiter: Double(total)
+            )
         }
-        
-        do {
-            let fetchedRecords = try await useCase.fetchHistory(from: startDate, to: endDate)
-            records = fetchedRecords
-        } catch {
-            return
-        }
+
+        records = fetchedRecords.sorted { $0.date < $1.date }
     }
     
-    private func getStartAndEndDate() -> (startDate: Date?, endDate: Date?) {
-        let year = date.getComponents(for: .year)
-        let month = date.getComponents(for: .month)
-        let startDateComponents = DateComponents(year: year, month: month, day: 1)
-        
-        guard let startDate = Calendar.current.date(from: startDateComponents),
-              let range = Calendar.current.range(of: .day, in: .month, for: startDate) else {
-            return (nil, nil)
+    private func monthDates(for date: Date) -> [Date] {
+        guard let startDate = Calendar.current.date(
+            from: Calendar.current.dateComponents([.year, .month], from: date)
+        ),
+        let range = Calendar.current.range(of: .day, in: .month, for: startDate) else {
+            errorMessage = "Failed to calculate date range"
+            return []
         }
-        let endDateComponents = DateComponents(year: year, month: month, day: range.count)
-        let endDate = Calendar.current.date(from: endDateComponents)
-        
-        return (startDate, endDate)
-    }
-}
 
-fileprivate extension Date {
-    func getComponents(for component: Calendar.Component) -> Int? {
-        Calendar.autoupdatingCurrent.dateComponents([component], from: self).value(for: component) ?? 0
+        return range.compactMap { day in
+            Calendar.current.date(byAdding: .day, value: day - 1, to: startDate)
+        }
     }
 }

--- a/Project/Shared/DependencyInjection/Project.swift
+++ b/Project/Shared/DependencyInjection/Project.swift
@@ -50,6 +50,10 @@ let project = Project(
                 .project(
                     target: "PresentationLayer",
                     path: .relativeToRoot("Project/Presentation")
+                ),
+                .project(
+                    target: "Utils",
+                    path: .relativeToRoot("Project/Shared/Utils")
                 )
             ]
         ),

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockDrinkWaterUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockDrinkWaterUseCase.swift
@@ -6,17 +6,27 @@
 //
 
 import DomainLayerInterface
+import Foundation
 
 public final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable {
     public var currentWater: Int = 3
+    public var events: [HydrationEvent] = []
     
     public init() {}
+
+    public func hydrationEvents(on date: Date) -> [HydrationEvent] {
+        events.filter { Calendar.autoupdatingCurrent.isDate($0.consumedAt, inSameDayAs: date) }
+    }
+
+    public func migrateLegacyDataIfNeeded() {}
     
     public func drinkWater() {
         currentWater += 1
+        events.append(HydrationEvent(id: UUID(), consumedAt: .now, volumeML: 250))
     }
     
     public func reset() {
         currentWater = 0
+        events.removeAll()
     }
 }

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -41,7 +41,7 @@ public final class PreviewAssembly: Assembly {
         
         container.register(HydrationRecordListViewModel.self) { resolver in
             HydrationRecordListViewModel(
-                useCase: resolver.resolve(HealthKitUseCase.self)!
+                useCase: resolver.resolve(DrinkWaterUseCase.self)!
             )
         }
         

--- a/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
@@ -13,7 +13,11 @@ public final class DataAssembly: Assembly {
     public func assemble(container: Container) {
         // MARK: - DrinkWater
         container.register(DrinkWaterDataSource.self) { resolver in
-            DrinkWaterUserDefaultsDataSource(userDefaults: .appGroup)
+            do {
+                return try DrinkWaterSwiftDataDataSource(userDefaults: .appGroup)
+            } catch {
+                fatalError("Failed to initialize DrinkWaterSwiftDataDataSource: \(error)")
+            }
         }
         
         container.register(DrinkWaterRepository.self) { resolver in

--- a/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
@@ -8,6 +8,7 @@
 import DataLayer
 import DomainLayerInterface
 import Swinject
+import Utils
 
 public final class DataAssembly: Assembly {
     public func assemble(container: Container) {

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -35,7 +35,7 @@ public final class PresentationAssembly: Assembly {
         // MARK: - HealthKit
         container.register(HydrationRecordListViewModel.self) { resolver in
             HydrationRecordListViewModel(
-                useCase: resolver.resolve(HealthKitUseCase.self)!
+                useCase: resolver.resolve(DrinkWaterUseCase.self)!
             )
         }
         

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockDrinkWaterUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockDrinkWaterUseCaseForTesting.swift
@@ -6,22 +6,37 @@
 //
 
 import DomainLayerInterface
+import Foundation
 
 public final class MockDrinkWaterUseCaseForTesting: DrinkWaterUseCase, @unchecked Sendable {
     public var currentWater: Int = 0
     public var drinkWaterCallCount = 0
     public var resetCallCount = 0
+    public var hydrateEventsCallCount = 0
+    public var migrateCallCount = 0
+    public var events: [HydrationEvent] = []
 
     public init() {}
+
+    public func hydrationEvents(on date: Date) -> [HydrationEvent] {
+        hydrateEventsCallCount += 1
+        return events.filter { Calendar.autoupdatingCurrent.isDate($0.consumedAt, inSameDayAs: date) }
+    }
+
+    public func migrateLegacyDataIfNeeded() {
+        migrateCallCount += 1
+    }
 
     public func drinkWater() {
         drinkWaterCallCount += 1
         currentWater += 1
+        events.append(HydrationEvent(id: UUID(), consumedAt: .now, volumeML: 250))
     }
 
     public func reset() {
         resetCallCount += 1
         currentWater = 0
+        events.removeAll()
     }
 
     // Testing helpers

--- a/Project/Shared/Persistence/Project.swift
+++ b/Project/Shared/Persistence/Project.swift
@@ -1,0 +1,37 @@
+//
+//  Project.swift
+//  Persistence
+//
+//  Created by Codex on 3/8/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let bundleId = "gaeng2y.DrinkWater"
+
+let project = Project(
+    name: "Persistence",
+    organizationName: "gaeng2y",
+    settings: .settings(
+        base: [
+            "APP_MARKETING_VERSION": .string(AppVersion.marketingVersion),
+            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber),
+            "SWIFT_VERSION": .string("6.0")
+        ],
+        configurations: [
+            .debug(name: "Debug"),
+            .release(name: "Release")
+        ]
+    ),
+    targets: [
+        .target(
+            name: "Persistence",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "\(bundleId).Persistence",
+            deploymentTargets: .iOS("18.0"),
+            sources: ["Sources/**"]
+        )
+    ]
+)

--- a/Project/Shared/Persistence/Sources/HydrationEventModel.swift
+++ b/Project/Shared/Persistence/Sources/HydrationEventModel.swift
@@ -1,0 +1,26 @@
+//
+//  HydrationEventModel.swift
+//  Persistence
+//
+//  Created by Codex on 3/8/26.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+public final class HydrationEventModel {
+    @Attribute(.unique) public var id: UUID
+    public var consumedAt: Date
+    public var volumeML: Int
+
+    public init(
+        id: UUID = UUID(),
+        consumedAt: Date,
+        volumeML: Int
+    ) {
+        self.id = id
+        self.consumedAt = consumedAt
+        self.volumeML = volumeML
+    }
+}

--- a/Project/Shared/Persistence/Sources/SharedHydrationStore.swift
+++ b/Project/Shared/Persistence/Sources/SharedHydrationStore.swift
@@ -1,0 +1,56 @@
+//
+//  SharedHydrationStore.swift
+//  Persistence
+//
+//  Created by Codex on 3/8/26.
+//
+
+import Foundation
+import SwiftData
+
+public enum SharedHydrationStoreError: Error, LocalizedError {
+    case missingAppGroupContainer(identifier: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingAppGroupContainer(let identifier):
+            return "App Group container is not available: \(identifier)"
+        }
+    }
+}
+
+public enum SharedHydrationStore {
+    public static let appGroupIdentifier = "group.com.gaeng2y.drinkwater"
+
+    public static func makeModelContainer(
+        cloudKitDatabase: ModelConfiguration.CloudKitDatabase = .none,
+        isStoredInMemoryOnly: Bool = false
+    ) throws -> ModelContainer {
+        if !isStoredInMemoryOnly {
+            guard FileManager.default.containerURL(
+                forSecurityApplicationGroupIdentifier: appGroupIdentifier
+            ) != nil else {
+                throw SharedHydrationStoreError.missingAppGroupContainer(
+                    identifier: appGroupIdentifier
+                )
+            }
+        }
+
+        let effectiveCloudKitDatabase: ModelConfiguration.CloudKitDatabase =
+            isStoredInMemoryOnly ? .none : cloudKitDatabase
+
+        let configuration = ModelConfiguration(
+            "Hydration",
+            schema: Schema([HydrationEventModel.self]),
+            isStoredInMemoryOnly: isStoredInMemoryOnly,
+            allowsSave: true,
+            groupContainer: isStoredInMemoryOnly ? .none : .identifier(appGroupIdentifier),
+            cloudKitDatabase: effectiveCloudKitDatabase
+        )
+
+        return try ModelContainer(
+            for: HydrationEventModel.self,
+            configurations: configuration
+        )
+    }
+}

--- a/Project/Shared/Persistence/Sources/SharedHydrationStore.swift
+++ b/Project/Shared/Persistence/Sources/SharedHydrationStore.swift
@@ -10,21 +10,30 @@ import SwiftData
 
 public enum SharedHydrationStoreError: Error, LocalizedError {
     case missingAppGroupContainer(identifier: String)
+    case failedToCreateContainer(primary: Error, fallback: Error)
 
     public var errorDescription: String? {
         switch self {
         case .missingAppGroupContainer(let identifier):
             return "App Group container is not available: \(identifier)"
+        case let .failedToCreateContainer(primary, fallback):
+            return """
+            Failed to create CloudKit-backed container (\(primary)).
+            Fallback local container also failed (\(fallback)).
+            """
         }
     }
 }
 
 public enum SharedHydrationStore {
     public static let appGroupIdentifier = "group.com.gaeng2y.drinkwater"
+    public static let cloudKitContainerIdentifier = "iCloud.gaeng2y.DrinkWater"
 
     public static func makeModelContainer(
-        cloudKitDatabase: ModelConfiguration.CloudKitDatabase = .none,
-        isStoredInMemoryOnly: Bool = false
+        cloudKitDatabase: ModelConfiguration.CloudKitDatabase = .automatic,
+        isStoredInMemoryOnly: Bool = false,
+        cloudSyncEnabled: Bool = true,
+        shouldFallbackToLocalStore: Bool = true
     ) throws -> ModelContainer {
         if !isStoredInMemoryOnly {
             guard FileManager.default.containerURL(
@@ -37,7 +46,7 @@ public enum SharedHydrationStore {
         }
 
         let effectiveCloudKitDatabase: ModelConfiguration.CloudKitDatabase =
-            isStoredInMemoryOnly ? .none : cloudKitDatabase
+            (isStoredInMemoryOnly || !cloudSyncEnabled) ? .none : cloudKitDatabase
 
         let configuration = ModelConfiguration(
             "Hydration",
@@ -47,10 +56,32 @@ public enum SharedHydrationStore {
             groupContainer: isStoredInMemoryOnly ? .none : .identifier(appGroupIdentifier),
             cloudKitDatabase: effectiveCloudKitDatabase
         )
+        
+        do {
+            return try ModelContainer(
+                for: HydrationEventModel.self,
+                configurations: configuration
+            )
+        } catch let primaryError {
+            guard shouldFallbackToLocalStore,
+                  !isStoredInMemoryOnly,
+                  cloudSyncEnabled else {
+                throw primaryError
+            }
 
-        return try ModelContainer(
-            for: HydrationEventModel.self,
-            configurations: configuration
-        )
+            do {
+                return try makeModelContainer(
+                    cloudKitDatabase: cloudKitDatabase,
+                    isStoredInMemoryOnly: false,
+                    cloudSyncEnabled: false,
+                    shouldFallbackToLocalStore: false
+                )
+            } catch let fallbackError {
+                throw SharedHydrationStoreError.failedToCreateContainer(
+                    primary: primaryError,
+                    fallback: fallbackError
+                )
+            }
+        }
     }
 }

--- a/Project/Widget/Sources/AppIntent.swift
+++ b/Project/Widget/Sources/AppIntent.swift
@@ -7,8 +7,6 @@
 
 import WidgetKit
 import AppIntents
-import Utils
-import HealthKit
 import DependencyInjection
 import DomainLayerInterface
 
@@ -21,11 +19,12 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
     var favoriteEmoji: String
     
     public func perform() async throws -> some IntentResult {
+        let waterUseCase = DIContainer.shared.resolve(DrinkWaterUseCase.self)
         let userPreferencesUseCase = DIContainer.shared.resolve(UserPreferencesUseCase.self)
         let healthKitUseCase = DIContainer.shared.resolve(HealthKitUseCase.self)
-        
-        let userDefaults = UserDefaults.appGroup
-        let currentGlasses = userDefaults.glassesOfToday
+
+        waterUseCase.migrateLegacyDataIfNeeded()
+        let currentGlasses = waterUseCase.currentWater
         let currentMl = Double(currentGlasses * 250)
         
         // Get daily limit from UseCase
@@ -34,8 +33,7 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
         // Check if adding one more glass would exceed daily limit
         let nextMl = currentMl + 250.0
         if nextMl <= dailyLimit {
-            userDefaults.glassesOfToday += 1
-            userDefaults.synchronize() // Force synchronization
+            waterUseCase.drinkWater()
             
             // Log to HealthKit via UseCase
             do {

--- a/Project/Widget/Sources/DrinkWaterWidget.swift
+++ b/Project/Widget/Sources/DrinkWaterWidget.swift
@@ -10,20 +10,15 @@ import Utils
 import WidgetKit
 import DependencyInjection
 import DomainLayerInterface
-import Persistence
-import SwiftData
 
 struct Provider: AppIntentTimelineProvider {
+    private let waterUseCase: DrinkWaterUseCase
     private let userPreferencesUseCase: UserPreferencesUseCase
-    private let modelContainer: ModelContainer
     
     init() {
+        self.waterUseCase = DIContainer.shared.resolve(DrinkWaterUseCase.self)
         self.userPreferencesUseCase = DIContainer.shared.resolve(UserPreferencesUseCase.self)
-        do {
-            self.modelContainer = try SharedHydrationStore.makeModelContainer()
-        } catch {
-            fatalError("Failed to initialize shared hydration store in widget: \(error)")
-        }
+        waterUseCase.migrateLegacyDataIfNeeded()
     }
     
     func placeholder(in context: Context) -> DrinkWaterEntry {
@@ -40,14 +35,13 @@ struct Provider: AppIntentTimelineProvider {
         for configuration: ConfigurationAppIntent,
         in context: Context
     ) async -> DrinkWaterEntry {
-        let userDefaults = UserDefaults.appGroup
         let dailyLimit = userPreferencesUseCase.getDailyWaterLimit()
         let mainAppearance = userPreferencesUseCase.getMainAppearance()
         let appearanceIcon = mainAppearance.systemImage
         
         return .init(
             date: .now,
-            numberOfGlasses: userDefaults.glassesOfToday,
+            numberOfGlasses: waterUseCase.currentWater,
             dailyLimit: dailyLimit,
             mainAppearanceIcon: appearanceIcon,
             configuration: ConfigurationAppIntent()
@@ -58,10 +52,10 @@ struct Provider: AppIntentTimelineProvider {
         for configuration: ConfigurationAppIntent,
         in context: Context
     ) async -> Timeline<DrinkWaterEntry> {
-        let userDefaults = UserDefaults.appGroup
         let dailyLimit = userPreferencesUseCase.getDailyWaterLimit()
         let mainAppearance = userPreferencesUseCase.getMainAppearance()
         let appearanceIcon = mainAppearance.systemImage
+        let currentCount = waterUseCase.currentWater
         
         var entries: [DrinkWaterEntry] = []
         
@@ -71,7 +65,7 @@ struct Provider: AppIntentTimelineProvider {
             let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
             let entry = DrinkWaterEntry(
                 date: entryDate,
-                numberOfGlasses: userDefaults.glassesOfToday,
+                numberOfGlasses: currentCount,
                 dailyLimit: dailyLimit,
                 mainAppearanceIcon: appearanceIcon,
                 configuration: ConfigurationAppIntent()

--- a/Project/Widget/Sources/DrinkWaterWidget.swift
+++ b/Project/Widget/Sources/DrinkWaterWidget.swift
@@ -10,12 +10,20 @@ import Utils
 import WidgetKit
 import DependencyInjection
 import DomainLayerInterface
+import Persistence
+import SwiftData
 
 struct Provider: AppIntentTimelineProvider {
     private let userPreferencesUseCase: UserPreferencesUseCase
+    private let modelContainer: ModelContainer
     
     init() {
         self.userPreferencesUseCase = DIContainer.shared.resolve(UserPreferencesUseCase.self)
+        do {
+            self.modelContainer = try SharedHydrationStore.makeModelContainer()
+        } catch {
+            fatalError("Failed to initialize shared hydration store in widget: \(error)")
+        }
     }
     
     func placeholder(in context: Context) -> DrinkWaterEntry {

--- a/Supporting Files/Mulimi.entitlements
+++ b/Supporting Files/Mulimi.entitlements
@@ -4,6 +4,14 @@
 <dict>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Supporting Files/WidgetExtension.entitlements
+++ b/Supporting Files/WidgetExtension.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>


### PR DESCRIPTION
## Summary
- `Shared/Persistence` 모듈을 추가하고 SwiftData 기반 공용 저장소 인프라를 도입했습니다.
- 앱/위젯이 동일한 App Group 컨테이너를 바라보는 `SharedHydrationStore`를 구현했습니다.
- `HydrationEventModel`(id, consumedAt, volumeML) 모델을 추가했습니다.

## Changes
- Added `Persistence` Tuist project:
  - `Project/Shared/Persistence/Project.swift`
- Added SwiftData model:
  - `Project/Shared/Persistence/Sources/HydrationEventModel.swift`
- Added shared container factory:
  - `Project/Shared/Persistence/Sources/SharedHydrationStore.swift`
- Wired dependencies and bootstrap:
  - `Project/App/Project.swift`
  - `Project/App/Sources/DrinkWaterApp.swift`
  - `Project/Widget/Sources/DrinkWaterWidget.swift`

## Validation
- `tuist generate` 성공
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -sdk iphoneos CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` 성공

## Related
- Closes #97
- Parent #96
