### PR TITLE
feat: [96-3] 앱 화면 로직 SwiftData 전환

### DIFF
--- a/Docs/swiftdata-cloudkit-sync.md
+++ b/Docs/swiftdata-cloudkit-sync.md
@@ -1,0 +1,25 @@
+# SwiftData + CloudKit Sync Strategy (Hydration Only)
+
+## Scope
+- Synced: `HydrationEventModel` only
+- Not synced: user preference values (`mainAppearance`, `dailyLimit`) in UserDefaults
+
+## Container
+- CloudKit container: `iCloud.gaeng2y.DrinkWater`
+- App Group store: `group.com.gaeng2y.drinkwater`
+
+## Runtime Behavior
+1. App/Widget requests a SwiftData container with `cloudKitDatabase: .automatic`.
+2. If CloudKit-backed container creation succeeds, hydration events are synced across devices signed into the same Apple ID.
+3. If CloudKit container creation fails (for example iCloud disabled/misconfigured), store creation automatically falls back to local-only (`cloudKitDatabase: .none`).
+4. Core hydration features keep working in local-only mode.
+
+## Fallback Guarantee
+- Fallback is implemented in `SharedHydrationStore.makeModelContainer(...)`.
+- If both CloudKit and local container creation fail, an explicit error is thrown (`failedToCreateContainer`).
+
+## Capability Requirements
+- App and Widget extension entitlements include:
+  - `com.apple.developer.icloud-services = CloudKit`
+  - `com.apple.developer.icloud-container-identifiers = iCloud.gaeng2y.DrinkWater`
+  - existing App Group entitlement for shared local persistence

