### PR TITLE
test: add unit tests for PresentationLayer view models (#110)

### DIFF
--- a/Project/Domain/Tests/Mock/MockAuthenticationRepository.swift
+++ b/Project/Domain/Tests/Mock/MockAuthenticationRepository.swift
@@ -1,0 +1,55 @@
+//
+//  MockAuthenticationRepository.swift
+//  DomainLayerTests
+//
+//  Created by Codex on 3/11/26.
+//
+
+import DomainLayerInterface
+import Foundation
+
+final class MockAuthenticationRepository: AuthenticationRepository, @unchecked Sendable {
+    var isAuthenticatedValue: Bool = false
+
+    private(set) var signInWithAppleCallCount = 0
+    private(set) var signOutCallCount = 0
+    private(set) var deleteAccountCallCount = 0
+
+    var signInError: Error?
+    var deleteAccountError: Error?
+    var signInCredentialToReturn = UserCredential(
+        userIdentifier: "mock-user-id",
+        email: "mock@example.com",
+        name: "Mock User"
+    )
+
+    var isAuthenticated: Bool {
+        isAuthenticatedValue
+    }
+
+    func signInWithApple() async throws -> UserCredential {
+        signInWithAppleCallCount += 1
+
+        if let signInError {
+            throw signInError
+        }
+
+        isAuthenticatedValue = true
+        return signInCredentialToReturn
+    }
+
+    func signOut() {
+        signOutCallCount += 1
+        isAuthenticatedValue = false
+    }
+
+    func deleteAccount() async throws {
+        deleteAccountCallCount += 1
+
+        if let deleteAccountError {
+            throw deleteAccountError
+        }
+
+        isAuthenticatedValue = false
+    }
+}

--- a/Project/Domain/Tests/SignInUseCaseTests.swift
+++ b/Project/Domain/Tests/SignInUseCaseTests.swift
@@ -1,0 +1,97 @@
+//
+//  SignInUseCaseTests.swift
+//  DomainLayerTests
+//
+//  Created by Codex on 3/11/26.
+//
+
+import DomainLayer
+import Foundation
+import Testing
+
+@testable import DomainLayer
+
+@Suite("SignInUseCase Tests")
+struct SignInUseCaseTests {
+    private enum MockSignInError: Error {
+        case signInFailed
+        case deleteAccountFailed
+    }
+
+    @Test("초기 인증 상태 조회 테스트")
+    func initialAuthenticationState() {
+        let mockRepository = MockAuthenticationRepository()
+        mockRepository.isAuthenticatedValue = false
+        let useCase = SignInUseCaseImpl(repository: mockRepository)
+
+        #expect(useCase.isAuthenticated == false)
+    }
+
+    @Test("인증 상태는 Repository 값을 그대로 반영한다")
+    func authenticationStateReflectsRepository() {
+        let mockRepository = MockAuthenticationRepository()
+        mockRepository.isAuthenticatedValue = true
+        let useCase = SignInUseCaseImpl(repository: mockRepository)
+
+        #expect(useCase.isAuthenticated == true)
+    }
+
+    @Test("Apple 로그인 성공 시 Repository 메소드를 위임 호출한다")
+    func signInWithAppleSuccess() async throws {
+        let mockRepository = MockAuthenticationRepository()
+        let useCase = SignInUseCaseImpl(repository: mockRepository)
+
+        try await useCase.signInWithApple()
+
+        #expect(mockRepository.signInWithAppleCallCount == 1)
+        #expect(useCase.isAuthenticated == true)
+    }
+
+    @Test("Apple 로그인 실패 시 에러를 그대로 전달한다")
+    func signInWithAppleFailure() async {
+        let mockRepository = MockAuthenticationRepository()
+        mockRepository.signInError = MockSignInError.signInFailed
+        let useCase = SignInUseCaseImpl(repository: mockRepository)
+
+        await #expect(throws: MockSignInError.signInFailed) {
+            try await useCase.signInWithApple()
+        }
+        #expect(mockRepository.signInWithAppleCallCount == 1)
+    }
+
+    @Test("로그아웃 시 Repository 메소드를 위임 호출한다")
+    func signOut() {
+        let mockRepository = MockAuthenticationRepository()
+        mockRepository.isAuthenticatedValue = true
+        let useCase = SignInUseCaseImpl(repository: mockRepository)
+
+        useCase.signOut()
+
+        #expect(mockRepository.signOutCallCount == 1)
+        #expect(useCase.isAuthenticated == false)
+    }
+
+    @Test("회원 탈퇴 성공 시 Repository 메소드를 위임 호출한다")
+    func deleteAccountSuccess() async throws {
+        let mockRepository = MockAuthenticationRepository()
+        mockRepository.isAuthenticatedValue = true
+        let useCase = SignInUseCaseImpl(repository: mockRepository)
+
+        try await useCase.deleteAccount()
+
+        #expect(mockRepository.deleteAccountCallCount == 1)
+        #expect(useCase.isAuthenticated == false)
+    }
+
+    @Test("회원 탈퇴 실패 시 에러를 그대로 전달한다")
+    func deleteAccountFailure() async {
+        let mockRepository = MockAuthenticationRepository()
+        mockRepository.deleteAccountError = MockSignInError.deleteAccountFailed
+        let useCase = SignInUseCaseImpl(repository: mockRepository)
+
+        await #expect(throws: MockSignInError.deleteAccountFailed) {
+            try await useCase.deleteAccount()
+        }
+        #expect(mockRepository.deleteAccountCallCount == 1)
+    }
+}

