### PR TITLE
feat: [96-4] 위젯/AppIntent SwiftData 공유 저장소 전환

### DIFF
--- a/Docs/swiftdata-cloudkit-sync.md
+++ b/Docs/swiftdata-cloudkit-sync.md
@@ -1,0 +1,25 @@
+# SwiftData + CloudKit Sync Strategy (Hydration Only)
+
+## Scope
+- Synced: `HydrationEventModel` only
+- Not synced: user preference values (`mainAppearance`, `dailyLimit`) in UserDefaults
+
+## Container
+- CloudKit container: `iCloud.gaeng2y.DrinkWater`
+- App Group store: `group.com.gaeng2y.drinkwater`
+
+## Runtime Behavior
+1. App/Widget requests a SwiftData container with `cloudKitDatabase: .automatic`.
+2. If CloudKit-backed container creation succeeds, hydration events are synced across devices signed into the same Apple ID.
+3. If CloudKit container creation fails (for example iCloud disabled/misconfigured), store creation automatically falls back to local-only (`cloudKitDatabase: .none`).
+4. Core hydration features keep working in local-only mode.
+
+## Fallback Guarantee
+- Fallback is implemented in `SharedHydrationStore.makeModelContainer(...)`.
+- If both CloudKit and local container creation fail, an explicit error is thrown (`failedToCreateContainer`).
+
+## Capability Requirements
+- App and Widget extension entitlements include:
+  - `com.apple.developer.icloud-services = CloudKit`
+  - `com.apple.developer.icloud-container-identifiers = iCloud.gaeng2y.DrinkWater`
+  - existing App Group entitlement for shared local persistence

