### PR TITLE
feat: 기록 화면 년/월 wheel picker 적용 (#23)

### DIFF
--- a/Project/Presentation/Sources/View/HydrationRecord/RecordCalendarView.swift
+++ b/Project/Presentation/Sources/View/HydrationRecord/RecordCalendarView.swift
@@ -11,6 +11,9 @@ import SwiftUI
 
 struct RecordCalendarView: View {
     @Bindable private var viewModel: HydrationRecordListViewModel
+    @State private var isYearMonthPickerPresented = false
+    @State private var selectedYear = Calendar.current.component(.year, from: .now)
+    @State private var selectedMonth = Calendar.current.component(.month, from: .now)
 
     private let calendar = Calendar.current
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 7)
@@ -53,19 +56,36 @@ struct RecordCalendarView: View {
         .task {
             await viewModel.fetchHydrationRecord()
         }
+        .sheet(isPresented: $isYearMonthPickerPresented) {
+            yearMonthPickerSheet
+        }
     }
 
     private var monthHeader: some View {
         HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(viewModel.date.formatted(.dateTime.year()))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+            Button {
+                syncPickerSelectionWithCurrentDate()
+                isYearMonthPickerPresented = true
+            } label: {
+                HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(viewModel.date.formatted(.dateTime.year()))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
 
-                Text(viewModel.date.formatted(.dateTime.month(.wide)))
-                    .font(.title2)
-                    .fontWeight(.bold)
+                        Text(viewModel.date.formatted(.dateTime.month(.wide)))
+                            .font(.title2)
+                            .fontWeight(.bold)
+                    }
+
+                    Image(systemName: "chevron.down")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(.secondary)
+                }
             }
+            .buttonStyle(.plain)
+            .accessibilityLabel("년월 선택")
+            .accessibilityHint("기록을 볼 년과 월을 선택합니다")
 
             Spacer()
 
@@ -155,6 +175,65 @@ struct RecordCalendarView: View {
         let goalPerMonth = dailyGoal * Double(daysInMonth)
         let totalConsumed = viewModel.records.reduce(0) { $0 + $1.mililiter }
         return min(Int((totalConsumed / goalPerMonth) * 100), 100)
+    }
+
+    private var selectableYears: [Int] {
+        let currentYear = calendar.component(.year, from: .now)
+        return Array((currentYear - 10)...(currentYear + 2))
+    }
+
+    @ViewBuilder
+    private var yearMonthPickerSheet: some View {
+        NavigationStack {
+            HStack(spacing: 0) {
+                Picker("년", selection: $selectedYear) {
+                    ForEach(selectableYears, id: \.self) { year in
+                        Text("\(year)년")
+                            .tag(year)
+                    }
+                }
+                .pickerStyle(.wheel)
+                .frame(maxWidth: .infinity)
+                .clipped()
+
+                Picker("월", selection: $selectedMonth) {
+                    ForEach(1...12, id: \.self) { month in
+                        Text("\(month)월")
+                            .tag(month)
+                    }
+                }
+                .pickerStyle(.wheel)
+                .frame(maxWidth: .infinity)
+                .clipped()
+            }
+            .navigationTitle("년/월 선택")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("취소") {
+                        isYearMonthPickerPresented = false
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("적용") {
+                        Task {
+                            await viewModel.updateDisplayedMonth(
+                                year: selectedYear,
+                                month: selectedMonth
+                            )
+                        }
+                        isYearMonthPickerPresented = false
+                    }
+                }
+            }
+        }
+        .presentationDetents([.height(320)])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func syncPickerSelectionWithCurrentDate() {
+        selectedYear = calendar.component(.year, from: viewModel.date)
+        selectedMonth = calendar.component(.month, from: viewModel.date)
     }
 }
 

--- a/Project/Presentation/Sources/ViewModel/HydrationRecordListViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationRecordListViewModel.swift
@@ -50,6 +50,24 @@ public final class HydrationRecordListViewModel {
 
         records = fetchedRecords.sorted { $0.date < $1.date }
     }
+
+    @MainActor
+    func updateDisplayedMonth(year: Int, month: Int) async {
+        guard (1...12).contains(month),
+              let newDate = Calendar.current.date(
+                from: DateComponents(year: year, month: month, day: 1)
+              ) else {
+            errorMessage = "Invalid date selection"
+            return
+        }
+
+        guard !Calendar.current.isDate(newDate, equalTo: date, toGranularity: .month) else {
+            return
+        }
+
+        date = newDate
+        await fetchHydrationRecord()
+    }
     
     private func monthDates(for date: Date) -> [Date] {
         guard let startDate = Calendar.current.date(

--- a/Project/Presentation/Sources/ViewModel/SettingsViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/SettingsViewModel.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import DomainLayerInterface
+import Utils
 import WidgetKit
 
 @Observable


### PR DESCRIPTION
## 📝 Summary
기록 캘린더에서 년/월을 직접 선택할 수 있도록 wheel picker 기반 월 선택 UX를 추가했습니다.
선택한 값은 Calendar(DateComponents)로 반영되어 해당 월 기록을 즉시 다시 조회합니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [x] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [ ] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #23
- Related to #23

## 📋 Changes Made
### Added
- 기록 화면 헤더 탭 시 년/월 선택 sheet(wheel picker 2열) 추가
- `HydrationRecordListViewModel.updateDisplayedMonth(year:month)` 추가

### Changed
- 헤더의 년/월 표시 영역을 선택 가능한 컨트롤로 변경
- 선택 적용 시 월 기준 기록 재조회 로직 연결

### Fixed
- `SettingsViewModel`에서 `.widgetKind` 참조를 위한 `Utils` import 누락 보완

### Removed
- 없음

## 🔍 Technical Details
- 월 선택값은 `DateComponents(year:month:day:1)` -> `Calendar.current.date(from:)`로 Date 변환
- 기존 월과 동일하면 fetch를 생략하고, 변경된 경우에만 `fetchHydrationRecord()` 실행

## 📸 Screenshots / Videos
### Before
- 헤더는 단순 텍스트 표시(년/월)

### After
- 헤더 탭 -> 년/월 wheel picker sheet 표시 -> 적용 시 캘린더 월 데이터 갱신

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [ ] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iPhoneOS 26.2 SDK
- Device: Any iOS Device (xcodebuild)
- Xcode Version: 17C529

### Test Results
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -sdk iphoneos CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` 성공

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- UI 스크린샷은 CLI 환경에서 첨부하지 못했습니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