--- a/Project/Presentation/Tests/AuthenticationViewModelTests.swift
+++ b/Project/Presentation/Tests/AuthenticationViewModelTests.swift
@@ -1,0 +1,85 @@
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("AuthenticationViewModel Tests")
+struct AuthenticationViewModelTests {
+    private enum MockError: LocalizedError {
+        case signInFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .signInFailed:
+                return "sign-in-failed"
+            }
+        }
+    }
+
+    @MainActor
+    @Test("초기 인증 상태는 UseCase 상태를 반영한다")
+    func initializeAuthenticationState() {
+        let mockSignInUseCase = MockSignInUseCase()
+        mockSignInUseCase.isAuthenticatedValue = true
+
+        let viewModel = AuthenticationViewModel(signInUseCase: mockSignInUseCase)
+
+        #expect(viewModel.isAuthenticated == true)
+    }
+
+    @MainActor
+    @Test("checkAuthenticationStatus는 최신 인증 상태를 반영한다")
+    func checkAuthenticationStatus() {
+        let mockSignInUseCase = MockSignInUseCase()
+        mockSignInUseCase.isAuthenticatedValue = false
+        let viewModel = AuthenticationViewModel(signInUseCase: mockSignInUseCase)
+
+        mockSignInUseCase.isAuthenticatedValue = true
+        viewModel.checkAuthenticationStatus()
+
+        #expect(viewModel.isAuthenticated == true)
+    }
+
+    @MainActor
+    @Test("signInWithApple 성공 시 인증 상태가 true가 된다")
+    func signInWithAppleSuccess() async {
+        let mockSignInUseCase = MockSignInUseCase()
+        let viewModel = AuthenticationViewModel(signInUseCase: mockSignInUseCase)
+
+        await viewModel.signInWithApple()
+
+        #expect(mockSignInUseCase.signInWithAppleCallCount == 1)
+        #expect(viewModel.isAuthenticated == true)
+        #expect(viewModel.isLoading == false)
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    @MainActor
+    @Test("signInWithApple 실패 시 에러 메시지를 노출한다")
+    func signInWithAppleFailure() async {
+        let mockSignInUseCase = MockSignInUseCase()
+        mockSignInUseCase.signInError = MockError.signInFailed
+        let viewModel = AuthenticationViewModel(signInUseCase: mockSignInUseCase)
+
+        await viewModel.signInWithApple()
+
+        #expect(mockSignInUseCase.signInWithAppleCallCount == 1)
+        #expect(viewModel.isAuthenticated == false)
+        #expect(viewModel.isLoading == false)
+        #expect(viewModel.errorMessage == MockError.signInFailed.localizedDescription)
+    }
+
+    @MainActor
+    @Test("signOut 호출 시 UseCase와 상태가 함께 갱신된다")
+    func signOut() {
+        let mockSignInUseCase = MockSignInUseCase()
+        mockSignInUseCase.isAuthenticatedValue = true
+        let viewModel = AuthenticationViewModel(signInUseCase: mockSignInUseCase)
+
+        viewModel.signOut()
+
+        #expect(mockSignInUseCase.signOutCallCount == 1)
+        #expect(viewModel.isAuthenticated == false)
+    }
+}

