### PR TITLE
ci: run unit tests on PRs

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 45
     env:
       TEAM_ID: "8UV3Y69NB7"
+      GITHUB_TOKEN: ${{ github.token }}
+      AQUA_GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -59,14 +59,19 @@ jobs:
         id: destination
         run: |
           set -e
-          DESTINATION_ID="$(xcodebuild -showdestinations -workspace Mulimi.xcworkspace -scheme DomainLayer 2>/dev/null | sed -n 's/.*platform:iOS Simulator, id:\([^,}]*\).*/\1/p' | head -n 1 | tr -d ' ')"
+          DESTINATION_ID="$(xcodebuild -showdestinations -workspace Mulimi.xcworkspace -scheme DomainLayer 2>/dev/null \
+            | grep 'platform:iOS Simulator' \
+            | grep 'OS:' \
+            | sed -n 's/.*id:\([^,}]*\).*/\1/p' \
+            | head -n 1 \
+            | tr -d ' ')"
           if [ -z "$DESTINATION_ID" ]; then
             echo "No iOS Simulator destination found for DomainLayer."
             xcodebuild -showdestinations -workspace Mulimi.xcworkspace -scheme DomainLayer
             exit 1
           fi
-          echo "destination=id=$DESTINATION_ID" >> "$GITHUB_OUTPUT"
-          echo "Using destination id=$DESTINATION_ID"
+          echo "destination=platform=iOS Simulator,id=$DESTINATION_ID" >> "$GITHUB_OUTPUT"
+          echo "Using destination platform=iOS Simulator,id=$DESTINATION_ID"
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -1,0 +1,81 @@
+name: PR Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    runs-on: macos-15
+    timeout-minutes: 45
+    env:
+      TEAM_ID: "8UV3Y69NB7"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare Secrets.xcconfig
+        run: |
+          set -e
+          if [ ! -f XCConfig/Secrets.xcconfig ]; then
+            if [ -f XCConfig/Secrets.xcconfig.template ]; then
+              sed "s/YOUR_TEAM_ID/${TEAM_ID}/g" XCConfig/Secrets.xcconfig.template > XCConfig/Secrets.xcconfig
+            else
+              echo "DEVELOPMENT_TEAM = ${TEAM_ID}" > XCConfig/Secrets.xcconfig
+            fi
+          fi
+
+      - name: Install mise
+        run: |
+          set -e
+          if ! command -v mise >/dev/null 2>&1; then
+            curl https://mise.run | sh
+          fi
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/share/mise/shims" >> "$GITHUB_PATH"
+
+      - name: Install tools and dependencies
+        run: |
+          set -e
+          mise --version
+          mise install
+          tuist version
+          tuist install
+          tuist generate
+
+      - name: Resolve iOS Simulator destination
+        id: destination
+        run: |
+          set -e
+          DESTINATION_ID="$(xcodebuild -showdestinations -workspace Mulimi.xcworkspace -scheme DomainLayer 2>/dev/null | sed -n 's/.*platform:iOS Simulator, id:\([^,}]*\).*/\1/p' | head -n 1 | tr -d ' ')"
+          if [ -z "$DESTINATION_ID" ]; then
+            echo "No iOS Simulator destination found for DomainLayer."
+            xcodebuild -showdestinations -workspace Mulimi.xcworkspace -scheme DomainLayer
+            exit 1
+          fi
+          echo "destination=id=$DESTINATION_ID" >> "$GITHUB_OUTPUT"
+          echo "Using destination id=$DESTINATION_ID"
+
+      - name: Run unit tests
+        run: |
+          set -euo pipefail
+          DESTINATION="${{ steps.destination.outputs.destination }}"
+          for SCHEME in DomainLayer DataLayer PresentationLayer; do
+            echo "Running tests for $SCHEME"
+            xcodebuild test \
+              -workspace Mulimi.xcworkspace \
+              -scheme "$SCHEME" \
+              -destination "$DESTINATION" \
+              CODE_SIGNING_ALLOWED=NO \
+              CODE_SIGNING_REQUIRED=NO
+          done

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -55,23 +55,42 @@ jobs:
           tuist install
           tuist generate
 
-      - name: Resolve iOS Simulator destination
+      - name: Resolve test destination
         id: destination
         run: |
           set -e
-          DESTINATION_ID="$(xcodebuild -showdestinations -workspace Mulimi.xcworkspace -scheme DomainLayer 2>/dev/null \
+          DESTINATIONS="$(xcodebuild -showdestinations -workspace Mulimi.xcworkspace -scheme DomainLayer)"
+          echo "$DESTINATIONS"
+
+          IOS_SIM_ID="$(printf '%s\n' "$DESTINATIONS" \
             | grep 'platform:iOS Simulator' \
             | grep 'OS:' \
             | sed -n 's/.*id:\([^,}]*\).*/\1/p' \
             | head -n 1 \
             | tr -d ' ')"
