### PR TITLE
feat: add hydration insight tab (#93)

### DIFF
--- a/Project/App/Sources/ContentView.swift
+++ b/Project/App/Sources/ContentView.swift
@@ -24,6 +24,12 @@ struct ContentView: View {
                     viewModel: DIContainer.shared.resolve(HydrationRecordListViewModel.self)
                 )
             }
+
+            Tab("인사이트", systemImage: "chart.bar.xaxis") {
+                HydrationInsightView(
+                    viewModel: DIContainer.shared.resolve(HydrationInsightViewModel.self)
+                )
+            }
             
             Tab("설정", systemImage: "gear") {
                 SettingsView(

--- a/Project/Data/Sources/DataSource/DrinkWaterPersistentDataSource.swift
+++ b/Project/Data/Sources/DataSource/DrinkWaterPersistentDataSource.swift
@@ -15,6 +15,7 @@ public protocol DrinkWaterDataSource: Sendable {
     var currentWater: Int { get async }
 
     func hydrationEvents(on date: Date) async -> [HydrationEvent]
+    func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent]
     func migrateLegacyDataIfNeeded() async
     func drinkWater() async
     func reset() async
@@ -83,6 +84,21 @@ public actor DrinkWaterPersistentDataSource: DrinkWaterDataSource {
             }
         } catch {
             assertionFailure("Failed to fetch hydration events: \(error)")
+            return []
+        }
+    }
+
+    public func hydrationEvents(in interval: DateInterval) -> [HydrationEvent] {
+        do {
+            return try fetchEventModels(in: interval, using: makeContext()).map {
+                HydrationEvent(
+                    id: $0.id,
+                    consumedAt: $0.consumedAt,
+                    volumeML: $0.volumeML
+                )
+            }
+        } catch {
+            assertionFailure("Failed to fetch hydration events for interval: \(error)")
             return []
         }
     }
@@ -195,6 +211,13 @@ public actor DrinkWaterPersistentDataSource: DrinkWaterDataSource {
         try Self.fetchEventModels(on: date, using: context, calendar: calendar)
     }
 
+    private func fetchEventModels(
+        in interval: DateInterval,
+        using context: ModelContext
+    ) throws -> [HydrationEventModel] {
+        try Self.fetchEventModels(in: interval, using: context)
+    }
+
     private static func syncLegacyCount(
         using context: ModelContext,
         userDefaults: UserDefaults,
@@ -225,6 +248,22 @@ public actor DrinkWaterPersistentDataSource: DrinkWaterDataSource {
         let descriptor = FetchDescriptor<HydrationEventModel>(
             predicate: #Predicate { model in
                 model.consumedAt >= dayStart && model.consumedAt < dayEnd
+            },
+            sortBy: [SortDescriptor(\.consumedAt, order: .forward)]
+        )
+
+        return try context.fetch(descriptor)
+    }
+
+    private static func fetchEventModels(
+        in interval: DateInterval,
+        using context: ModelContext
+    ) throws -> [HydrationEventModel] {
+        let intervalStart = interval.start
+        let intervalEnd = interval.end
+        let descriptor = FetchDescriptor<HydrationEventModel>(
+            predicate: #Predicate { model in
+                model.consumedAt >= intervalStart && model.consumedAt < intervalEnd
             },
             sortBy: [SortDescriptor(\.consumedAt, order: .forward)]
         )

--- a/Project/Data/Sources/Repository/DrinkWaterRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/DrinkWaterRepositoryImpl.swift
@@ -26,6 +26,10 @@ public struct DrinkWaterRepositoryImpl: DrinkWaterRepository {
         await dataSource.hydrationEvents(on: date)
     }
 
+    public func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent] {
+        await dataSource.hydrationEvents(in: interval)
+    }
+
     public func migrateLegacyDataIfNeeded() async {
         await dataSource.migrateLegacyDataIfNeeded()
     }

--- a/Project/Data/Tests/DrinkWaterPersistentDataSourceTests.swift
+++ b/Project/Data/Tests/DrinkWaterPersistentDataSourceTests.swift
@@ -7,6 +7,8 @@
 
 import DataLayer
 import Foundation
+import Persistence
+import SwiftData
 import Testing
 
 @Suite("DrinkWaterPersistentDataSource Tests")