--- a/Project/Presentation/Tests/DrinkWaterViewModelTests.swift
+++ b/Project/Presentation/Tests/DrinkWaterViewModelTests.swift
@@ -1,0 +1,162 @@
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("DrinkWaterViewModel Tests")
+struct DrinkWaterViewModelTests {
+    private enum MockError: Error {
+        case failed
+    }
+
+    @MainActor
+    @Test("초기화 시 legacy 마이그레이션과 초기 상태를 반영한다")
+    func initializeState() {
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.currentWater = 2
+        let healthKitUseCase = MockHealthKitUseCase()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.mainAppearanceValue = .heart
+        userPreferencesUseCase.dailyWaterLimitValue = 1500
+
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            healthKitUseCase: healthKitUseCase,
+            userPreferencesUseCase: userPreferencesUseCase
+        )
+
+        #expect(waterUseCase.migrateLegacyDataIfNeededCallCount == 1)
+        #expect(viewModel.drinkWaterCount == 2)
+        #expect(viewModel.mainAppearance == .heart)
+        #expect(viewModel.dailyLimit == 1500)
+        #expect(viewModel.currentWaterIntakeInMl == 500)
+        #expect(viewModel.mililiters == "500ml")
+        #expect(viewModel.isLimitReached == false)
+    }
+
+    @MainActor
+    @Test("drinkWater는 제한 이하일 때 로컬/UseCase 상태를 모두 갱신한다")
+    func drinkWaterWithinLimit() async {
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.currentWater = 0
+        let healthKitUseCase = MockHealthKitUseCase()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 1000
+
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            healthKitUseCase: healthKitUseCase,
+            userPreferencesUseCase: userPreferencesUseCase
+        )
+
+        await viewModel.drinkWater()
+
+        #expect(viewModel.drinkWaterCount == 1)
+        #expect(waterUseCase.drinkWaterCallCount == 1)
+        #expect(healthKitUseCase.drinkWaterCallCount == 1)
+    }
+
+    @MainActor
+    @Test("drinkWater는 제한을 초과하면 동작하지 않는다")
+    func drinkWaterOverLimit() async {
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.currentWater = 4
+        let healthKitUseCase = MockHealthKitUseCase()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 1000
+
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            healthKitUseCase: healthKitUseCase,
+            userPreferencesUseCase: userPreferencesUseCase
+        )
+
+        await viewModel.drinkWater()
+
+        #expect(viewModel.drinkWaterCount == 4)
+        #expect(waterUseCase.drinkWaterCallCount == 0)
+        #expect(healthKitUseCase.drinkWaterCallCount == 0)
+    }
+
+    @MainActor
+    @Test("drinkWater는 HealthKit 실패가 있어도 로컬 카운트를 유지한다")
+    func drinkWaterHandlesHealthKitError() async {
+        let waterUseCase = MockDrinkWaterUseCase()
+        let healthKitUseCase = MockHealthKitUseCase()
+        healthKitUseCase.drinkWaterError = MockError.failed
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 1000
+
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            healthKitUseCase: healthKitUseCase,
+            userPreferencesUseCase: userPreferencesUseCase
+        )
+
+        await viewModel.drinkWater()
+
+        #expect(viewModel.drinkWaterCount == 1)
+        #expect(waterUseCase.drinkWaterCallCount == 1)
+        #expect(healthKitUseCase.drinkWaterCallCount == 1)
+    }
+
+    @MainActor
+    @Test("reset은 카운트를 0으로 만들고 UseCase 리셋을 호출한다")
+    func reset() async {
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.currentWater = 3
+        let healthKitUseCase = MockHealthKitUseCase()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            healthKitUseCase: healthKitUseCase,
+            userPreferencesUseCase: userPreferencesUseCase
+        )
+
+        await viewModel.reset()
+
+        #expect(viewModel.drinkWaterCount == 0)
+        #expect(waterUseCase.resetCallCount == 1)
+        #expect(healthKitUseCase.resetCallCount == 1)
+    }
+
+    @MainActor
+    @Test("refreshState는 UseCase 최신값으로 상태를 갱신한다")
+    func refreshState() {
+        let waterUseCase = MockDrinkWaterUseCase()
+        let healthKitUseCase = MockHealthKitUseCase()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            healthKitUseCase: healthKitUseCase,
+            userPreferencesUseCase: userPreferencesUseCase
+        )
+
+        waterUseCase.currentWater = 5
+        userPreferencesUseCase.mainAppearanceValue = .cloud
+        userPreferencesUseCase.dailyWaterLimitValue = 2300
+
+        viewModel.refreshState()
+
+        #expect(viewModel.drinkWaterCount == 5)
+        #expect(viewModel.mainAppearance == .cloud)
+        #expect(viewModel.dailyLimit == 2300)
+    }
+
+    @MainActor
+    @Test("startAnimation은 offset을 360으로 설정한다")
+    func startAnimation() {
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: MockDrinkWaterUseCase(),
+            healthKitUseCase: MockHealthKitUseCase(),
+            userPreferencesUseCase: MockUserPreferencesUseCase()
+        )
+
+        viewModel.startAnimation()
+
+        #expect(viewModel.offset == 360)
+    }
+}