-          if [ -z "$DESTINATION_ID" ]; then
-            echo "No iOS Simulator destination found for DomainLayer."
-            xcodebuild -showdestinations -workspace Mulimi.xcworkspace -scheme DomainLayer
-            exit 1
+
+          if [ -n "$IOS_SIM_ID" ]; then
+            DESTINATION="platform=iOS Simulator,id=$IOS_SIM_ID"
+            echo "Using iOS Simulator destination: $DESTINATION"
+            echo "destination=$DESTINATION" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-          echo "destination=platform=iOS Simulator,id=$DESTINATION_ID" >> "$GITHUB_OUTPUT"
-          echo "Using destination platform=iOS Simulator,id=$DESTINATION_ID"
+
+          MAC_ID="$(printf '%s\n' "$DESTINATIONS" \
+            | grep 'platform:macOS' \
+            | sed -n 's/.*id:\([^,}]*\).*/\1/p' \
+            | head -n 1 \
+            | tr -d ' ')"
+
+          if [ -n "$MAC_ID" ]; then
+            DESTINATION="platform=macOS,id=$MAC_ID"
+            echo "No concrete iOS Simulator found. Falling back to macOS destination: $DESTINATION"
+            echo "destination=$DESTINATION" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "No valid destination found for DomainLayer."
+          exit 1
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -55,42 +55,28 @@ jobs:
           tuist install
           tuist generate
 
-      - name: Resolve test destination
+      - name: Resolve iOS Simulator destination
         id: destination
         run: |
-          set -e
-          DESTINATIONS="$(xcodebuild -showdestinations -workspace Mulimi.xcworkspace -scheme DomainLayer)"
-          echo "$DESTINATIONS"
+          set -euo pipefail
+          xcrun simctl list devices available
 
-          IOS_SIM_ID="$(printf '%s\n' "$DESTINATIONS" \
-            | grep 'platform:iOS Simulator' \
-            | grep 'OS:' \
-            | sed -n 's/.*id:\([^,}]*\).*/\1/p' \
-            | head -n 1 \
-            | tr -d ' ')"
+          IOS_SIM_ID="$(xcrun simctl list devices available \
+            | awk -F '[()]' '/iPhone/ && /(Booted|Shutdown)/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}')"
 
-          if [ -n "$IOS_SIM_ID" ]; then
-            DESTINATION="platform=iOS Simulator,id=$IOS_SIM_ID"
-            echo "Using iOS Simulator destination: $DESTINATION"
-            echo "destination=$DESTINATION" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [ -z "$IOS_SIM_ID" ]; then
+            IOS_SIM_ID="$(xcrun simctl list devices available \
+              | awk -F '[()]' '/iPad/ && /(Booted|Shutdown)/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}')"
           fi
 
-          MAC_ID="$(printf '%s\n' "$DESTINATIONS" \
-            | grep 'platform:macOS' \
-            | sed -n 's/.*id:\([^,}]*\).*/\1/p' \
-            | head -n 1 \
-            | tr -d ' ')"
-
-          if [ -n "$MAC_ID" ]; then
-            DESTINATION="platform=macOS,id=$MAC_ID"
-            echo "No concrete iOS Simulator found. Falling back to macOS destination: $DESTINATION"
-            echo "destination=$DESTINATION" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [ -z "$IOS_SIM_ID" ]; then
+            echo "No concrete iOS simulator device found."
+            xcodebuild -showdestinations -workspace Mulimi.xcworkspace -scheme DomainLayer || true
+            exit 1
           fi
 
-          echo "No valid destination found for DomainLayer."
-          exit 1
+          echo "destination=id=$IOS_SIM_ID" >> "$GITHUB_OUTPUT"
+          echo "Using destination id=$IOS_SIM_ID"
 
       - name: Run unit tests
         run: |
@@ -102,6 +88,7 @@ jobs:
               -workspace Mulimi.xcworkspace \
               -scheme "$SCHEME" \
               -destination "$DESTINATION" \
+              -destination-timeout 180 \
               CODE_SIGNING_ALLOWED=NO \
               CODE_SIGNING_REQUIRED=NO
           done


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for pull request unit tests
- generate `XCConfig/Secrets.xcconfig` in CI when missing
- install tools via `mise`, run `tuist install` and `tuist generate`
- execute `xcodebuild test` for `DomainLayer`, `DataLayer`, and `PresentationLayer` schemes

## Notes
- targets PRs into `main` and `develop`
- includes manual trigger (`workflow_dispatch`)

## Verification
- workflow YAML parsed locally (`yaml ok`)

Related: #41