@@ -100,6 +102,42 @@ struct DrinkWaterPersistentDataSourceTests {
 
         #expect(await dataSource.currentWater == 10)
         #expect(await dataSource.hydrationEvents(on: .now).count == 10)
+    }
+
+    @Test("hydrationEvents(in:)은 지정한 기간의 이벤트만 반환한다")
+    func hydrationEventsInInterval() async throws {
+        let suiteName = makeIsolatedSuiteName()
+        let setupUserDefaults = makeIsolatedUserDefaults(suiteName: suiteName)
+        defer { setupUserDefaults.removePersistentDomain(forName: suiteName) }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let modelContainer = try SharedHydrationStore.makeModelContainer(isStoredInMemoryOnly: true)
+        let context = ModelContext(modelContainer)
+        let firstDay = calendar.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 8))!
+        let secondDay = calendar.date(byAdding: .day, value: 1, to: firstDay)!
+        let thirdDay = calendar.date(byAdding: .day, value: 2, to: firstDay)!
+
+        context.insert(HydrationEventModel(consumedAt: firstDay, volumeML: 250))
+        context.insert(HydrationEventModel(consumedAt: secondDay, volumeML: 500))
+        context.insert(HydrationEventModel(consumedAt: thirdDay, volumeML: 750))
+        try context.save()
+
+        let dataSource = DrinkWaterPersistentDataSource(
+            modelContainer: modelContainer,
+            userDefaults: makeIsolatedUserDefaults(suiteName: suiteName),
+            calendar: calendar
+        )
+
+        let interval = DateInterval(
+            start: calendar.startOfDay(for: secondDay),
+            end: calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: thirdDay))!
+        )
+        let events = await dataSource.hydrationEvents(in: interval)
+
+        #expect(events.count == 2)
+        #expect(events.map(\.volumeML) == [500, 750])
     }
 
     private func makeIsolatedSuiteName() -> String {

--- a/Project/Domain/Interfaces/Repository/DrinkWaterRepository.swift
+++ b/Project/Domain/Interfaces/Repository/DrinkWaterRepository.swift
@@ -12,6 +12,7 @@ public protocol DrinkWaterRepository: Sendable {
     var currentWater: Int { get async }
 
     func hydrationEvents(on date: Date) async -> [HydrationEvent]
+    func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent]
     func migrateLegacyDataIfNeeded() async
     func drinkWater() async
     func reset() async

--- a/Project/Domain/Interfaces/UseCase/DrinkWaterUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/DrinkWaterUseCase.swift
@@ -12,6 +12,7 @@ public protocol DrinkWaterUseCase: Sendable {
     var currentWater: Int { get async }
 
     func hydrationEvents(on date: Date) async -> [HydrationEvent]
+    func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent]
     func migrateLegacyDataIfNeeded() async
     func drinkWater() async
     func reset() async

--- a/Project/Domain/Sources/UseCase/DrinkWaterUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/DrinkWaterUseCaseImpl.swift
@@ -26,6 +26,10 @@ public struct DrinkWaterUseCaseImpl: DrinkWaterUseCase {
         await repository.hydrationEvents(on: date)
     }
 
+    public func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent] {
+        await repository.hydrationEvents(in: interval)
+    }
+
     public func migrateLegacyDataIfNeeded() async {
         await repository.migrateLegacyDataIfNeeded()
     }

--- a/Project/Domain/Tests/DrinkWaterUseCaseTests.swift
+++ b/Project/Domain/Tests/DrinkWaterUseCaseTests.swift
@@ -183,6 +183,26 @@ struct DrinkWaterUseCaseTests {
         #expect(actual == expected)
     }
 
+    @Test("기간 HydrationEvent 조회는 Repository 호출 결과를 그대로 반환한다")
+    func hydrationEventsInInterval() async {
+        let mockRepository = MockDrinkWaterRepository()
+        let calendar = Calendar(identifier: .gregorian)
+        let start = calendar.date(from: DateComponents(year: 2026, month: 3, day: 10))!
+        let insideDate = calendar.date(byAdding: .hour, value: 12, to: start)!
+        let end = calendar.date(byAdding: .day, value: 3, to: start)!
+        let expected = [
+            HydrationEvent(id: UUID(), consumedAt: insideDate, volumeML: 250),
+            HydrationEvent(id: UUID(), consumedAt: calendar.date(byAdding: .day, value: 1, to: insideDate)!, volumeML: 500)
+        ]
+        mockRepository.setHydrationEvents(expected)
+        let useCase = DrinkWaterUseCaseImpl(repository: mockRepository)
+
+        let actual = await useCase.hydrationEvents(in: DateInterval(start: start, end: end))
+
+        #expect(mockRepository.hydrationEventsInIntervalCallCount == 1)
+        #expect(actual == expected)
+    }
+
     @Test("Legacy 마이그레이션 요청은 Repository에 위임된다")
     func migrateLegacyDataIfNeeded() async {
         let mockRepository = MockDrinkWaterRepository()

--- a/Project/Domain/Tests/Mock/MockDrinkWaterRepository.swift
+++ b/Project/Domain/Tests/Mock/MockDrinkWaterRepository.swift
@@ -17,6 +17,7 @@ final class MockDrinkWaterRepository: DrinkWaterRepository, @unchecked Sendable 
     private(set) var drinkWaterCallCount = 0
     private(set) var resetCallCount = 0
     private(set) var hydrationEventsCallCount = 0
+    private(set) var hydrationEventsInIntervalCallCount = 0
     private(set) var migrateCallCount = 0
     
     var currentWater: Int {
@@ -28,6 +29,13 @@ final class MockDrinkWaterRepository: DrinkWaterRepository, @unchecked Sendable 
     func hydrationEvents(on date: Date) async -> [HydrationEvent] {
         hydrationEventsCallCount += 1
         return _events.filter { Calendar.autoupdatingCurrent.isDate($0.consumedAt, inSameDayAs: date) }
+    }
+
+    func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent] {
+        hydrationEventsInIntervalCallCount += 1
+        return _events.filter {
+            interval.contains($0.consumedAt)
+        }
     }
 
     func migrateLegacyDataIfNeeded() async {
@@ -66,6 +74,7 @@ final class MockDrinkWaterRepository: DrinkWaterRepository, @unchecked Sendable 
         drinkWaterCallCount = 0
         resetCallCount = 0
         hydrationEventsCallCount = 0
+        hydrationEventsInIntervalCallCount = 0
         migrateCallCount = 0
     }
 }