--- a/Project/Presentation/Tests/HydrationRecordListViewModelTests.swift
+++ b/Project/Presentation/Tests/HydrationRecordListViewModelTests.swift
@@ -1,0 +1,70 @@
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("HydrationRecordListViewModel Tests")
+struct HydrationRecordListViewModelTests {
+    @MainActor
+    @Test("fetchHydrationRecord는 날짜별 합계를 계산해 정렬된 기록을 만든다")
+    func fetchHydrationRecord() async {
+        let mockUseCase = MockDrinkWaterUseCase()
+        let viewModel = HydrationRecordListViewModel(useCase: mockUseCase)
+        let calendar = Calendar.current
+        let monthStart = calendar.date(
+            from: calendar.dateComponents([.year, .month], from: .now)
+        )!
+        let secondDay = calendar.date(byAdding: .day, value: 1, to: monthStart)!
+
+        mockUseCase.setHydrationEvents(
+            [
+                HydrationEvent(id: UUID(), consumedAt: monthStart, volumeML: 250),
+                HydrationEvent(id: UUID(), consumedAt: monthStart.addingTimeInterval(60), volumeML: 500)
+            ],
+            on: monthStart
+        )
+        mockUseCase.setHydrationEvents(
+            [HydrationEvent(id: UUID(), consumedAt: secondDay, volumeML: 300)],
+            on: secondDay
+        )
+
+        await viewModel.fetchHydrationRecord()
+
+        #expect(viewModel.records.count == 2)
+        #expect(viewModel.records[0].mililiter == 750)
+        #expect(viewModel.records[1].mililiter == 300)
+        #expect(calendar.isDate(viewModel.records[0].date, inSameDayAs: monthStart))
+        #expect(calendar.isDate(viewModel.records[1].date, inSameDayAs: secondDay))
+    }
+
+    @MainActor
+    @Test("updateDisplayedMonth는 잘못된 월 입력 시 에러를 설정한다")
+    func updateDisplayedMonthWithInvalidMonth() async {
+        let viewModel = HydrationRecordListViewModel(useCase: MockDrinkWaterUseCase())
+
+        await viewModel.updateDisplayedMonth(year: 2026, month: 13)
+
+        #expect(viewModel.errorMessage == "Invalid date selection")
+    }
+
+    @MainActor
+    @Test("updateDisplayedMonth는 유효한 입력 시 월을 전환하고 기록을 다시 조회한다")
+    func updateDisplayedMonth() async {
+        let mockUseCase = MockDrinkWaterUseCase()
+        let viewModel = HydrationRecordListViewModel(useCase: mockUseCase)
+        let calendar = Calendar.current
+        let targetDate = calendar.date(from: DateComponents(year: 2025, month: 8, day: 1))!
+
+        mockUseCase.setHydrationEvents(
+            [HydrationEvent(id: UUID(), consumedAt: targetDate, volumeML: 250)],
+            on: targetDate
+        )
+
+        await viewModel.updateDisplayedMonth(year: 2025, month: 8)
+
+        #expect(calendar.isDate(viewModel.date, equalTo: targetDate, toGranularity: .month))
+        #expect(viewModel.records.count == 1)
+        #expect(viewModel.records.first?.mililiter == 250)
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockDrinkWaterUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockDrinkWaterUseCase.swift
@@ -1,0 +1,44 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable {
+    var currentWater: Int = 0
+
+    var migrateLegacyDataIfNeededCallCount: Int = 0
+    var drinkWaterCallCount: Int = 0
+    var resetCallCount: Int = 0
+
+    private var hydrationEventsByDay: [String: [HydrationEvent]] = [:]
+
+    func hydrationEvents(on date: Date) -> [HydrationEvent] {
+        hydrationEventsByDay[dayKey(for: date)] ?? []
+    }
+
+    func migrateLegacyDataIfNeeded() {
+        migrateLegacyDataIfNeededCallCount += 1
+    }
+
+    func drinkWater() {
+        drinkWaterCallCount += 1
+        currentWater += 1
+    }
+
+    func reset() {
+        resetCallCount += 1
+        currentWater = 0
+    }
+
+    func setHydrationEvents(_ events: [HydrationEvent], on date: Date) {
+        hydrationEventsByDay[dayKey(for: date)] = events
+    }
+
+    private func dayKey(for date: Date) -> String {
+        let dayStart = Calendar.current.startOfDay(for: date)
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar.current
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone.current
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: dayStart)
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockHealthKitUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockHealthKitUseCase.swift
@@ -1,0 +1,57 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockHealthKitUseCase: HealthKitUseCase, @unchecked Sendable {
+    var authorizationStatusValue: HealthKitAuthorizationStatus = .notDetermined
+
+    private(set) var requestAuthorizationCallCount = 0
+    private(set) var drinkWaterCallCount = 0
+    private(set) var resetCallCount = 0
+    private(set) var fetchHistoryCallCount = 0
+
+    var requestAuthorizationError: Error?
+    var drinkWaterError: Error?
+    var resetError: Error?
+    var fetchHistoryError: Error?
+
+    var historyToReturn: [HydrationRecord] = []
+
+    private(set) var capturedFetchStartDate: Date?
+    private(set) var capturedFetchEndDate: Date?
+
+    var authorisationStatus: HealthKitAuthorizationStatus {
+        authorizationStatusValue
+    }
+
+    func requestAuthorization() async throws {
+        requestAuthorizationCallCount += 1
+        if let requestAuthorizationError {
+            throw requestAuthorizationError
+        }
+        authorizationStatusValue = .sharingAuthorized
+    }
+
+    func drinkWater() async throws {
+        drinkWaterCallCount += 1
+        if let drinkWaterError {
+            throw drinkWaterError
+        }
+    }
+
+    func reset() async throws {
+        resetCallCount += 1
+        if let resetError {
+            throw resetError
+        }
+    }
+
+    func fetchHistory(from startDate: Date, to endDate: Date) async throws -> [HydrationRecord] {
+        fetchHistoryCallCount += 1
+        capturedFetchStartDate = startDate
+        capturedFetchEndDate = endDate
+        if let fetchHistoryError {
+            throw fetchHistoryError
+        }
+        return historyToReturn
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockSignInUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockSignInUseCase.swift
@@ -1,0 +1,38 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockSignInUseCase: SignInUseCase, @unchecked Sendable {
+    var isAuthenticatedValue: Bool = false
+
+    var signInWithAppleCallCount: Int = 0
+    var signOutCallCount: Int = 0
+    var deleteAccountCallCount: Int = 0
+
+    var signInError: Error?
+    var deleteAccountError: Error?
+
+    var isAuthenticated: Bool {
+        isAuthenticatedValue
+    }
+
+    func signInWithApple() async throws {
+        signInWithAppleCallCount += 1
+        if let signInError {
+            throw signInError
+        }
+        isAuthenticatedValue = true
+    }
+
+    func signOut() {
+        signOutCallCount += 1
+        isAuthenticatedValue = false
+    }
+
+    func deleteAccount() async throws {
+        deleteAccountCallCount += 1
+        if let deleteAccountError {
+            throw deleteAccountError
+        }
+        isAuthenticatedValue = false
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockUserPreferencesUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockUserPreferencesUseCase.swift
@@ -1,0 +1,36 @@
+import DomainLayerInterface
+
+final class MockUserPreferencesUseCase: UserPreferencesUseCase, @unchecked Sendable {
+    var mainAppearanceValue: MainAppearance = .default
+    var dailyWaterLimitValue: Double = 2000
+
+    private(set) var getMainAppearanceCallCount = 0
+    private(set) var setMainAppearanceCallCount = 0
+    private(set) var getDailyWaterLimitCallCount = 0
+    private(set) var setDailyWaterLimitCallCount = 0
+
+    private(set) var capturedMainAppearance: MainAppearance?
+    private(set) var capturedDailyWaterLimit: Double?
+
+    func getMainAppearance() -> MainAppearance {
+        getMainAppearanceCallCount += 1
+        return mainAppearanceValue
+    }
+
+    func setMainAppearance(_ appearance: MainAppearance) {
+        setMainAppearanceCallCount += 1
+        capturedMainAppearance = appearance
+        mainAppearanceValue = appearance
+    }
+
+    func getDailyWaterLimit() -> Double {
+        getDailyWaterLimitCallCount += 1
+        return dailyWaterLimitValue
+    }
+
+    func setDailyWaterLimit(_ limit: Double) {
+        setDailyWaterLimitCallCount += 1
+        capturedDailyWaterLimit = limit
+        dailyWaterLimitValue = limit
+    }
+}

--- a/Project/Presentation/Tests/SettingsViewModelTests.swift
+++ b/Project/Presentation/Tests/SettingsViewModelTests.swift
@@ -1,0 +1,171 @@
+import DomainLayerInterface
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("SettingsViewModel Tests")
+struct SettingsViewModelTests {
+    private enum MockError: LocalizedError {
+        case deleteFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .deleteFailed:
+                return "delete-failed"
+            }
+        }
+    }
+
+    @MainActor
+    @Test("초기화 시 사용자 설정 상태를 반영한다")
+    func initializeState() {
+        let navigationRouter = NavigationRouter()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.mainAppearanceValue = .heart
+        userPreferencesUseCase.dailyWaterLimitValue = 2100
+        let signInUseCase = MockSignInUseCase()
+        let authenticationViewModel = AuthenticationViewModel(signInUseCase: signInUseCase)
+
+        let viewModel = SettingsViewModel(
+            navigationRouter: navigationRouter,
+            userPreferencesUseCase: userPreferencesUseCase,
+            signInUseCase: signInUseCase,
+            authenticationViewModel: authenticationViewModel
+        )
+
+        #expect(viewModel.currentMainAppearance == .heart)
+        #expect(viewModel.currentDailyWaterLimit == 2100)
+        #expect(userPreferencesUseCase.getMainAppearanceCallCount == 1)
+        #expect(userPreferencesUseCase.getDailyWaterLimitCallCount == 1)
+    }
+
+    @MainActor
+    @Test("navigate/navigateBack/resetNavigation은 settingsPath를 제어한다")
+    func navigationActions() {
+        let navigationRouter = NavigationRouter()
+        let viewModel = SettingsViewModel(
+            navigationRouter: navigationRouter,
+            userPreferencesUseCase: MockUserPreferencesUseCase(),
+            signInUseCase: MockSignInUseCase(),
+            authenticationViewModel: AuthenticationViewModel(signInUseCase: MockSignInUseCase())
+        )
+
+        viewModel.navigate(to: .dailyLimit)
+        #expect(viewModel.hasNavigationPath == true)
+        #expect(navigationRouter.settingsPathCount == 1)
+
+        viewModel.navigateBack()
+        #expect(viewModel.hasNavigationPath == false)
+        #expect(navigationRouter.settingsPathCount == 0)
+
+        viewModel.navigate(to: .mainShape)
+        viewModel.resetNavigation()
+        #expect(viewModel.hasNavigationPath == false)
+        #expect(navigationRouter.settingsPathCount == 0)
+    }
+
+    @MainActor
+    @Test("setMainAppearance는 상태와 UseCase를 함께 갱신한다")
+    func setMainAppearance() {
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        let viewModel = SettingsViewModel(
+            navigationRouter: NavigationRouter(),
+            userPreferencesUseCase: userPreferencesUseCase,
+            signInUseCase: MockSignInUseCase(),
+            authenticationViewModel: AuthenticationViewModel(signInUseCase: MockSignInUseCase())
+        )
+
+        viewModel.setMainAppearance(.cloud)
+
+        #expect(viewModel.currentMainAppearance == .cloud)
+        #expect(userPreferencesUseCase.setMainAppearanceCallCount == 1)
+        #expect(userPreferencesUseCase.capturedMainAppearance == .cloud)
+    }
+
+    @MainActor
+    @Test("dailyWaterLimit setter는 상태와 UseCase를 함께 갱신한다")
+    func setDailyWaterLimit() {
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        let viewModel = SettingsViewModel(
+            navigationRouter: NavigationRouter(),
+            userPreferencesUseCase: userPreferencesUseCase,
+            signInUseCase: MockSignInUseCase(),
+            authenticationViewModel: AuthenticationViewModel(signInUseCase: MockSignInUseCase())
+        )
+
+        viewModel.dailyWaterLimit = 2750
+
+        #expect(viewModel.currentDailyWaterLimit == 2750)
+        #expect(userPreferencesUseCase.setDailyWaterLimitCallCount == 1)
+        #expect(userPreferencesUseCase.capturedDailyWaterLimit == 2750)
+    }
+
+    @MainActor
+    @Test("requestWithdrawal/cancelWithdrawal은 확인 상태를 토글한다")
+    func withdrawalRequestAndCancel() {
+        let viewModel = SettingsViewModel(
+            navigationRouter: NavigationRouter(),
+            userPreferencesUseCase: MockUserPreferencesUseCase(),
+            signInUseCase: MockSignInUseCase(),
+            authenticationViewModel: AuthenticationViewModel(signInUseCase: MockSignInUseCase())
+        )
+
+        viewModel.requestWithdrawal()
+        #expect(viewModel.showWithdrawalConfirmation == true)
+
+        viewModel.withdrawalError = "temporary-error"
+        viewModel.cancelWithdrawal()
+        #expect(viewModel.showWithdrawalConfirmation == false)
+        #expect(viewModel.withdrawalError == nil)
+    }
+
+    @MainActor
+    @Test("confirmWithdrawal 성공 시 인증 상태를 false로 전환한다")
+    func confirmWithdrawalSuccess() async {
+        let signInUseCase = MockSignInUseCase()
+        signInUseCase.isAuthenticatedValue = true
+        let authenticationViewModel = AuthenticationViewModel(signInUseCase: signInUseCase)
+        authenticationViewModel.isAuthenticated = true
+        let viewModel = SettingsViewModel(
+            navigationRouter: NavigationRouter(),
+            userPreferencesUseCase: MockUserPreferencesUseCase(),
+            signInUseCase: signInUseCase,
+            authenticationViewModel: authenticationViewModel
+        )
+        viewModel.requestWithdrawal()
+
+        await viewModel.confirmWithdrawal()
+
+        #expect(signInUseCase.deleteAccountCallCount == 1)
+        #expect(viewModel.isWithdrawing == false)
+        #expect(viewModel.showWithdrawalConfirmation == false)
+        #expect(viewModel.withdrawalError == nil)
+        #expect(authenticationViewModel.isAuthenticated == false)
+    }
+
+    @MainActor
+    @Test("confirmWithdrawal 실패 시 에러를 노출하고 인증 상태를 유지한다")
+    func confirmWithdrawalFailure() async {
+        let signInUseCase = MockSignInUseCase()
+        signInUseCase.deleteAccountError = MockError.deleteFailed
+        let authenticationViewModel = AuthenticationViewModel(signInUseCase: signInUseCase)
+        authenticationViewModel.isAuthenticated = true
+        let viewModel = SettingsViewModel(
+            navigationRouter: NavigationRouter(),
+            userPreferencesUseCase: MockUserPreferencesUseCase(),
+            signInUseCase: signInUseCase,
+            authenticationViewModel: authenticationViewModel
+        )
+        viewModel.requestWithdrawal()
+
+        await viewModel.confirmWithdrawal()
+
+        #expect(signInUseCase.deleteAccountCallCount == 1)
+        #expect(viewModel.isWithdrawing == false)
+        #expect(viewModel.showWithdrawalConfirmation == true)
+        #expect(viewModel.withdrawalError == MockError.deleteFailed.localizedDescription)
+        #expect(authenticationViewModel.isAuthenticated == true)
+    }
+}


### PR DESCRIPTION
## 📝 Summary
- PresentationLayer의 ViewModel 단위 테스트를 추가했습니다.
- 인증/기록 ViewModel의 핵심 상태 전이와 로직을 검증합니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #110
- Related to #93

## 📋 Changes Made
### Added
- `AuthenticationViewModelTests` 추가
- `HydrationRecordListViewModelTests` 추가
- 테스트용 Mock UseCase 2종 추가

### Changed
- 없음

### Fixed
- 없음

### Removed
- 없음

## 🔍 Technical Details
- Swift Testing(`@Suite`, `@Test`) 기반으로 작성
- 비동기/메인액터 경로를 `@MainActor` 테스트로 검증
- Hydration 이벤트 집계, 월 전환 유효성 검증, 인증 성공/실패 상태 전이 검증 포함

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [x] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS Simulator 26.2
- Device: iPhone 17 (Simulator)
- Xcode Version: Xcode 16.x

### Test Results
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer -destination id=C61B75FD-E529-4229-8645-1C13B948DB47 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme DataLayer -destination id=C61B75FD-E529-4229-8645-1C13B948DB47 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination id=C61B75FD-E529-4229-8645-1C13B948DB47 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- 이번 PR은 PresentationLayer 테스트 공백을 우선 보강하는 범위입니다.
- 다음 단계로 SettingsViewModel 테스트/위젯 연동 경계 테스트를 추가할 수 있습니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