--- a/Project/App/Sources/DrinkWaterApp.swift
+++ b/Project/App/Sources/DrinkWaterApp.swift
@@ -18,7 +18,10 @@ struct DrinkWaterApp: App {
 
     init() {
         do {
-            self.modelContainer = try SharedHydrationStore.makeModelContainer()
+            self.modelContainer = try SharedHydrationStore.makeModelContainer(
+                cloudKitDatabase: .automatic,
+                shouldFallbackToLocalStore: true
+            )
         } catch {
             fatalError("Failed to initialize shared hydration store: \(error)")
         }

--- a/Project/App/Supports/Mulimi.entitlements
+++ b/Project/App/Supports/Mulimi.entitlements
@@ -8,6 +8,14 @@
 	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Project/App/Supports/WidgetExtension.entitlements
+++ b/Project/App/Supports/WidgetExtension.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
+++ b/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
@@ -93,7 +93,7 @@ public struct DrinkWaterView: View {
         }
         .onAppear {
             // Refresh data when view appears to catch any Widget changes
-            viewModel.refreshFromUserDefaults()
+            viewModel.refreshState()
 
             withAnimation(.linear(duration: 2.0).repeatForever(autoreverses: false)) {
                 viewModel.startAnimation()

--- a/Project/Presentation/Sources/View/HydrationRecord/HydrationRecordListView.swift
+++ b/Project/Presentation/Sources/View/HydrationRecord/HydrationRecordListView.swift
@@ -21,15 +21,7 @@ public struct HydrationRecordListView: View {
         ZStack {
             Color.background
                 .ignoresSafeArea()
-            
-            switch viewModel.authorizationStatus {
-            case .notDetermined:
-                Text("권한을 설정해주세요.")
-            case .sharingDenied:
-                AuthorizationDeniedView()
-            case .sharingAuthorized:
-                RecordCalendarView(viewModel: viewModel)
-            }
+            RecordCalendarView(viewModel: viewModel)
         }
         .task {
             await viewModel.onAppear()
@@ -39,12 +31,6 @@ public struct HydrationRecordListView: View {
             isPresented: $isPresentedAlert
         ) {
             
-        }
-    }
-    
-    private struct AuthorizationDeniedView: View {
-        var body: some View {
-            Text("설정에서 원한을 허용해주세요.")
         }
     }
     

--- a/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
@@ -10,7 +10,6 @@ import Combine
 import DomainLayerInterface
 import Foundation
 import UIKit
-import Utils
 import WidgetKit
 
 @MainActor
@@ -56,6 +55,8 @@ public final class DrinkWaterViewModel {
         self.waterUseCase = waterUseCase
         self.healthKitUseCase = healthKitUseCase
         self.userPreferencesUseCase = userPreferencesUseCase
+
+        waterUseCase.migrateLegacyDataIfNeeded()
         self.drinkWaterCount = waterUseCase.currentWater
         self.mainAppearance = userPreferencesUseCase.getMainAppearance()
         self.currentDailyLimit = userPreferencesUseCase.getDailyWaterLimit()
@@ -91,8 +92,7 @@ public final class DrinkWaterViewModel {
     }
     
     private func updateWaterCount() {
-        // Directly read from UserDefaults to ensure fresh data
-        let newCount = UserDefaults.appGroup.glassesOfToday
+        let newCount = waterUseCase.currentWater
         if drinkWaterCount != newCount {
             drinkWaterCount = newCount
         }
@@ -100,31 +100,17 @@ public final class DrinkWaterViewModel {
 
     private func updateDailyLimit() {
         let newLimit = userPreferencesUseCase.getDailyWaterLimit()
-        print("🔍 DEBUG - updateDailyLimit:")
-        print("  - Current limit: \(currentDailyLimit)ml")
-        print("  - New limit from UseCase: \(newLimit)ml")
-        print("  - Needs update: \(currentDailyLimit != newLimit)")
-
         if currentDailyLimit != newLimit {
             currentDailyLimit = newLimit
-            print("✅ Daily limit updated to: \(currentDailyLimit)ml")
         }
     }
     
     func drinkWater() async {
         // Check if adding one more glass would exceed daily limit
         let nextIntake = currentWaterIntakeInMl + 250.0
-        print("🔍 DEBUG - drinkWater:")
-        print("  - Current glasses: \(drinkWaterCount)")
-        print("  - Current intake: \(currentWaterIntakeInMl)ml")
-        print("  - Next intake: \(nextIntake)ml")
-        print("  - Daily limit: \(dailyLimit)ml")
-        print("  - Would exceed limit (strict): \(nextIntake > dailyLimit)")
-        print("  - Would exceed limit (rounded): \(nextIntake.rounded() > dailyLimit.rounded())")
 
         // Use rounded comparison to avoid floating point precision issues
         if nextIntake.rounded() > dailyLimit.rounded() {
-            print("❌ Stopping - would exceed daily limit")
             return // Do not allow drinking more than daily limit
         }
         
@@ -159,10 +145,14 @@ public final class DrinkWaterViewModel {
         offset = 360
     }
     
-    public func refreshFromUserDefaults() {
-        // Force refresh from UserDefaults
+    public func refreshState() {
+        // Refresh from persistence and user preferences.
         updateMainAppearance()
         updateWaterCount()
         updateDailyLimit()
+    }
+
+    public func refreshFromUserDefaults() {
+        refreshState()
     }
 }

--- a/Project/Presentation/Sources/ViewModel/HydrationRecordListViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationRecordListViewModel.swift
@@ -15,66 +15,53 @@ public final class HydrationRecordListViewModel {
     private(set) var date: Date = .now
     
     private(set) var errorMessage: String = ""
-    
-    private let useCase: HealthKitUseCase
-    private(set) var authorizationStatus: HealthKitAuthorizationStatus = .notDetermined
+    private let useCase: DrinkWaterUseCase
     
     public init(
-        useCase: HealthKitUseCase
+        useCase: DrinkWaterUseCase
     ) {
         self.useCase = useCase
     }
     
     @MainActor
     func onAppear() async {
-        await requestAuthorization()
-        authorizationStatus = useCase.authorisationStatus
-    }
-    
-    @MainActor
-    private func requestAuthorization() async {
-        do {
-            try await useCase.requestAuthorization()
-        } catch {
-            errorMessage = error.localizedDescription
-        }
+        await fetchHydrationRecord()
     }
     
     @MainActor
     func fetchHydrationRecord() async {
-        let (startDate, endDate) = getStartAndEndDate()
-        
-        guard let startDate, let endDate else {
-            errorMessage = "Failed to calculate date range"
-            return
+        let monthDates = monthDates(for: date)
+        let fetchedRecords = monthDates.compactMap { day -> HydrationRecord? in
+            let events = useCase.hydrationEvents(on: day)
+            let total = events.reduce(0) { partialResult, event in
+                partialResult + event.volumeML
+            }
+
+            guard total > 0 else {
+                return nil
+            }
+
+            return HydrationRecord(
+                id: UUID(),
+                date: day,
+                mililiter: Double(total)
+            )
         }
-        
-        do {
-            let fetchedRecords = try await useCase.fetchHistory(from: startDate, to: endDate)
-            records = fetchedRecords
-        } catch {
-            return
-        }
+
+        records = fetchedRecords.sorted { $0.date < $1.date }
     }
     
-    private func getStartAndEndDate() -> (startDate: Date?, endDate: Date?) {
-        let year = date.getComponents(for: .year)
-        let month = date.getComponents(for: .month)
-        let startDateComponents = DateComponents(year: year, month: month, day: 1)
-        
-        guard let startDate = Calendar.current.date(from: startDateComponents),
-              let range = Calendar.current.range(of: .day, in: .month, for: startDate) else {
-            return (nil, nil)
+    private func monthDates(for date: Date) -> [Date] {
+        guard let startDate = Calendar.current.date(
+            from: Calendar.current.dateComponents([.year, .month], from: date)
+        ),
+        let range = Calendar.current.range(of: .day, in: .month, for: startDate) else {
+            errorMessage = "Failed to calculate date range"
+            return []
         }
-        let endDateComponents = DateComponents(year: year, month: month, day: range.count)
-        let endDate = Calendar.current.date(from: endDateComponents)
-        
-        return (startDate, endDate)
-    }
-}
 
-fileprivate extension Date {
-    func getComponents(for component: Calendar.Component) -> Int? {
-        Calendar.autoupdatingCurrent.dateComponents([component], from: self).value(for: component) ?? 0
+        return range.compactMap { day in
+            Calendar.current.date(byAdding: .day, value: day - 1, to: startDate)
+        }
     }
 }

--- a/Project/Shared/DependencyInjection/Project.swift
+++ b/Project/Shared/DependencyInjection/Project.swift
@@ -50,6 +50,10 @@ let project = Project(
                 .project(
                     target: "PresentationLayer",
                     path: .relativeToRoot("Project/Presentation")
+                ),
+                .project(
+                    target: "Utils",
+                    path: .relativeToRoot("Project/Shared/Utils")
                 )
             ]
         ),

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -41,7 +41,7 @@ public final class PreviewAssembly: Assembly {
         
         container.register(HydrationRecordListViewModel.self) { resolver in
             HydrationRecordListViewModel(
-                useCase: resolver.resolve(HealthKitUseCase.self)!
+                useCase: resolver.resolve(DrinkWaterUseCase.self)!
             )
         }
         

--- a/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
@@ -8,6 +8,7 @@
 import DataLayer
 import DomainLayerInterface
 import Swinject
+import Utils
 
 public final class DataAssembly: Assembly {
     public func assemble(container: Container) {

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -35,7 +35,7 @@ public final class PresentationAssembly: Assembly {
         // MARK: - HealthKit
         container.register(HydrationRecordListViewModel.self) { resolver in
             HydrationRecordListViewModel(
-                useCase: resolver.resolve(HealthKitUseCase.self)!
+                useCase: resolver.resolve(DrinkWaterUseCase.self)!
             )
         }
         

--- a/Project/Shared/Persistence/Sources/SharedHydrationStore.swift
+++ b/Project/Shared/Persistence/Sources/SharedHydrationStore.swift
@@ -10,21 +10,30 @@ import SwiftData
 
 public enum SharedHydrationStoreError: Error, LocalizedError {
     case missingAppGroupContainer(identifier: String)
+    case failedToCreateContainer(primary: Error, fallback: Error)
 
     public var errorDescription: String? {
         switch self {
         case .missingAppGroupContainer(let identifier):
             return "App Group container is not available: \(identifier)"
+        case let .failedToCreateContainer(primary, fallback):
+            return """
+            Failed to create CloudKit-backed container (\(primary)).
+            Fallback local container also failed (\(fallback)).
+            """
         }
     }
 }
 
 public enum SharedHydrationStore {
     public static let appGroupIdentifier = "group.com.gaeng2y.drinkwater"
+    public static let cloudKitContainerIdentifier = "iCloud.gaeng2y.DrinkWater"
 
     public static func makeModelContainer(
-        cloudKitDatabase: ModelConfiguration.CloudKitDatabase = .none,
-        isStoredInMemoryOnly: Bool = false
+        cloudKitDatabase: ModelConfiguration.CloudKitDatabase = .automatic,
+        isStoredInMemoryOnly: Bool = false,
+        cloudSyncEnabled: Bool = true,
+        shouldFallbackToLocalStore: Bool = true
     ) throws -> ModelContainer {
         if !isStoredInMemoryOnly {
             guard FileManager.default.containerURL(
@@ -37,7 +46,7 @@ public enum SharedHydrationStore {
         }
 
         let effectiveCloudKitDatabase: ModelConfiguration.CloudKitDatabase =
-            isStoredInMemoryOnly ? .none : cloudKitDatabase
+            (isStoredInMemoryOnly || !cloudSyncEnabled) ? .none : cloudKitDatabase
 
         let configuration = ModelConfiguration(
             "Hydration",
@@ -47,10 +56,32 @@ public enum SharedHydrationStore {
             groupContainer: isStoredInMemoryOnly ? .none : .identifier(appGroupIdentifier),
             cloudKitDatabase: effectiveCloudKitDatabase
         )
+        
+        do {
+            return try ModelContainer(
+                for: HydrationEventModel.self,
+                configurations: configuration
+            )
+        } catch let primaryError {
+            guard shouldFallbackToLocalStore,
+                  !isStoredInMemoryOnly,
+                  cloudSyncEnabled else {
+                throw primaryError
+            }
 
-        return try ModelContainer(
-            for: HydrationEventModel.self,
-            configurations: configuration
-        )
+            do {
+                return try makeModelContainer(
+                    cloudKitDatabase: cloudKitDatabase,
+                    isStoredInMemoryOnly: false,
+                    cloudSyncEnabled: false,
+                    shouldFallbackToLocalStore: false
+                )
+            } catch let fallbackError {
+                throw SharedHydrationStoreError.failedToCreateContainer(
+                    primary: primaryError,
+                    fallback: fallbackError
+                )
+            }
+        }
     }
 }

--- a/Project/Widget/Sources/AppIntent.swift
+++ b/Project/Widget/Sources/AppIntent.swift
@@ -7,8 +7,6 @@
 
 import WidgetKit
 import AppIntents
-import Utils
-import HealthKit
 import DependencyInjection
 import DomainLayerInterface
 
@@ -21,11 +19,12 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
     var favoriteEmoji: String
     
     public func perform() async throws -> some IntentResult {
+        let waterUseCase = DIContainer.shared.resolve(DrinkWaterUseCase.self)
         let userPreferencesUseCase = DIContainer.shared.resolve(UserPreferencesUseCase.self)
         let healthKitUseCase = DIContainer.shared.resolve(HealthKitUseCase.self)
-        
-        let userDefaults = UserDefaults.appGroup
-        let currentGlasses = userDefaults.glassesOfToday
+
+        waterUseCase.migrateLegacyDataIfNeeded()
+        let currentGlasses = waterUseCase.currentWater
         let currentMl = Double(currentGlasses * 250)
         
         // Get daily limit from UseCase
@@ -34,8 +33,7 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
         // Check if adding one more glass would exceed daily limit
         let nextMl = currentMl + 250.0
         if nextMl <= dailyLimit {
-            userDefaults.glassesOfToday += 1
-            userDefaults.synchronize() // Force synchronization
+            waterUseCase.drinkWater()
             
             // Log to HealthKit via UseCase
             do {

--- a/Project/Widget/Sources/DrinkWaterWidget.swift
+++ b/Project/Widget/Sources/DrinkWaterWidget.swift
@@ -10,20 +10,15 @@ import Utils
 import WidgetKit
 import DependencyInjection
 import DomainLayerInterface
-import Persistence
-import SwiftData
 
 struct Provider: AppIntentTimelineProvider {
+    private let waterUseCase: DrinkWaterUseCase
     private let userPreferencesUseCase: UserPreferencesUseCase
-    private let modelContainer: ModelContainer
     
     init() {
+        self.waterUseCase = DIContainer.shared.resolve(DrinkWaterUseCase.self)
         self.userPreferencesUseCase = DIContainer.shared.resolve(UserPreferencesUseCase.self)
-        do {
-            self.modelContainer = try SharedHydrationStore.makeModelContainer()
-        } catch {
-            fatalError("Failed to initialize shared hydration store in widget: \(error)")
-        }
+        waterUseCase.migrateLegacyDataIfNeeded()
     }
     
     func placeholder(in context: Context) -> DrinkWaterEntry {
@@ -40,14 +35,13 @@ struct Provider: AppIntentTimelineProvider {
         for configuration: ConfigurationAppIntent,
         in context: Context
     ) async -> DrinkWaterEntry {
-        let userDefaults = UserDefaults.appGroup
         let dailyLimit = userPreferencesUseCase.getDailyWaterLimit()
         let mainAppearance = userPreferencesUseCase.getMainAppearance()
         let appearanceIcon = mainAppearance.systemImage
         
         return .init(
             date: .now,
-            numberOfGlasses: userDefaults.glassesOfToday,
+            numberOfGlasses: waterUseCase.currentWater,
             dailyLimit: dailyLimit,
             mainAppearanceIcon: appearanceIcon,
             configuration: ConfigurationAppIntent()
@@ -58,10 +52,10 @@ struct Provider: AppIntentTimelineProvider {
         for configuration: ConfigurationAppIntent,
         in context: Context
     ) async -> Timeline<DrinkWaterEntry> {
-        let userDefaults = UserDefaults.appGroup
         let dailyLimit = userPreferencesUseCase.getDailyWaterLimit()
         let mainAppearance = userPreferencesUseCase.getMainAppearance()
         let appearanceIcon = mainAppearance.systemImage
+        let currentCount = waterUseCase.currentWater
         
         var entries: [DrinkWaterEntry] = []
         
@@ -71,7 +65,7 @@ struct Provider: AppIntentTimelineProvider {
             let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
             let entry = DrinkWaterEntry(
                 date: entryDate,
-                numberOfGlasses: userDefaults.glassesOfToday,
+                numberOfGlasses: currentCount,
                 dailyLimit: dailyLimit,
                 mainAppearanceIcon: appearanceIcon,
                 configuration: ConfigurationAppIntent()

--- a/Supporting Files/Mulimi.entitlements
+++ b/Supporting Files/Mulimi.entitlements
@@ -4,6 +4,14 @@
 <dict>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Supporting Files/WidgetExtension.entitlements
+++ b/Supporting Files/WidgetExtension.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>


### PR DESCRIPTION
## Summary
- migrate app drink screen refresh/read path to `DrinkWaterUseCase` (SwiftData-backed)
- remove direct `UserDefaults.appGroup.glassesOfToday` reads from `DrinkWaterViewModel`
- migrate record tab source from HealthKit history to monthly aggregation from `HydrationEvent`
- simplify record tab gate (no HealthKit authorization dependency for local hydration records)

## Verification
- `tuist generate`
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -sdk iphoneos CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

Closes #99
Parent #96
