### PR TITLE
chore: Xcode Cloud release-build only setup (#15)

### DIFF
--- a/Docs/xcode-cloud-release-build.md
+++ b/Docs/xcode-cloud-release-build.md
@@ -1,0 +1,44 @@
+# Xcode Cloud: Release Build Only Setup
+
+이 문서는 `#15` 이슈 범위를 "Release Build"로 한정해서 설정하는 절차입니다.
+`PR-UnitTests` 워크플로는 만들지 않습니다.
+
+## 1) 저장소 준비
+- 커스텀 스크립트 경로를 Xcode Cloud 표준인 `ci_scripts/`로 사용
+- 현재 스크립트: `ci_scripts/ci_post_clone.sh`
+- 스크립트에서 수행:
+  - `mise` 설치/활성화
+  - `tuist install`
+  - `tuist generate`
+
+## 2) Xcode Cloud 워크플로 생성
+Xcode > Report navigator > Cloud 또는 App Store Connect > Xcode Cloud에서 워크플로 생성:
+
+1. Workflow name: `Release-Build`
+2. Start Condition (권장):
+   - `Tag changes` with pattern: `v*`
+3. Action:
+   - `Archive`
+4. Scheme:
+   - `Mulimi`
+5. Configuration:
+   - `Release`
+6. Destination:
+   - iOS
+
+참고: 태그 기반으로 두면 의도된 릴리즈 시점에만 아카이브가 실행됩니다.
+
+## 3) (선택) 배포 연동
+필요하면 같은 워크플로에 배포 단계를 추가:
+- TestFlight distribute
+- 또는 아카이브 산출물만 유지
+
+## 4) 운영 방식
+- 릴리즈 빌드 트리거:
+  - `git tag v1.0.0`
+  - `git push origin v1.0.0`
+- 빌드 결과는 Xcode Cloud 대시보드에서 확인
+
+## 5) 현재 범위
+- 포함: Release Archive 자동화
+- 제외: PR 생성 시 유닛 테스트 게이팅

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 set -e
-cd ..
 
-curl https://mise.run | sh
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v mise >/dev/null 2>&1; then
+  curl https://mise.run | sh
+fi
 export PATH="$HOME/.local/bin:$PATH"
 
 # Output the current PATH for debugging


### PR DESCRIPTION
## 📝 Summary
Xcode Cloud를 PR 테스트 워크플로 없이 `Release-Build` 전용으로 운영할 수 있도록 저장소 구조와 가이드를 정리했습니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [x] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [x] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [ ] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #15
- Related to #15

## 📋 Changes Made
### Added
- `Docs/xcode-cloud-release-build.md` 문서 추가

### Changed
- Xcode Cloud post-clone 스크립트 경로를 `ci_scripts/ci_post_clone.sh`로 정리
- 스크립트가 저장소 루트를 안정적으로 찾도록 경로 처리 개선
- `mise`가 이미 설치된 경우 재설치를 건너뛰도록 보완

### Fixed
- Xcode Cloud 표준 스크립트 디렉토리 미사용 상태 해소

### Removed
- 기존 `ci_script/ci_post_clone.sh` 경로 제거(renamed)

## 🔍 Technical Details
- `ci_scripts/ci_post_clone.sh`는 다음 순서로 동작:
  1. repo root 이동
  2. `mise` 준비
  3. `tuist install`
  4. `tuist generate`
- 워크플로 범위는 Release Archive 자동화에 한정

## 📸 Screenshots / Videos
### Before
- Xcode Cloud 표준 경로(`ci_scripts`) 미사용

### After
- `ci_scripts/ci_post_clone.sh` 기준으로 Release Build 준비 가능

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: N/A (스크립트/설정 변경)
- Device: N/A
- Xcode Version: N/A

### Test Results
- `tuist generate` 성공
- `sh -n ci_scripts/ci_post_clone.sh` 구문 검증 성공

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- Xcode Cloud UI에서 별도로 `Release-Build` 워크플로를 생성해야 실제 동작합니다.
- 권장 조건: `Tag changes (v*)` + `Archive` + Scheme `Mulimi` + Configuration `Release`

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [x] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
