### PR TITLE
fix: refine drink and history tab navigation (#114)

### DIFF
--- a/Project/App/Sources/ContentView.swift
+++ b/Project/App/Sources/ContentView.swift
@@ -13,7 +13,7 @@ import PresentationLayer
 struct ContentView: View {
     var body: some View {
         TabView {
-            Tab("물", systemImage: "waterbottle") {
+            Tab("섭취", systemImage: "waterbottle") {
                 DrinkWaterView(
                     viewModel: DIContainer.shared.resolve(DrinkWaterViewModel.self)
                 )

--- a/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
+++ b/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
@@ -17,87 +17,94 @@ public struct DrinkWaterView: View {
     }
     
     public var body: some View {
-        ZStack {
-            Color.background
-                .ignoresSafeArea()
-            
-            VStack {
-                GeometryReader { proxy in
-                    WaterDropView(
-                        appearance: viewModel.mainAppearance,
-                        progress: viewModel.progress,
-                        offset: viewModel.offset
-                    )
-                    .frame(
-                        width: proxy.size.width,
-                        height: proxy.size.height,
-                        alignment: .center
-                    )
-                }
-                .frame(height: 450)
+        NavigationStack {
+            ZStack {
+                Color.background
+                    .ignoresSafeArea()
                 
-                VStack(spacing: 8) {
-                    HStack(alignment: .firstTextBaseline) {
-                        Text("\(viewModel.drinkWaterCount)잔")
-                            .font(.title)
-                        Text("\(viewModel.mililiters)")
-                            .font(.callout)
+                VStack {
+                    GeometryReader { proxy in
+                        WaterDropView(
+                            appearance: viewModel.mainAppearance,
+                            progress: viewModel.progress,
+                            offset: viewModel.offset
+                        )
+                        .animation(
+                            .linear(duration: 2.0).repeatForever(autoreverses: false),
+                            value: viewModel.offset
+                        )
+                        .frame(
+                            width: proxy.size.width,
+                            height: proxy.size.height,
+                            alignment: .center
+                        )
                     }
+                    .frame(height: 450)
                     
-                    HStack(alignment: .firstTextBaseline) {
-                        Text("목표: \(Int(viewModel.dailyLimit.rounded()))ml")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        if viewModel.isLimitReached {
-                            Text("완료!")
+                    VStack(spacing: 8) {
+                        HStack(alignment: .firstTextBaseline) {
+                            Text("\(viewModel.drinkWaterCount)잔")
+                                .font(.title)
+                            Text("\(viewModel.mililiters)")
+                                .font(.callout)
+                        }
+                        
+                        HStack(alignment: .firstTextBaseline) {
+                            Text("목표: \(Int(viewModel.dailyLimit.rounded()))ml")
                                 .font(.caption)
-                                .foregroundColor(.green)
-                                .fontWeight(.semibold)
+                                .foregroundColor(.secondary)
+                            if viewModel.isLimitReached {
+                                Text("완료!")
+                                    .font(.caption)
+                                    .foregroundColor(.green)
+                                    .fontWeight(.semibold)
+                            }
                         }
                     }
-                }
-                .padding()
-                
-                HStack {
-                    Button {
-                        Task {
-                            await viewModel.drinkWater()
-                        }
-                    } label: {
-                        Text(viewModel.isLimitReached ? "목표 달성!" : "마시기")
-                            .font(.headline)
-                            .fontWeight(.bold)
-                            .padding()
-                            .background(viewModel.isLimitReached ? Color.gray : Color.accent)
-                            .foregroundColor(.white)
-                            .cornerRadius(10)
-                    }
-                    .disabled(viewModel.isLimitReached)
+                    .padding()
                     
-                    
-                    Button {
-                        Task {
-                            await viewModel.reset()
+                    HStack {
+                        Button {
+                            Task {
+                                await viewModel.drinkWater()
+                            }
+                        } label: {
+                            Text(viewModel.isLimitReached ? "목표 달성!" : "마시기")
+                                .font(.headline)
+                                .fontWeight(.bold)
+                                .padding()
+                                .background(viewModel.isLimitReached ? Color.gray : Color.accent)
+                                .foregroundColor(.white)
+                                .cornerRadius(10)
                         }
-                    } label: {
-                        Text("초기화")
-                            .font(.headline)
-                            .fontWeight(.bold)
-                            .padding()
-                            .background(.white)
-                            .foregroundColor(.black)
-                            .cornerRadius(10)
+                        .disabled(viewModel.isLimitReached)
+                        
+                        Button {
+                            Task {
+                                await viewModel.reset()
+                            }
+                        } label: {
+                            Text("초기화")
+                                .font(.headline)
+                                .fontWeight(.bold)
+                                .padding()
+                                .background(.white)
+                                .foregroundColor(.black)
+                                .cornerRadius(10)
+                        }
                     }
                 }
             }
-        }
-        .onAppear {
-            // Refresh data when view appears to catch any Widget changes
-            Task {
+            .navigationTitle("섭취")
+            .navigationBarTitleDisplayMode(.large)
+            .task {
+                // Refresh data when view appears to catch any Widget changes.
                 await viewModel.loadInitialState()
             }
-
-            withAnimation(.linear(duration: 2.0).repeatForever(autoreverses: false)) {
+            .task {
+                // Start the repeating wave after the initial frame is committed.
+                viewModel.resetAnimation()
+                await Task.yield()
                 viewModel.startAnimation()
             }
         }

--- a/Project/Presentation/Sources/View/HydrationRecord/HydrationRecordListView.swift
+++ b/Project/Presentation/Sources/View/HydrationRecord/HydrationRecordListView.swift
@@ -18,10 +18,14 @@ public struct HydrationRecordListView: View {
     }
     
     public var body: some View {
-        ZStack {
-            Color.background
-                .ignoresSafeArea()
+        NavigationStack {
             RecordCalendarView(viewModel: viewModel)
+            .navigationTitle("기록")
+            .navigationBarTitleDisplayMode(.large)
+            .background(
+                Color.background
+                    .ignoresSafeArea()
+            )
         }
         .task {
             await viewModel.onAppear()
@@ -42,11 +46,8 @@ public struct HydrationRecordListView: View {
         }
         
         var body: some View {
-            NavigationStack {
-                List(viewModel.records) { record in
-                    HydrationRecordRow(record: record)
-                }
-                .navigationTitle(viewModel.date.formatted(.dateTime.year().month()))
+            List(viewModel.records) { record in
+                HydrationRecordRow(record: record)
             }
         }
     }

--- a/Project/Presentation/Sources/View/HydrationRecord/RecordCalendarView.swift
+++ b/Project/Presentation/Sources/View/HydrationRecord/RecordCalendarView.swift
@@ -25,16 +25,9 @@ struct RecordCalendarView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            VStack(spacing: 0) {
-                monthHeader
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 12)
-
-                weekDayHeader
-                    .padding(.horizontal, 16)
-
-                ScrollView(showsIndicators: false) {
+        ScrollView(showsIndicators: false) {
+            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                Section {
                     LazyVGrid(columns: columns, spacing: 8) {
                         ForEach(calendarDays, id: \.self) { day in
                             CalendarDayView(
@@ -48,11 +41,20 @@ struct RecordCalendarView: View {
                     }
                     .padding(.horizontal, 16)
                     .padding(.top, 12)
+                } header: {
+                    VStack(spacing: 0) {
+                        monthHeader
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 12)
+
+                        weekDayHeader
+                            .padding(.horizontal, 16)
+                    }
+                    .background(Color(uiColor: .systemGroupedBackground))
                 }
             }
-            .background(Color(uiColor: .systemGroupedBackground))
-            .navigationBarHidden(true)
         }
+        .background(Color(uiColor: .systemGroupedBackground))
         .task {
             await viewModel.fetchHydrationRecord()
         }

--- a/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
@@ -148,6 +148,10 @@ public final class DrinkWaterViewModel {
             print("Failed to reset HealthKit data: \(error)")
         }
     }
+
+    func resetAnimation() {
+        offset = 0
+    }
     
     func startAnimation() {
         offset = 360

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -38,6 +38,7 @@ public final class PreviewAssembly: Assembly {
                 userPreferencesUseCase: resolver.resolve(UserPreferencesUseCase.self)!
             )
         }
+        .inObjectScope(.container)
         
         container.register(HydrationRecordListViewModel.self) { resolver in
             HydrationRecordListViewModel(

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -31,6 +31,7 @@ public final class PresentationAssembly: Assembly {
                 )
             }
         }
+        .inObjectScope(.container)
         
         // MARK: - HealthKit
         container.register(HydrationRecordListViewModel.self) { resolver in


### PR DESCRIPTION
## Summary
- rename the drink tab to 섭취 and apply large navigation titles to drink/history screens
- stabilize DrinkWaterView wave animation when the navigation container is rebuilt
- move the history sticky header into a pinned scroll section so it no longer overlaps the large title area

## Verification
- tuist generate
- xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO

Closes #114