--- a/Project/Presentation/Sources/View/HydrationInsight/HydrationInsightView.swift
+++ b/Project/Presentation/Sources/View/HydrationInsight/HydrationInsightView.swift
@@ -1,0 +1,351 @@
+//
+//  HydrationInsightView.swift
+//  PresentationLayer
+//
+//  Created by Codex on 3/14/26.
+//
+
+import Charts
+import DesignSystem
+import SwiftUI
+
+public struct HydrationInsightView: View {
+    @State private var viewModel: HydrationInsightViewModel
+
+    public init(viewModel: HydrationInsightViewModel) {
+        self._viewModel = State(wrappedValue: viewModel)
+    }
+
+    public var body: some View {
+        NavigationStack {
+            ZStack {
+                LinearGradient(
+                    colors: [
+                        Color.background,
+                        Color.accent.opacity(0.08),
+                        Color.background
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .ignoresSafeArea()
+
+                Group {
+                    if viewModel.isLoading {
+                        ProgressView("인사이트 불러오는 중...")
+                    } else if viewModel.isEmpty {
+                        emptyState
+                    } else {
+                        insightContent
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+            .navigationTitle("인사이트")
+            .task {
+                await viewModel.loadInsights()
+            }
+            .refreshable {
+                await viewModel.loadInsights()
+            }
+        }
+    }
+
+    private var insightContent: some View {
+        ScrollView {
+            VStack(spacing: 18) {
+                overviewCard
+
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(), spacing: 14),
+                        GridItem(.flexible(), spacing: 14)
+                    ],
+                    spacing: 14
+                ) {
+                    ForEach(viewModel.metrics) { metric in
+                        MetricCard(metric: metric)
+                    }
+                }
+
+                streakCard
+                weekdayPatternCard
+            }
+            .padding(.vertical, 20)
+        }
+    }
+
+    private var overviewCard: some View {
+        ZStack(alignment: .topTrailing) {
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.accent.opacity(0.95),
+                            Color.cyan.opacity(0.8)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+
+            Circle()
+                .fill(.white.opacity(0.18))
+                .frame(width: 120, height: 120)
+                .offset(x: 30, y: -30)
+
+            VStack(alignment: .leading, spacing: 16) {
+                Label("이번 주와 이번 달 흐름", systemImage: "chart.bar.xaxis")
+                    .font(.headline)
+                    .foregroundStyle(.white.opacity(0.92))
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("하루 목표는 \(viewModel.dailyGoalText)")
+                        .font(.title3.weight(.bold))
+                        .foregroundStyle(.white)
+                    Text("이번 주 달성률 \(viewModel.weeklyAchievementText), 이번 달 달성률 \(viewModel.monthlyAchievementText)")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.88))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                HStack(spacing: 12) {
+                    PillLabel(title: "현재 streak", value: viewModel.streakText)
+                    PillLabel(title: "이번 달 평균", value: "\(Int(viewModel.monthlyAverageML.rounded()))ml")
+                }
+            }
+            .padding(22)
+        }
+        .shadow(color: .black.opacity(0.08), radius: 20, x: 0, y: 14)
+    }
+
+    private var streakCard: some View {
+        InsightCard(title: "연속 달성 흐름", subtitle: "오늘 목표를 아직 채우지 않았다면 어제까지의 연속 달성일을 보여줍니다.") {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(alignment: .firstTextBaseline, spacing: 10) {
+                    Text(viewModel.streakText)
+                        .font(.system(size: 36, weight: .bold, design: .rounded))
+                    Text("연속 목표 달성")
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 10) {
+                    AchievementProgressRow(
+                        title: "이번 주",
+                        detail: "\(viewModel.weeklyAchievedDays)/\(max(viewModel.weeklyElapsedDays, 1))일 달성",
+                        progress: viewModel.weeklyAchievementRate
+                    )
+                    AchievementProgressRow(
+                        title: "이번 달",
+                        detail: "\(viewModel.monthlyAchievedDays)/\(max(viewModel.monthlyElapsedDays, 1))일 달성",
+                        progress: viewModel.monthlyAchievementRate
+                    )
+                }
+            }
+        }
+    }
+
+    private var weekdayPatternCard: some View {
+        InsightCard(title: "이번 달 요일 패턴", subtitle: viewModel.weekdayInsightText) {
+            VStack(alignment: .leading, spacing: 14) {
+                Chart(viewModel.weekdayDistributions) { distribution in
+                    BarMark(
+                        x: .value("요일", distribution.label),
+                        y: .value("평균 섭취량", distribution.averageIntakeML)
+                    )
+                    .cornerRadius(8)
+                    .foregroundStyle(
+                        distribution.weekday == viewModel.bestWeekday?.weekday ?
+                        Color.accent.gradient :
+                        Color.cyan.opacity(0.55).gradient
+                    )
+
+                    if viewModel.dailyGoalML > 0 {
+                        RuleMark(y: .value("목표", viewModel.dailyGoalML))
+                            .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 4]))
+                            .foregroundStyle(Color.secondary.opacity(0.7))
+                    }
+                }
+                .chartYScale(domain: 0...max(viewModel.chartUpperBound, 1))
+                .chartLegend(.hidden)
+                .frame(height: 220)
+
+                HStack(spacing: 12) {
+                    if let bestWeekday = viewModel.bestWeekday {
+                        BadgeView(
+                            title: "가장 많이 마신 날",
+                            value: "\(bestWeekday.label) · \(Int(bestWeekday.averageIntakeML.rounded()))ml"
+                        )
+                    }
+
+                    if let leastWeekday = viewModel.leastWeekday {
+                        BadgeView(
+                            title: "가장 적게 마신 날",
+                            value: "\(leastWeekday.label) · \(Int(leastWeekday.averageIntakeML.rounded()))ml"
+                        )
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(Color.secondary.opacity(0.7))
+                        .frame(width: 8, height: 8)
+                    Text("점선은 하루 목표량을 뜻합니다.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 18) {
+            Spacer()
+
+            Image(systemName: "chart.bar.doc.horizontal")
+                .font(.system(size: 44))
+                .foregroundStyle(Color.accent)
+
+            VStack(spacing: 8) {
+                Text("아직 보여줄 인사이트가 없어요")
+                    .font(.title3.weight(.bold))
+                Text("최근 기록이 쌓이면 주간 평균, 달성률, streak, 요일 패턴을 한 번에 볼 수 있습니다. 오늘 목표는 \(viewModel.dailyGoalText)입니다.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+private struct InsightCard<Content: View>: View {
+    let title: String
+    let subtitle: String
+    let content: Content
+
+    init(
+        title: String,
+        subtitle: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            content
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color(uiColor: .secondarySystemBackground).opacity(0.95))
+        )
+    }
+}
+
+private struct MetricCard: View {
+    let metric: HydrationInsightMetric
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(metric.title)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Text(metric.value)
+                .font(.title3.weight(.bold))
+
+            Text(metric.detail)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 118, alignment: .leading)
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(Color(uiColor: .systemBackground))
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .stroke(Color.black.opacity(0.04), lineWidth: 1)
+        }
+    }
+}
+
+private struct AchievementProgressRow: View {
+    let title: String
+    let detail: String
+    let progress: Double
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Text(detail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            ProgressView(value: progress, total: 1)
+                .tint(Color.accent)
+        }
+    }
+}
+
+private struct BadgeView: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.subheadline.weight(.semibold))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            Capsule(style: .continuous)
+                .fill(Color(uiColor: .systemBackground))
+        )
+    }
+}
+
+private struct PillLabel: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.white.opacity(0.75))
+            Text(value)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.white)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(.white.opacity(0.14), in: Capsule(style: .continuous))
+    }
+}