--- a/Project/App/Sources/DrinkWaterApp.swift
+++ b/Project/App/Sources/DrinkWaterApp.swift
@@ -18,7 +18,10 @@ struct DrinkWaterApp: App {
 
     init() {
         do {
-            self.modelContainer = try SharedHydrationStore.makeModelContainer()
+            self.modelContainer = try SharedHydrationStore.makeModelContainer(
+                cloudKitDatabase: .automatic,
+                shouldFallbackToLocalStore: true
+            )
         } catch {
             fatalError("Failed to initialize shared hydration store: \(error)")
         }

--- a/Project/App/Supports/Mulimi.entitlements
+++ b/Project/App/Supports/Mulimi.entitlements
@@ -8,6 +8,14 @@
 	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Project/App/Supports/WidgetExtension.entitlements
+++ b/Project/App/Supports/WidgetExtension.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Project/Shared/Persistence/Sources/SharedHydrationStore.swift
+++ b/Project/Shared/Persistence/Sources/SharedHydrationStore.swift
@@ -10,21 +10,30 @@ import SwiftData
 
 public enum SharedHydrationStoreError: Error, LocalizedError {
     case missingAppGroupContainer(identifier: String)
+    case failedToCreateContainer(primary: Error, fallback: Error)
 
     public var errorDescription: String? {
         switch self {
         case .missingAppGroupContainer(let identifier):
             return "App Group container is not available: \(identifier)"
+        case let .failedToCreateContainer(primary, fallback):
+            return """
+            Failed to create CloudKit-backed container (\(primary)).
+            Fallback local container also failed (\(fallback)).
+            """
         }
     }
 }
 
 public enum SharedHydrationStore {
     public static let appGroupIdentifier = "group.com.gaeng2y.drinkwater"
+    public static let cloudKitContainerIdentifier = "iCloud.gaeng2y.DrinkWater"
 
     public static func makeModelContainer(
-        cloudKitDatabase: ModelConfiguration.CloudKitDatabase = .none,
-        isStoredInMemoryOnly: Bool = false
+        cloudKitDatabase: ModelConfiguration.CloudKitDatabase = .automatic,
+        isStoredInMemoryOnly: Bool = false,
+        cloudSyncEnabled: Bool = true,
+        shouldFallbackToLocalStore: Bool = true
     ) throws -> ModelContainer {
         if !isStoredInMemoryOnly {
             guard FileManager.default.containerURL(
@@ -37,7 +46,7 @@ public enum SharedHydrationStore {
         }
 
         let effectiveCloudKitDatabase: ModelConfiguration.CloudKitDatabase =
-            isStoredInMemoryOnly ? .none : cloudKitDatabase
+            (isStoredInMemoryOnly || !cloudSyncEnabled) ? .none : cloudKitDatabase
 
         let configuration = ModelConfiguration(
             "Hydration",
@@ -47,10 +56,32 @@ public enum SharedHydrationStore {
             groupContainer: isStoredInMemoryOnly ? .none : .identifier(appGroupIdentifier),
             cloudKitDatabase: effectiveCloudKitDatabase
         )
+        
+        do {
+            return try ModelContainer(
+                for: HydrationEventModel.self,
+                configurations: configuration
+            )
+        } catch let primaryError {
+            guard shouldFallbackToLocalStore,
+                  !isStoredInMemoryOnly,
+                  cloudSyncEnabled else {
+                throw primaryError
+            }
 
-        return try ModelContainer(
-            for: HydrationEventModel.self,
-            configurations: configuration
-        )
+            do {
+                return try makeModelContainer(
+                    cloudKitDatabase: cloudKitDatabase,
+                    isStoredInMemoryOnly: false,
+                    cloudSyncEnabled: false,
+                    shouldFallbackToLocalStore: false
+                )
+            } catch let fallbackError {
+                throw SharedHydrationStoreError.failedToCreateContainer(
+                    primary: primaryError,
+                    fallback: fallbackError
+                )
+            }
+        }
     }
 }

--- a/Project/Widget/Sources/AppIntent.swift
+++ b/Project/Widget/Sources/AppIntent.swift
@@ -7,8 +7,6 @@
 
 import WidgetKit
 import AppIntents
-import Utils
-import HealthKit
 import DependencyInjection
 import DomainLayerInterface
 
@@ -21,11 +19,12 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
     var favoriteEmoji: String
     
     public func perform() async throws -> some IntentResult {
+        let waterUseCase = DIContainer.shared.resolve(DrinkWaterUseCase.self)
         let userPreferencesUseCase = DIContainer.shared.resolve(UserPreferencesUseCase.self)
         let healthKitUseCase = DIContainer.shared.resolve(HealthKitUseCase.self)
-        
-        let userDefaults = UserDefaults.appGroup
-        let currentGlasses = userDefaults.glassesOfToday
+
+        waterUseCase.migrateLegacyDataIfNeeded()
+        let currentGlasses = waterUseCase.currentWater
         let currentMl = Double(currentGlasses * 250)
         
         // Get daily limit from UseCase
@@ -34,8 +33,7 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
         // Check if adding one more glass would exceed daily limit
         let nextMl = currentMl + 250.0
         if nextMl <= dailyLimit {
-            userDefaults.glassesOfToday += 1
-            userDefaults.synchronize() // Force synchronization
+            waterUseCase.drinkWater()
             
             // Log to HealthKit via UseCase
             do {

--- a/Project/Widget/Sources/DrinkWaterWidget.swift
+++ b/Project/Widget/Sources/DrinkWaterWidget.swift
@@ -10,20 +10,15 @@ import Utils
 import WidgetKit
 import DependencyInjection
 import DomainLayerInterface
-import Persistence
-import SwiftData
 
 struct Provider: AppIntentTimelineProvider {
+    private let waterUseCase: DrinkWaterUseCase
     private let userPreferencesUseCase: UserPreferencesUseCase
-    private let modelContainer: ModelContainer
     
     init() {
+        self.waterUseCase = DIContainer.shared.resolve(DrinkWaterUseCase.self)
         self.userPreferencesUseCase = DIContainer.shared.resolve(UserPreferencesUseCase.self)
-        do {
-            self.modelContainer = try SharedHydrationStore.makeModelContainer()
-        } catch {
-            fatalError("Failed to initialize shared hydration store in widget: \(error)")
-        }
+        waterUseCase.migrateLegacyDataIfNeeded()
     }
     
     func placeholder(in context: Context) -> DrinkWaterEntry {
@@ -40,14 +35,13 @@ struct Provider: AppIntentTimelineProvider {
         for configuration: ConfigurationAppIntent,
         in context: Context
     ) async -> DrinkWaterEntry {
-        let userDefaults = UserDefaults.appGroup
         let dailyLimit = userPreferencesUseCase.getDailyWaterLimit()
         let mainAppearance = userPreferencesUseCase.getMainAppearance()
         let appearanceIcon = mainAppearance.systemImage
         
         return .init(
             date: .now,
-            numberOfGlasses: userDefaults.glassesOfToday,
+            numberOfGlasses: waterUseCase.currentWater,
             dailyLimit: dailyLimit,
             mainAppearanceIcon: appearanceIcon,
             configuration: ConfigurationAppIntent()
@@ -58,10 +52,10 @@ struct Provider: AppIntentTimelineProvider {
         for configuration: ConfigurationAppIntent,
         in context: Context
     ) async -> Timeline<DrinkWaterEntry> {
-        let userDefaults = UserDefaults.appGroup
         let dailyLimit = userPreferencesUseCase.getDailyWaterLimit()
         let mainAppearance = userPreferencesUseCase.getMainAppearance()
         let appearanceIcon = mainAppearance.systemImage
+        let currentCount = waterUseCase.currentWater
         
         var entries: [DrinkWaterEntry] = []
         
@@ -71,7 +65,7 @@ struct Provider: AppIntentTimelineProvider {
             let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
             let entry = DrinkWaterEntry(
                 date: entryDate,
-                numberOfGlasses: userDefaults.glassesOfToday,
+                numberOfGlasses: currentCount,
                 dailyLimit: dailyLimit,
                 mainAppearanceIcon: appearanceIcon,
                 configuration: ConfigurationAppIntent()

--- a/Supporting Files/Mulimi.entitlements
+++ b/Supporting Files/Mulimi.entitlements
@@ -4,6 +4,14 @@
 <dict>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Supporting Files/WidgetExtension.entitlements
+++ b/Supporting Files/WidgetExtension.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.gaeng2y.DrinkWater</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>


### PR DESCRIPTION
## Summary
- migrate Widget `Provider` count read path from `UserDefaults.appGroup` to `DrinkWaterUseCase` (SwiftData-backed)
- migrate Widget `AppIntent` write path from `UserDefaults.appGroup` to `DrinkWaterUseCase.drinkWater()`
- keep Widget timeline reload and HealthKit logging behavior while switching shared persistence path

## Verification
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -sdk iphoneos CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

Closes #100
Parent #96