--- a/Project/Presentation/Sources/ViewModel/HydrationInsightViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationInsightViewModel.swift
@@ -1,0 +1,330 @@
+//
+//  HydrationInsightViewModel.swift
+//  PresentationLayer
+//
+//  Created by Codex on 3/14/26.
+//
+
+import DomainLayerInterface
+import Foundation
+
+struct HydrationInsightMetric: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let value: String
+    let detail: String
+}
+
+struct HydrationInsightWeekdayDistribution: Identifiable, Equatable {
+    let weekday: Int
+    let label: String
+    let averageIntakeML: Double
+    let totalIntakeML: Double
+    let occurrenceCount: Int
+
+    var id: Int { weekday }
+}
+
+@MainActor
+@Observable
+public final class HydrationInsightViewModel {
+    public private(set) var isLoading: Bool = false
+    public private(set) var isEmpty: Bool = false
+    public private(set) var dailyGoalML: Double
+    public private(set) var weeklyAverageML: Double = 0
+    public private(set) var monthlyAverageML: Double = 0
+    public private(set) var weeklyAchievementRate: Double = 0
+    public private(set) var monthlyAchievementRate: Double = 0
+    public private(set) var weeklyAchievedDays: Int = 0
+    public private(set) var monthlyAchievedDays: Int = 0
+    public private(set) var weeklyElapsedDays: Int = 0
+    public private(set) var monthlyElapsedDays: Int = 0
+    public private(set) var currentStreak: Int = 0
+    private(set) var bestWeekday: HydrationInsightWeekdayDistribution?
+    private(set) var leastWeekday: HydrationInsightWeekdayDistribution?
+    private(set) var weekdayDistributions: [HydrationInsightWeekdayDistribution] = []
+
+    private let waterUseCase: DrinkWaterUseCase
+    private let userPreferencesUseCase: UserPreferencesUseCase
+    private let calendar: Calendar
+    private let currentDateProvider: @Sendable () -> Date
+
+    public init(
+        waterUseCase: DrinkWaterUseCase,
+        userPreferencesUseCase: UserPreferencesUseCase,
+        calendar: Calendar = .autoupdatingCurrent,
+        currentDateProvider: @escaping @Sendable () -> Date = { .now }
+    ) {
+        self.waterUseCase = waterUseCase
+        self.userPreferencesUseCase = userPreferencesUseCase
+        self.calendar = calendar
+        self.currentDateProvider = currentDateProvider
+        self.dailyGoalML = userPreferencesUseCase.getDailyWaterLimit()
+    }
+
+    var metrics: [HydrationInsightMetric] {
+        [
+            HydrationInsightMetric(
+                id: "weeklyAverage",
+                title: "이번 주 평균",
+                value: volumeText(weeklyAverageML),
+                detail: "\(weeklyElapsedDays)일 기준"
+            ),
+            HydrationInsightMetric(
+                id: "monthlyAverage",
+                title: "이번 달 평균",
+                value: volumeText(monthlyAverageML),
+                detail: "\(monthlyElapsedDays)일 기준"
+            ),
+            HydrationInsightMetric(
+                id: "weeklyAchievement",
+                title: "주간 달성률",
+                value: percentText(weeklyAchievementRate),
+                detail: "\(weeklyAchievedDays)/\(max(weeklyElapsedDays, 1))일 달성"
+            ),
+            HydrationInsightMetric(
+                id: "monthlyAchievement",
+                title: "월간 달성률",
+                value: percentText(monthlyAchievementRate),
+                detail: "\(monthlyAchievedDays)/\(max(monthlyElapsedDays, 1))일 달성"
+            )
+        ]
+    }
+
+    var streakText: String {
+        "\(currentStreak)일"
+    }
+
+    var dailyGoalText: String {
+        volumeText(dailyGoalML)
+    }
+
+    var weeklyAchievementText: String {
+        percentText(weeklyAchievementRate)
+    }
+
+    var monthlyAchievementText: String {
+        percentText(monthlyAchievementRate)
+    }
+
+    var weekdayInsightText: String {
+        guard let bestWeekday, let leastWeekday else {
+            return "이번 달 요일별 패턴을 만들 기록이 아직 부족합니다."
+        }
+
+        return "\(bestWeekday.label)에 평균 \(volumeText(bestWeekday.averageIntakeML))로 가장 많이 마셨고, \(leastWeekday.label)에는 평균 \(volumeText(leastWeekday.averageIntakeML))로 가장 적게 마셨어요."
+    }
+
+    var chartUpperBound: Double {
+        let highestAverage = weekdayDistributions.map(\.averageIntakeML).max() ?? 0
+        return max(dailyGoalML, highestAverage) * 1.2
+    }
+
+    public func loadInsights() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        let referenceDate = currentDateProvider()
+        dailyGoalML = userPreferencesUseCase.getDailyWaterLimit()
+
+        guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: referenceDate),
+              let monthInterval = calendar.dateInterval(of: .month, for: referenceDate) else {
+            resetInsightState()
+            return
+        }
+
+        let elapsedWeekInterval = elapsedInterval(from: weekInterval, upTo: referenceDate)
+        let elapsedMonthInterval = elapsedInterval(from: monthInterval, upTo: referenceDate)
+
+        async let weeklyEvents = waterUseCase.hydrationEvents(in: elapsedWeekInterval)
+        async let monthlyEvents = waterUseCase.hydrationEvents(in: elapsedMonthInterval)
+
+        let (resolvedWeeklyEvents, resolvedMonthlyEvents) = await (weeklyEvents, monthlyEvents)
+        let weeklyTotals = dailyTotals(from: resolvedWeeklyEvents)
+        let monthlyTotals = dailyTotals(from: resolvedMonthlyEvents)
+
+        weeklyElapsedDays = elapsedDayCount(in: elapsedWeekInterval)
+        monthlyElapsedDays = elapsedDayCount(in: elapsedMonthInterval)
+        weeklyAchievedDays = achievedDayCount(in: weeklyTotals)
+        monthlyAchievedDays = achievedDayCount(in: monthlyTotals)
+        weeklyAverageML = averageIntake(from: weeklyTotals, dayCount: weeklyElapsedDays)
+        monthlyAverageML = averageIntake(from: monthlyTotals, dayCount: monthlyElapsedDays)
+        weeklyAchievementRate = achievementRate(achievedDays: weeklyAchievedDays, dayCount: weeklyElapsedDays)
+        monthlyAchievementRate = achievementRate(achievedDays: monthlyAchievedDays, dayCount: monthlyElapsedDays)
+        if resolvedMonthlyEvents.isEmpty {
+            weekdayDistributions = []
+            bestWeekday = nil
+            leastWeekday = nil
+        } else {
+            weekdayDistributions = makeWeekdayDistributions(
+                from: monthlyTotals,
+                in: elapsedMonthInterval
+            )
+            bestWeekday = weekdayDistributions.max { lhs, rhs in
+                lhs.averageIntakeML < rhs.averageIntakeML
+            }
+            leastWeekday = weekdayDistributions.min { lhs, rhs in
+                lhs.averageIntakeML < rhs.averageIntakeML
+            }
+        }
+        currentStreak = await calculateCurrentStreak(referenceDate: referenceDate)
+        isEmpty = resolvedWeeklyEvents.isEmpty && resolvedMonthlyEvents.isEmpty
+    }
+
+    private func resetInsightState() {
+        isEmpty = true
+        weeklyAverageML = 0
+        monthlyAverageML = 0
+        weeklyAchievementRate = 0
+        monthlyAchievementRate = 0
+        weeklyAchievedDays = 0
+        monthlyAchievedDays = 0
+        weeklyElapsedDays = 0
+        monthlyElapsedDays = 0
+        currentStreak = 0
+        bestWeekday = nil
+        leastWeekday = nil
+        weekdayDistributions = []
+    }
+
+    private func elapsedInterval(from interval: DateInterval, upTo referenceDate: Date) -> DateInterval {
+        let intervalEnd = calendar.date(
+            byAdding: .day,
+            value: 1,
+            to: calendar.startOfDay(for: referenceDate)
+        ) ?? interval.end
+
+        return DateInterval(
+            start: interval.start,
+            end: min(interval.end, intervalEnd)
+        )
+    }
+
+    private func elapsedDayCount(in interval: DateInterval) -> Int {
+        max(
+            calendar.dateComponents([.day], from: interval.start, to: interval.end).day ?? 0,
+            1
+        )
+    }
+
+    private func dailyTotals(from events: [HydrationEvent]) -> [Date: Double] {
+        events.reduce(into: [:]) { partialResult, event in
+            let day = calendar.startOfDay(for: event.consumedAt)
+            partialResult[day, default: 0] += Double(event.volumeML)
+        }
+    }
+
+    private func achievedDayCount(in totals: [Date: Double]) -> Int {
+        guard dailyGoalML > 0 else {
+            return 0
+        }
+
+        return totals.values.filter { $0 >= dailyGoalML }.count
+    }
+
+    private func averageIntake(from totals: [Date: Double], dayCount: Int) -> Double {
+        guard dayCount > 0 else {
+            return 0
+        }
+
+        let totalIntake = totals.values.reduce(0, +)
+        return totalIntake / Double(dayCount)
+    }
+
+    private func achievementRate(achievedDays: Int, dayCount: Int) -> Double {
+        guard dayCount > 0 else {
+            return 0
+        }
+
+        return Double(achievedDays) / Double(dayCount)
+    }
+
+    private func makeWeekdayDistributions(
+        from monthlyTotals: [Date: Double],
+        in interval: DateInterval
+    ) -> [HydrationInsightWeekdayDistribution] {
+        var totalByWeekday: [Int: Double] = [:]
+        var occurrencesByWeekday: [Int: Int] = [:]
+        var currentDate = interval.start
+
+        while currentDate < interval.end {
+            let weekday = calendar.component(.weekday, from: currentDate)
+            occurrencesByWeekday[weekday, default: 0] += 1
+            totalByWeekday[weekday, default: 0] += monthlyTotals[currentDate, default: 0]
+
+            guard let nextDate = calendar.date(byAdding: .day, value: 1, to: currentDate) else {
+                break
+            }
+            currentDate = nextDate
+        }
+
+        let weekdaySymbols = makeWeekdaySymbols()
+        let orderedWeekdays = (0..<7).map { offset in
+            ((calendar.firstWeekday - 1 + offset) % 7) + 1
+        }
+
+        return orderedWeekdays.compactMap { weekday in
+            guard let occurrenceCount = occurrencesByWeekday[weekday], occurrenceCount > 0 else {
+                return nil
+            }
+
+            let totalIntake = totalByWeekday[weekday, default: 0]
+
+            return HydrationInsightWeekdayDistribution(
+                weekday: weekday,
+                label: weekdaySymbols[weekday - 1],
+                averageIntakeML: totalIntake / Double(occurrenceCount),
+                totalIntakeML: totalIntake,
+                occurrenceCount: occurrenceCount
+            )
+        }
+    }
+
+    private func makeWeekdaySymbols() -> [String] {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? Locale.autoupdatingCurrent
+        return formatter.shortWeekdaySymbols
+    }
+
+    private func calculateCurrentStreak(referenceDate: Date) async -> Int {
+        guard dailyGoalML > 0 else {
+            return 0
+        }
+
+        var date = calendar.startOfDay(for: referenceDate)
+        if await totalIntake(on: date) < dailyGoalML {
+            guard let previousDate = calendar.date(byAdding: .day, value: -1, to: date) else {
+                return 0
+            }
+            date = previousDate
+        }
+
+        var streak = 0
+
+        while await totalIntake(on: date) >= dailyGoalML {
+            streak += 1
+
+            guard let previousDate = calendar.date(byAdding: .day, value: -1, to: date) else {
+                break
+            }
+            date = previousDate
+        }
+
+        return streak
+    }
+
+    private func totalIntake(on date: Date) async -> Double {
+        (await waterUseCase.hydrationEvents(on: date)).reduce(0) { partialResult, event in
+            partialResult + Double(event.volumeML)
+        }
+    }
+
+    private func volumeText(_ volumeML: Double) -> String {
+        "\(Int(volumeML.rounded()))ml"
+    }
+
+    private func percentText(_ ratio: Double) -> String {
+        "\(Int((ratio * 100).rounded()))%"
+    }
+}

--- a/Project/Presentation/Tests/HydrationInsightViewModelTests.swift
+++ b/Project/Presentation/Tests/HydrationInsightViewModelTests.swift
@@ -1,0 +1,89 @@
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("HydrationInsightViewModel Tests")
+struct HydrationInsightViewModelTests {
+    @MainActor
+    @Test("loadInsights는 주간/월간 지표와 streak를 계산한다")
+    func loadInsights() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let waterUseCase = MockDrinkWaterUseCase()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 2000
+
+        setTotal(2500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 9))!, using: waterUseCase)
+        setTotal(1000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!, using: waterUseCase)
+        setTotal(1500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 7, hour: 9))!, using: waterUseCase)
+        setTotal(2000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 9, hour: 9))!, using: waterUseCase)
+        setTotal(2500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 9))!, using: waterUseCase)
+        setTotal(2000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 11, hour: 9))!, using: waterUseCase)
+        setTotal(1000, on: referenceDate, using: waterUseCase)
+
+        let viewModel = HydrationInsightViewModel(
+            waterUseCase: waterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            calendar: calendar,
+            currentDateProvider: { referenceDate }
+        )
+
+        await viewModel.loadInsights()
+
+        #expect(viewModel.isEmpty == false)
+        #expect(viewModel.dailyGoalML == 2000)
+        #expect(viewModel.weeklyElapsedDays == 4)
+        #expect(viewModel.monthlyElapsedDays == 12)
+        #expect(viewModel.weeklyAchievedDays == 3)
+        #expect(viewModel.monthlyAchievedDays == 4)
+        #expect(viewModel.weeklyAverageML == 1875)
+        #expect(viewModel.monthlyAverageML == (12500.0 / 12.0))
+        #expect(viewModel.weeklyAchievementRate == 0.75)
+        #expect(viewModel.monthlyAchievementRate == (4.0 / 12.0))
+        #expect(viewModel.currentStreak == 3)
+        #expect(viewModel.weekdayDistributions.count == 7)
+        #expect(viewModel.bestWeekday?.weekday == 2)
+        #expect(viewModel.bestWeekday?.averageIntakeML == 2250)
+        #expect(viewModel.leastWeekday?.weekday == 1)
+        #expect(viewModel.leastWeekday?.averageIntakeML == 0)
+    }
+
+    @MainActor
+    @Test("loadInsights는 최근 기록이 없으면 empty state를 노출한다")
+    func loadInsightsEmptyState() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let viewModel = HydrationInsightViewModel(
+            waterUseCase: MockDrinkWaterUseCase(),
+            userPreferencesUseCase: MockUserPreferencesUseCase(),
+            calendar: calendar,
+            currentDateProvider: { referenceDate }
+        )
+
+        await viewModel.loadInsights()
+
+        #expect(viewModel.isEmpty == true)
+        #expect(viewModel.weeklyAverageML == 0)
+        #expect(viewModel.monthlyAverageML == 0)
+        #expect(viewModel.weekdayDistributions.isEmpty)
+        #expect(viewModel.currentStreak == 0)
+    }
+
+    private func setTotal(_ volumeML: Int, on date: Date, using useCase: MockDrinkWaterUseCase) {
+        useCase.setHydrationEvents(
+            [HydrationEvent(id: UUID(), consumedAt: date, volumeML: volumeML)],
+            on: date
+        )
+    }
+
+    private func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.firstWeekday = 2
+        calendar.minimumDaysInFirstWeek = 4
+        return calendar
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockDrinkWaterUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockDrinkWaterUseCase.swift
@@ -20,6 +20,13 @@ final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable {
         hydrationEventsByDay[dayKey(for: date)] ?? []
     }
 
+    func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent] {
+        hydrationEventsByDay.values
+            .flatMap { $0 }
+            .filter { interval.contains($0.consumedAt) }
+            .sorted { $0.consumedAt < $1.consumedAt }
+    }
+
     func migrateLegacyDataIfNeeded() async {
         migrateLegacyDataIfNeededCallCount += 1
     }

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockDrinkWaterUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockDrinkWaterUseCase.swift
@@ -24,6 +24,10 @@ public final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable
         events.filter { Calendar.autoupdatingCurrent.isDate($0.consumedAt, inSameDayAs: date) }
     }
 
+    public func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent] {
+        events.filter { interval.contains($0.consumedAt) }
+    }
+
     public func migrateLegacyDataIfNeeded() async {}
     
     public func drinkWater() async {

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -44,6 +44,13 @@ public final class PreviewAssembly: Assembly {
                 useCase: resolver.resolve(DrinkWaterUseCase.self)!
             )
         }
+
+        container.register(HydrationInsightViewModel.self) { resolver in
+            HydrationInsightViewModel(
+                waterUseCase: resolver.resolve(DrinkWaterUseCase.self)!,
+                userPreferencesUseCase: resolver.resolve(UserPreferencesUseCase.self)!
+            )
+        }
         
         // MARK: - Navigation (Preview)
         container.register(NavigationRouter.self) { _ in

--- a/Project/Shared/DependencyInjection/Sources/Preview/ViewPreviews.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/ViewPreviews.swift
@@ -23,6 +23,11 @@ import SwiftUI
     HydrationRecordListView(viewModel: viewModel)
 }
 
+#Preview("HydrationInsightView") {
+    let viewModel = DIContainer.preview.resolve(HydrationInsightViewModel.self)
+    HydrationInsightView(viewModel: viewModel)
+}
+
 // MARK: - SettingsView Preview
 #Preview("SettingsView") {
     let viewModel = DIContainer.preview.resolve(SettingsViewModel.self)

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -38,6 +38,18 @@ public final class PresentationAssembly: Assembly {
                 useCase: resolver.resolve(DrinkWaterUseCase.self)!
             )
         }
+
+        container.register(HydrationInsightViewModel.self) { resolver in
+            let waterUseCase = resolver.resolve(DrinkWaterUseCase.self)!
+            let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
+
+            return MainActor.assumeIsolated {
+                HydrationInsightViewModel(
+                    waterUseCase: waterUseCase,
+                    userPreferencesUseCase: userPreferencesUseCase
+                )
+            }
+        }
         
         // MARK: - Authentication
         container.register(AuthenticationViewModel.self) { resolver in

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockDrinkWaterUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockDrinkWaterUseCaseForTesting.swift
@@ -29,6 +29,11 @@ public final class MockDrinkWaterUseCaseForTesting: DrinkWaterUseCase, @unchecke
         return events.filter { Calendar.autoupdatingCurrent.isDate($0.consumedAt, inSameDayAs: date) }
     }
 
+    public func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent] {
+        hydrateEventsCallCount += 1
+        return events.filter { interval.contains($0.consumedAt) }
+    }
+
     public func migrateLegacyDataIfNeeded() async {
         migrateCallCount += 1
     }


### PR DESCRIPTION
## Summary
- add a new 인사이트 tab with hydration overview cards and weekday chart
- extend the drink water data path with date-range hydration event queries
- add presentation, domain, and data layer tests for the new insight flow

## Verification
- xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination "platform=iOS Simulator,name=iPhone 17"
- xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer -destination "platform=iOS Simulator,name=iPhone 17"
- xcodebuild test -workspace Mulimi.xcworkspace -scheme DataLayer -destination "platform=iOS Simulator,name=iPhone 17"
- xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO

Closes #93