### PR TITLE
feat: add shared localization module with string catalog (#116)

### DIFF
--- a/Project/App/Project.swift
+++ b/Project/App/Project.swift
@@ -51,6 +51,10 @@ let project = Project(
                     path: .relativeToRoot("Project/Shared/Persistence")
                 ),
                 .project(
+                    target: "Localization",
+                    path: .relativeToRoot("Project/Shared/Localization")
+                ),
+                .project(
                     target: "Utils",
                     path: .relativeToRoot("Project/Shared/Utils")
                 ),

--- a/Project/App/Sources/ContentView.swift
+++ b/Project/App/Sources/ContentView.swift
@@ -7,34 +7,39 @@
 //
 
 import DependencyInjection
-import SwiftUI
+import Localization
 import PresentationLayer
+import SwiftUI
 
 struct ContentView: View {
     var body: some View {
         TabView {
-            Tab("섭취", systemImage: "waterbottle") {
-                DrinkWaterView(
-                    viewModel: DIContainer.shared.resolve(DrinkWaterViewModel.self)
-                )
-            }
-            
-            Tab("기록", systemImage: "calendar") {
-                HydrationRecordListView(
-                    viewModel: DIContainer.shared.resolve(HydrationRecordListViewModel.self)
-                )
+            DrinkWaterView(
+                viewModel: DIContainer.shared.resolve(DrinkWaterViewModel.self)
+            )
+            .tabItem {
+                Label(L10n.tr("drinkTitle"), systemImage: "waterbottle")
             }
 
-            Tab("인사이트", systemImage: "chart.bar.xaxis") {
-                HydrationInsightView(
-                    viewModel: DIContainer.shared.resolve(HydrationInsightViewModel.self)
-                )
+            HydrationRecordListView(
+                viewModel: DIContainer.shared.resolve(HydrationRecordListViewModel.self)
+            )
+            .tabItem {
+                Label(L10n.tr("historyTitle"), systemImage: "calendar")
             }
-            
-            Tab("설정", systemImage: "gear") {
-                SettingsView(
-                    viewModel: DIContainer.shared.resolve(SettingsViewModel.self)
-                )
+
+            HydrationInsightView(
+                viewModel: DIContainer.shared.resolve(HydrationInsightViewModel.self)
+            )
+            .tabItem {
+                Label(L10n.tr("insightNavigationTitle"), systemImage: "chart.bar.xaxis")
+            }
+
+            SettingsView(
+                viewModel: DIContainer.shared.resolve(SettingsViewModel.self)
+            )
+            .tabItem {
+                Label(L10n.tr("settingsTitle"), systemImage: "gear")
             }
         }
         .tint(.accent)

--- a/Project/Domain/Interfaces/Entity/MainAppearance.swift
+++ b/Project/Domain/Interfaces/Entity/MainAppearance.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Localization
 
 public enum MainAppearance: CaseIterable, Identifiable, Sendable {
     case drop
@@ -18,11 +19,11 @@ public enum MainAppearance: CaseIterable, Identifiable, Sendable {
     public var displayName: String {
         switch self {
         case .drop:
-            return "물방울"
+            return L10n.tr("mainAppearanceDropName")
         case .heart:
-            return "하트"
+            return L10n.tr("mainAppearanceHeartName")
         case .cloud:
-            return "구름"
+            return L10n.tr("mainAppearanceCloudName")
         }
     }
     
@@ -51,11 +52,11 @@ public enum MainAppearance: CaseIterable, Identifiable, Sendable {
     public var description: String {
         switch self {
         case .drop:
-            return "물방울 모양으로 물의 본질을 표현합니다"
+            return L10n.tr("mainAppearanceDropDescription")
         case .heart:
-            return "하트 모양으로 사랑스럽고 친근한 느낌을 줍니다"
+            return L10n.tr("mainAppearanceHeartDescription")
         case .cloud:
-            return "구름 모양으로 부드럽고 편안한 느낌을 줍니다"
+            return L10n.tr("mainAppearanceCloudDescription")
         }
     }
     

--- a/Project/Domain/Interfaces/Entity/SettingMenu.swift
+++ b/Project/Domain/Interfaces/Entity/SettingMenu.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import Localization
 
 public enum SettingMenu: CaseIterable, Identifiable {
     case dailyLimit
@@ -17,9 +18,9 @@ public enum SettingMenu: CaseIterable, Identifiable {
 
     public var title: String {
         switch self {
-        case .dailyLimit: "하루 목표량"
-        case .mainShape: "메인 화면 모양"
-        case .withdrawal: "회원 탈퇴"
+        case .dailyLimit: L10n.tr("settingDailyLimitTitle")
+        case .mainShape: L10n.tr("settingMainShapeTitle")
+        case .withdrawal: L10n.tr("settingWithdrawalTitle")
         }
     }
 
@@ -37,11 +38,11 @@ public enum SettingMenu: CaseIterable, Identifiable {
     public var description: String {
         switch self {
         case .dailyLimit:
-            return "하루 동안 마실 물의 목표량을 설정합니다"
+            return L10n.tr("settingDailyLimitDescription")
         case .mainShape:
-            return "메인 화면의 디자인을 선택합니다"
+            return L10n.tr("settingMainShapeDescription")
         case .withdrawal:
-            return "계정을 영구적으로 삭제합니다"
+            return L10n.tr("settingWithdrawalDescription")
         }
     }
 

--- a/Project/Domain/Project.swift
+++ b/Project/Domain/Project.swift
@@ -24,7 +24,13 @@ let project = Project(
             product: .framework,
             bundleId: "\(bundleId).DomainLayer.Interface",
             deploymentTargets: .iOS("18.0"),
-            sources: ["Interfaces/**"]
+            sources: ["Interfaces/**"],
+            dependencies: [
+                .project(
+                    target: "Localization",
+                    path: .relativeToRoot("Project/Shared/Localization")
+                )
+            ]
         ),
         .target(
             name: "DomainLayer",

--- a/Project/Presentation/Project.swift
+++ b/Project/Presentation/Project.swift
@@ -44,6 +44,10 @@ let project = Project(
                 .project(
                     target: "DesignSystem",
                     path: .relativeToRoot("Project/Shared/DesignSystem")
+                ),
+                .project(
+                    target: "Localization",
+                    path: .relativeToRoot("Project/Shared/Localization")
                 )
             ]
         ),
@@ -55,7 +59,11 @@ let project = Project(
             deploymentTargets: .iOS("18.0"),
             sources: ["Tests/**"],
             dependencies: [
-                .target(name: "PresentationLayer")
+                .target(name: "PresentationLayer"),
+                .project(
+                    target: "Localization",
+                    path: .relativeToRoot("Project/Shared/Localization")
+                )
             ]
         )
     ]

--- a/Project/Presentation/Sources/View/Authentication/SignInView.swift
+++ b/Project/Presentation/Sources/View/Authentication/SignInView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 gaeng2y. All rights reserved.
 //
 
+import Localization
 import SwiftUI
 
 public struct SignInView: View {
@@ -25,11 +26,11 @@ public struct SignInView: View {
                     .font(.system(size: 80))
                     .foregroundColor(.blue)
 
-                Text("물 마시기")
+                Text(L10n.tr("signInTitle"))
                     .font(.largeTitle)
                     .fontWeight(.bold)
 
-                Text("건강한 수분 섭취를 위해\n로그인이 필요합니다")
+                Text(L10n.tr("signInSubtitle"))
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -63,7 +64,7 @@ public struct SignInView: View {
                                 .font(.title3)
                                 .fontWeight(.medium)
 
-                            Text("Sign in with Apple")
+                            Text(L10n.tr("signInWithAppleTitle"))
                                 .font(.body)
                                 .fontWeight(.medium)
                         }

--- a/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
+++ b/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
@@ -7,6 +7,7 @@
 
 import DesignSystem
 import DomainLayerInterface
+import Localization
 import SwiftUI
 
 public struct DrinkWaterView: View {
@@ -43,18 +44,18 @@ public struct DrinkWaterView: View {
                     
                     VStack(spacing: 8) {
                         HStack(alignment: .firstTextBaseline) {
-                            Text("\(viewModel.drinkWaterCount)잔")
+                            Text(L10n.tr("drinkWaterGlassCountFormat", viewModel.drinkWaterCount))
                                 .font(.title)
                             Text("\(viewModel.mililiters)")
                                 .font(.callout)
                         }
                         
                         HStack(alignment: .firstTextBaseline) {
-                            Text("목표: \(Int(viewModel.dailyLimit.rounded()))ml")
+                            Text(L10n.tr("drinkWaterGoalFormat", Int(viewModel.dailyLimit.rounded())))
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                             if viewModel.isLimitReached {
-                                Text("완료!")
+                                Text(L10n.tr("drinkWaterCompleteLabel"))
                                     .font(.caption)
                                     .foregroundColor(.green)
                                     .fontWeight(.semibold)
@@ -69,7 +70,11 @@ public struct DrinkWaterView: View {
                                 await viewModel.drinkWater()
                             }
                         } label: {
-                            Text(viewModel.isLimitReached ? "목표 달성!" : "마시기")
+                            Text(
+                                viewModel.isLimitReached ?
+                                L10n.tr("drinkWaterButtonReachedTitle") :
+                                L10n.tr("drinkWaterButtonTitle")
+                            )
                                 .font(.headline)
                                 .fontWeight(.bold)
                                 .padding()
@@ -84,7 +89,7 @@ public struct DrinkWaterView: View {
                                 await viewModel.reset()
                             }
                         } label: {
-                            Text("초기화")
+                            Text(L10n.tr("commonResetTitle"))
                                 .font(.headline)
                                 .fontWeight(.bold)
                                 .padding()
@@ -95,7 +100,7 @@ public struct DrinkWaterView: View {
                     }
                 }
             }
-            .navigationTitle("섭취")
+            .navigationTitle(L10n.tr("drinkTitle"))
             .navigationBarTitleDisplayMode(.large)
             .task {
                 // Refresh data when view appears to catch any Widget changes.

--- a/Project/Presentation/Sources/View/HydrationInsight/HydrationInsightView.swift
+++ b/Project/Presentation/Sources/View/HydrationInsight/HydrationInsightView.swift
@@ -7,6 +7,7 @@
 
 import Charts
 import DesignSystem
+import Localization
 import SwiftUI
 
 public struct HydrationInsightView: View {
@@ -32,7 +33,7 @@ public struct HydrationInsightView: View {
 
                 Group {
                     if viewModel.isLoading {
-                        ProgressView("인사이트 불러오는 중...")
+                        ProgressView(L10n.tr("insightLoadingTitle"))
                     } else if viewModel.isEmpty {
                         emptyState
                     } else {
@@ -41,7 +42,7 @@ public struct HydrationInsightView: View {
                 }
                 .padding(.horizontal, 20)
             }
-            .navigationTitle("인사이트")
+            .navigationTitle(L10n.tr("insightNavigationTitle"))
             .task {
                 await viewModel.loadInsights()
             }
@@ -95,23 +96,38 @@ public struct HydrationInsightView: View {
                 .offset(x: 30, y: -30)
 
             VStack(alignment: .leading, spacing: 16) {
-                Label("이번 주와 이번 달 흐름", systemImage: "chart.bar.xaxis")
+                Label(L10n.tr("insightOverviewTitle"), systemImage: "chart.bar.xaxis")
                     .font(.headline)
                     .foregroundStyle(.white.opacity(0.92))
 
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("하루 목표는 \(viewModel.dailyGoalText)")
+                    Text(L10n.tr("insightDailyGoalFormat", viewModel.dailyGoalText))
                         .font(.title3.weight(.bold))
                         .foregroundStyle(.white)
-                    Text("이번 주 달성률 \(viewModel.weeklyAchievementText), 이번 달 달성률 \(viewModel.monthlyAchievementText)")
+                    Text(
+                        L10n.tr(
+                            "insightAchievementSummaryFormat",
+                            viewModel.weeklyAchievementText,
+                            viewModel.monthlyAchievementText
+                        )
+                    )
                         .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.88))
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
                 HStack(spacing: 12) {
-                    PillLabel(title: "현재 streak", value: viewModel.streakText)
-                    PillLabel(title: "이번 달 평균", value: "\(Int(viewModel.monthlyAverageML.rounded()))ml")
+                    PillLabel(
+                        title: L10n.tr("insightStreakPillTitle"),
+                        value: viewModel.streakText
+                    )
+                    PillLabel(
+                        title: L10n.tr("insightThisMonthLabel"),
+                        value: L10n.tr(
+                            "commonMilliliterFormat",
+                            Int(viewModel.monthlyAverageML.rounded())
+                        )
+                    )
                 }
             }
             .padding(22)
@@ -120,25 +136,36 @@ public struct HydrationInsightView: View {
     }
 
     private var streakCard: some View {
-        InsightCard(title: "연속 달성 흐름", subtitle: "오늘 목표를 아직 채우지 않았다면 어제까지의 연속 달성일을 보여줍니다.") {
+        InsightCard(
+            title: L10n.tr("insightStreakCardTitle"),
+            subtitle: L10n.tr("insightStreakCardSubtitle")
+        ) {
             VStack(alignment: .leading, spacing: 16) {
                 HStack(alignment: .firstTextBaseline, spacing: 10) {
                     Text(viewModel.streakText)
                         .font(.system(size: 36, weight: .bold, design: .rounded))
-                    Text("연속 목표 달성")
+                    Text(L10n.tr("insightStreakAchievementLabel"))
                         .font(.headline)
                         .foregroundStyle(.secondary)
                 }
 
                 VStack(alignment: .leading, spacing: 10) {
                     AchievementProgressRow(
-                        title: "이번 주",
-                        detail: "\(viewModel.weeklyAchievedDays)/\(max(viewModel.weeklyElapsedDays, 1))일 달성",
+                        title: L10n.tr("insightThisWeekLabel"),
+                        detail: L10n.tr(
+                            "insightAchievementDaysFormat",
+                            viewModel.weeklyAchievedDays,
+                            max(viewModel.weeklyElapsedDays, 1)
+                        ),
                         progress: viewModel.weeklyAchievementRate
                     )
                     AchievementProgressRow(
-                        title: "이번 달",
-                        detail: "\(viewModel.monthlyAchievedDays)/\(max(viewModel.monthlyElapsedDays, 1))일 달성",
+                        title: L10n.tr("insightThisMonthLabel"),
+                        detail: L10n.tr(
+                            "insightAchievementDaysFormat",
+                            viewModel.monthlyAchievedDays,
+                            max(viewModel.monthlyElapsedDays, 1)
+                        ),
                         progress: viewModel.monthlyAchievementRate
                     )
                 }
@@ -147,12 +174,18 @@ public struct HydrationInsightView: View {
     }
 
     private var weekdayPatternCard: some View {
-        InsightCard(title: "이번 달 요일 패턴", subtitle: viewModel.weekdayInsightText) {
+        InsightCard(
+            title: L10n.tr("insightWeekdayPatternTitle"),
+            subtitle: viewModel.weekdayInsightText
+        ) {
             VStack(alignment: .leading, spacing: 14) {
                 Chart(viewModel.weekdayDistributions) { distribution in
                     BarMark(
-                        x: .value("요일", distribution.label),
-                        y: .value("평균 섭취량", distribution.averageIntakeML)
+                        x: .value(L10n.tr("insightChartWeekdayAxisTitle"), distribution.label),
+                        y: .value(
+                            L10n.tr("insightChartAverageIntakeAxisTitle"),
+                            distribution.averageIntakeML
+                        )
                     )
                     .cornerRadius(8)
                     .foregroundStyle(
@@ -162,7 +195,12 @@ public struct HydrationInsightView: View {
                     )
 
                     if viewModel.dailyGoalML > 0 {
-                        RuleMark(y: .value("목표", viewModel.dailyGoalML))
+                        RuleMark(
+                            y: .value(
+                                L10n.tr("insightChartGoalAxisTitle"),
+                                viewModel.dailyGoalML
+                            )
+                        )
                             .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 4]))
                             .foregroundStyle(Color.secondary.opacity(0.7))
                     }
@@ -174,15 +212,23 @@ public struct HydrationInsightView: View {
                 HStack(spacing: 12) {
                     if let bestWeekday = viewModel.bestWeekday {
                         BadgeView(
-                            title: "가장 많이 마신 날",
-                            value: "\(bestWeekday.label) · \(Int(bestWeekday.averageIntakeML.rounded()))ml"
+                            title: L10n.tr("insightMostDrankDayTitle"),
+                            value: L10n.tr(
+                                "insightWeekdayBadgeValueFormat",
+                                bestWeekday.label,
+                                Int(bestWeekday.averageIntakeML.rounded())
+                            )
                         )
                     }
 
                     if let leastWeekday = viewModel.leastWeekday {
                         BadgeView(
-                            title: "가장 적게 마신 날",
-                            value: "\(leastWeekday.label) · \(Int(leastWeekday.averageIntakeML.rounded()))ml"
+                            title: L10n.tr("insightLeastDrankDayTitle"),
+                            value: L10n.tr(
+                                "insightWeekdayBadgeValueFormat",
+                                leastWeekday.label,
+                                Int(leastWeekday.averageIntakeML.rounded())
+                            )
                         )
                     }
                 }
@@ -191,7 +237,7 @@ public struct HydrationInsightView: View {
                     Circle()
                         .fill(Color.secondary.opacity(0.7))
                         .frame(width: 8, height: 8)
-                    Text("점선은 하루 목표량을 뜻합니다.")
+                    Text(L10n.tr("insightGoalRuleDescription"))
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
@@ -208,9 +254,9 @@ public struct HydrationInsightView: View {
                 .foregroundStyle(Color.accent)
 
             VStack(spacing: 8) {
-                Text("아직 보여줄 인사이트가 없어요")
+                Text(L10n.tr("insightEmptyTitle"))
                     .font(.title3.weight(.bold))
-                Text("최근 기록이 쌓이면 주간 평균, 달성률, streak, 요일 패턴을 한 번에 볼 수 있습니다. 오늘 목표는 \(viewModel.dailyGoalText)입니다.")
+                Text(L10n.tr("insightEmptyDescriptionFormat", viewModel.dailyGoalText))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)

--- a/Project/Presentation/Sources/View/HydrationRecord/HydrationRecordListView.swift
+++ b/Project/Presentation/Sources/View/HydrationRecord/HydrationRecordListView.swift
@@ -7,6 +7,7 @@
 //
 
 import DomainLayerInterface
+import Localization
 import SwiftUI
 
 public struct HydrationRecordListView: View {
@@ -20,7 +21,7 @@ public struct HydrationRecordListView: View {
     public var body: some View {
         NavigationStack {
             RecordCalendarView(viewModel: viewModel)
-            .navigationTitle("기록")
+            .navigationTitle(L10n.tr("historyTitle"))
             .navigationBarTitleDisplayMode(.large)
             .background(
                 Color.background
@@ -56,17 +57,7 @@ public struct HydrationRecordListView: View {
         let record: HydrationRecord
         
         private var dateString: String {
-            let dateComponents = Calendar.current.dateComponents(
-                [.year, .month, .day],
-                from: record.date
-            )
-            
-            guard let year = dateComponents.year,
-                  let month = dateComponents.month,
-                  let day = dateComponents.day else {
-                return ""
-            }
-            return "\(year)-\(month)-\(day)"
+            record.date.formatted(.dateTime.year().month().day())
         }
         
         var body: some View {
@@ -78,7 +69,7 @@ public struct HydrationRecordListView: View {
                 
                 HStack {
                     Spacer()
-                    Text(String(format: "%.0fml", record.mililiter))
+                    Text(L10n.tr("commonMilliliterFormat", Int(record.mililiter.rounded())))
                         .font(.subheadline)
                         .fontWeight(.semibold)
                 }

--- a/Project/Presentation/Sources/View/HydrationRecord/RecordCalendarView.swift
+++ b/Project/Presentation/Sources/View/HydrationRecord/RecordCalendarView.swift
@@ -7,6 +7,7 @@
 //
 
 import DomainLayerInterface
+import Localization
 import SwiftUI
 
 struct RecordCalendarView: View {
@@ -17,7 +18,6 @@ struct RecordCalendarView: View {
 
     private let calendar = Calendar.current
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 7)
-    private let weekDays = ["월", "화", "수", "목", "금", "토", "일"]
     private let dailyGoal: Double = 2000
 
     init(viewModel: HydrationRecordListViewModel) {
@@ -86,17 +86,17 @@ struct RecordCalendarView: View {
                 }
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("년월 선택")
-            .accessibilityHint("기록을 볼 년과 월을 선택합니다")
+            .accessibilityLabel(L10n.tr("recordCalendarMonthPickerAccessibilityLabel"))
+            .accessibilityHint(L10n.tr("recordCalendarMonthPickerAccessibilityHint"))
 
             Spacer()
 
             VStack(alignment: .trailing, spacing: 4) {
-                Text("월 목표")
+                Text(L10n.tr("recordCalendarMonthlyGoalTitle"))
                     .font(.caption)
                     .foregroundColor(.secondary)
 
-                Text("\(monthlyProgress)%")
+                Text(L10n.tr("commonPercentFormat", monthlyProgress))
                     .font(.title3)
                     .fontWeight(.semibold)
                     .foregroundColor(.accentColor)
@@ -184,13 +184,25 @@ struct RecordCalendarView: View {
         return Array((currentYear - 10)...(currentYear + 2))
     }
 
+    private var weekDays: [String] {
+        [
+            L10n.tr("commonWeekdayMondayShort"),
+            L10n.tr("commonWeekdayTuesdayShort"),
+            L10n.tr("commonWeekdayWednesdayShort"),
+            L10n.tr("commonWeekdayThursdayShort"),
+            L10n.tr("commonWeekdayFridayShort"),
+            L10n.tr("commonWeekdaySaturdayShort"),
+            L10n.tr("commonWeekdaySundayShort")
+        ]
+    }
+
     @ViewBuilder
     private var yearMonthPickerSheet: some View {
         NavigationStack {
             HStack(spacing: 0) {
-                Picker("년", selection: $selectedYear) {
+                Picker(L10n.tr("recordCalendarYearPickerTitle"), selection: $selectedYear) {
                     ForEach(selectableYears, id: \.self) { year in
-                        Text("\(year)년")
+                        Text(L10n.tr("commonYearFormat", year))
                             .tag(year)
                     }
                 }
@@ -198,9 +210,9 @@ struct RecordCalendarView: View {
                 .frame(maxWidth: .infinity)
                 .clipped()
 
-                Picker("월", selection: $selectedMonth) {
+                Picker(L10n.tr("recordCalendarMonthPickerTitle"), selection: $selectedMonth) {
                     ForEach(1...12, id: \.self) { month in
-                        Text("\(month)월")
+                        Text(L10n.tr("commonMonthFormat", month))
                             .tag(month)
                     }
                 }
@@ -208,16 +220,16 @@ struct RecordCalendarView: View {
                 .frame(maxWidth: .infinity)
                 .clipped()
             }
-            .navigationTitle("년/월 선택")
+            .navigationTitle(L10n.tr("recordCalendarSelectionTitle"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("취소") {
+                    Button(L10n.tr("commonCancelTitle")) {
                         isYearMonthPickerPresented = false
                     }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("적용") {
+                    Button(L10n.tr("commonApplyTitle")) {
                         Task {
                             await viewModel.updateDisplayedMonth(
                                 year: selectedYear,

--- a/Project/Presentation/Sources/View/Settings/SettingDetailView.swift
+++ b/Project/Presentation/Sources/View/Settings/SettingDetailView.swift
@@ -6,8 +6,9 @@
 //  Copyright © 2025 gaeng2y. All rights reserved.
 //
 
-import SwiftUI
 import DomainLayerInterface
+import Localization
+import SwiftUI
 import WidgetKit
 import UIKit
 
@@ -45,7 +46,7 @@ private struct DailyLimitSettingView: View {
     var body: some View {
         VStack(spacing: 20) {
             HStack {
-                Text("\(Int(viewModel.dailyWaterLimit.rounded())) ml")
+                Text(L10n.tr("settingsDailyLimitValueFormat", Int(viewModel.dailyWaterLimit.rounded())))
                     .font(.largeTitle)
                     .fontWeight(.semibold)
             }
@@ -58,7 +59,7 @@ private struct DailyLimitSettingView: View {
                     WidgetCenter.shared.reloadAllTimelines()
                 }
             ), in: 1000...4000, step: 250) {
-                Text("목표량")
+                Text(L10n.tr("settingsDailyLimitSliderTitle"))
             }
             .padding(.horizontal)
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
@@ -67,11 +68,11 @@ private struct DailyLimitSettingView: View {
             }
             
             HStack {
-                Text("1000ml")
+                Text(L10n.tr("commonMilliliterFormat", 1000))
                     .font(.caption)
                     .foregroundColor(.secondary)
                 Spacer()
-                Text("4000ml")
+                Text(L10n.tr("commonMilliliterFormat", 4000))
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -80,7 +81,7 @@ private struct DailyLimitSettingView: View {
             Spacer()
         }
         .padding()
-        .navigationTitle("하루 목표량")
+        .navigationTitle(L10n.tr("settingDailyLimitTitle"))
         .navigationBarTitleDisplayMode(.inline)
     }
 }
@@ -149,7 +150,7 @@ private struct MainShapeSettingView: View {
             Spacer()
         }
         .padding()
-        .navigationTitle("메인 화면 모양")
+        .navigationTitle(L10n.tr("settingMainShapeTitle"))
         .navigationBarTitleDisplayMode(.inline)
     }
 }
@@ -168,11 +169,11 @@ private struct WithdrawalSettingView: View {
                     .font(.system(size: 60))
                     .foregroundColor(.red)
 
-                Text("회원 탈퇴")
+                Text(L10n.tr("settingWithdrawalTitle"))
                     .font(.title2)
                     .fontWeight(.bold)
 
-                Text("계정을 삭제하면 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다.")
+                Text(L10n.tr("withdrawalDescription"))
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -181,9 +182,9 @@ private struct WithdrawalSettingView: View {
             .padding(.top, 40)
 
             VStack(alignment: .leading, spacing: 12) {
-                Label("저장된 물 섭취 기록 삭제", systemImage: "drop.fill")
-                Label("개인 설정 정보 삭제", systemImage: "gearshape.fill")
-                Label("계정 정보 삭제", systemImage: "person.fill")
+                Label(L10n.tr("withdrawalDeleteRecordsItem"), systemImage: "drop.fill")
+                Label(L10n.tr("withdrawalDeletePreferencesItem"), systemImage: "gearshape.fill")
+                Label(L10n.tr("withdrawalDeleteAccountItem"), systemImage: "person.fill")
             }
             .font(.subheadline)
             .foregroundColor(.secondary)
@@ -200,7 +201,7 @@ private struct WithdrawalSettingView: View {
             Button {
                 viewModel.requestWithdrawal()
             } label: {
-                Text("회원 탈퇴하기")
+                Text(L10n.tr("withdrawalActionTitle"))
                     .font(.headline)
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
@@ -211,22 +212,22 @@ private struct WithdrawalSettingView: View {
             .padding(.horizontal)
             .padding(.bottom)
         }
-        .navigationTitle("회원 탈퇴")
+        .navigationTitle(L10n.tr("settingWithdrawalTitle"))
         .navigationBarTitleDisplayMode(.inline)
-        .alert("정말 탈퇴하시겠습니까?", isPresented: $viewModel.showWithdrawalConfirmation) {
-            Button("취소", role: .cancel) {
+        .alert(L10n.tr("withdrawalConfirmationTitle"), isPresented: $viewModel.showWithdrawalConfirmation) {
+            Button(L10n.tr("commonCancelTitle"), role: .cancel) {
                 viewModel.cancelWithdrawal()
             }
-            Button("탈퇴", role: .destructive) {
+            Button(L10n.tr("commonWithdrawTitle"), role: .destructive) {
                 Task {
                     await viewModel.confirmWithdrawal()
                 }
             }
         } message: {
-            Text("이 작업은 되돌릴 수 없습니다. 모든 데이터가 영구적으로 삭제됩니다.")
+            Text(L10n.tr("withdrawalConfirmationMessage"))
         }
-        .alert("탈퇴 실패", isPresented: .constant(viewModel.withdrawalError != nil)) {
-            Button("확인", role: .cancel) {
+        .alert(L10n.tr("withdrawalFailureTitle"), isPresented: .constant(viewModel.withdrawalError != nil)) {
+            Button(L10n.tr("commonConfirmTitle"), role: .cancel) {
                 viewModel.withdrawalError = nil
             }
         } message: {
@@ -240,7 +241,7 @@ private struct WithdrawalSettingView: View {
                     Color.black.opacity(0.3)
                         .ignoresSafeArea()
                     
-                    ProgressView("탈퇴 처리 중...")
+                    ProgressView(L10n.tr("withdrawalProgressTitle"))
                         .padding()
                         .background(
                             RoundedRectangle(cornerRadius: 12)

--- a/Project/Presentation/Sources/View/Settings/SettingsView.swift
+++ b/Project/Presentation/Sources/View/Settings/SettingsView.swift
@@ -7,6 +7,7 @@
 //
 
 import DomainLayerInterface
+import Localization
 import SwiftUI
 
 public struct SettingsView: View {
@@ -39,7 +40,7 @@ public struct SettingsView: View {
                 }
                 .buttonStyle(PlainButtonStyle())
             }
-            .navigationTitle("설정")
+            .navigationTitle(L10n.tr("settingsTitle"))
             .navigationDestination(for: NavigationDestination.self) { destination in
                 switch destination {
                 case .settingDetail(let menu):

--- a/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
@@ -9,6 +9,7 @@
 import Combine
 import DomainLayerInterface
 import Foundation
+import Localization
 import UIKit
 import WidgetKit
 
@@ -27,7 +28,7 @@ public final class DrinkWaterViewModel {
     private var cancellables = Set<AnyCancellable>()
     
     var mililiters: String {
-        String(format: "%.0fml", currentWaterIntakeInMl)
+        L10n.tr("commonMilliliterFormat", Int(currentWaterIntakeInMl.rounded()))
     }
     
     var currentWaterIntakeInMl: Double {

--- a/Project/Presentation/Sources/ViewModel/HydrationInsightViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationInsightViewModel.swift
@@ -7,6 +7,7 @@
 
 import DomainLayerInterface
 import Foundation
+import Localization
 
 struct HydrationInsightMetric: Identifiable, Equatable {
     let id: String
@@ -66,33 +67,41 @@ public final class HydrationInsightViewModel {
         [
             HydrationInsightMetric(
                 id: "weeklyAverage",
-                title: "이번 주 평균",
+                title: L10n.tr("insightMetricWeeklyAverageTitle"),
                 value: volumeText(weeklyAverageML),
-                detail: "\(weeklyElapsedDays)일 기준"
+                detail: L10n.tr("insightElapsedDaysFormat", weeklyElapsedDays)
             ),
             HydrationInsightMetric(
                 id: "monthlyAverage",
-                title: "이번 달 평균",
+                title: L10n.tr("insightMetricMonthlyAverageTitle"),
                 value: volumeText(monthlyAverageML),
-                detail: "\(monthlyElapsedDays)일 기준"
+                detail: L10n.tr("insightElapsedDaysFormat", monthlyElapsedDays)
             ),
             HydrationInsightMetric(
                 id: "weeklyAchievement",
-                title: "주간 달성률",
+                title: L10n.tr("insightMetricWeeklyAchievementTitle"),
                 value: percentText(weeklyAchievementRate),
-                detail: "\(weeklyAchievedDays)/\(max(weeklyElapsedDays, 1))일 달성"
+                detail: L10n.tr(
+                    "insightAchievementDaysFormat",
+                    weeklyAchievedDays,
+                    max(weeklyElapsedDays, 1)
+                )
             ),
             HydrationInsightMetric(
                 id: "monthlyAchievement",
-                title: "월간 달성률",
+                title: L10n.tr("insightMetricMonthlyAchievementTitle"),
                 value: percentText(monthlyAchievementRate),
-                detail: "\(monthlyAchievedDays)/\(max(monthlyElapsedDays, 1))일 달성"
+                detail: L10n.tr(
+                    "insightAchievementDaysFormat",
+                    monthlyAchievedDays,
+                    max(monthlyElapsedDays, 1)
+                )
             )
         ]
     }
 
     var streakText: String {
-        "\(currentStreak)일"
+        L10n.tr("insightStreakValueFormat", currentStreak)
     }
 
     var dailyGoalText: String {
@@ -109,10 +118,16 @@ public final class HydrationInsightViewModel {
 
     var weekdayInsightText: String {
         guard let bestWeekday, let leastWeekday else {
-            return "이번 달 요일별 패턴을 만들 기록이 아직 부족합니다."
+            return L10n.tr("insightWeekdayInsightInsufficient")
         }
 
-        return "\(bestWeekday.label)에 평균 \(volumeText(bestWeekday.averageIntakeML))로 가장 많이 마셨고, \(leastWeekday.label)에는 평균 \(volumeText(leastWeekday.averageIntakeML))로 가장 적게 마셨어요."
+        return L10n.tr(
+            "insightWeekdayInsightFormat",
+            bestWeekday.label,
+            volumeText(bestWeekday.averageIntakeML),
+            leastWeekday.label,
+            volumeText(leastWeekday.averageIntakeML)
+        )
     }
 
     var chartUpperBound: Double {
@@ -321,10 +336,10 @@ public final class HydrationInsightViewModel {
     }
 
     private func volumeText(_ volumeML: Double) -> String {
-        "\(Int(volumeML.rounded()))ml"
+        L10n.tr("commonMilliliterFormat", Int(volumeML.rounded()))
     }
 
     private func percentText(_ ratio: Double) -> String {
-        "\(Int((ratio * 100).rounded()))%"
+        L10n.tr("commonPercentFormat", Int((ratio * 100).rounded()))
     }
 }

--- a/Project/Presentation/Sources/ViewModel/HydrationRecordListViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationRecordListViewModel.swift
@@ -8,6 +8,7 @@
 
 import DomainLayerInterface
 import Foundation
+import Localization
 
 @Observable
 public final class HydrationRecordListViewModel {
@@ -61,7 +62,7 @@ public final class HydrationRecordListViewModel {
               let newDate = Calendar.current.date(
                 from: DateComponents(year: year, month: month, day: 1)
               ) else {
-            errorMessage = "Invalid date selection"
+            errorMessage = L10n.tr("historyInvalidDateSelectionError")
             return
         }
 
@@ -78,7 +79,7 @@ public final class HydrationRecordListViewModel {
             from: Calendar.current.dateComponents([.year, .month], from: date)
         ),
         let range = Calendar.current.range(of: .day, in: .month, for: startDate) else {
-            errorMessage = "Failed to calculate date range"
+            errorMessage = L10n.tr("historyFailedDateRangeError")
             return []
         }
 

--- a/Project/Presentation/Tests/DrinkWaterViewModelTests.swift
+++ b/Project/Presentation/Tests/DrinkWaterViewModelTests.swift
@@ -1,5 +1,6 @@
 import DomainLayerInterface
 import Foundation
+import Localization
 import Testing
 
 @testable import PresentationLayer
@@ -33,7 +34,7 @@ struct DrinkWaterViewModelTests {
         #expect(viewModel.mainAppearance == .heart)
         #expect(viewModel.dailyLimit == 1500)
         #expect(viewModel.currentWaterIntakeInMl == 500)
-        #expect(viewModel.mililiters == "500ml")
+        #expect(viewModel.mililiters == L10n.tr("commonMilliliterFormat", 500))
         #expect(viewModel.isLimitReached == false)
     }
 

--- a/Project/Presentation/Tests/HydrationRecordListViewModelTests.swift
+++ b/Project/Presentation/Tests/HydrationRecordListViewModelTests.swift
@@ -1,5 +1,6 @@
 import DomainLayerInterface
 import Foundation
+import Localization
 import Testing
 
 @testable import PresentationLayer
@@ -45,7 +46,7 @@ struct HydrationRecordListViewModelTests {
 
         await viewModel.updateDisplayedMonth(year: 2026, month: 13)
 
-        #expect(viewModel.errorMessage == "Invalid date selection")
+        #expect(viewModel.errorMessage == L10n.tr("historyInvalidDateSelectionError"))
     }
 
     @MainActor

--- a/Project/Shared/Localization/Project.swift
+++ b/Project/Shared/Localization/Project.swift
@@ -1,0 +1,32 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let bundleId = "gaeng2y.DrinkWater"
+
+let project = Project(
+    name: "Localization",
+    organizationName: "gaeng2y",
+    settings: .settings(
+        base: [
+            "APP_MARKETING_VERSION": .string(AppVersion.marketingVersion),
+            "APP_BUILD_NUMBER": .string(AppVersion.buildNumber),
+            "DEVELOPMENT_LANGUAGE": .string("ko"),
+            "SWIFT_VERSION": .string("6.0")
+        ],
+        configurations: [
+            .debug(name: "Debug"),
+            .release(name: "Release")
+        ]
+    ),
+    targets: [
+        .target(
+            name: "Localization",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "\(bundleId).Localization",
+            deploymentTargets: .iOS("18.0"),
+            sources: ["Sources/**"],
+            resources: ["Resources/**"]
+        )
+    ]
+)

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -1,0 +1,974 @@
+{
+  "sourceLanguage" : "ko",
+  "strings" : {
+    "commonApplyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "적용"
+          }
+        }
+      }
+    },
+    "commonCancelTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
+          }
+        }
+      }
+    },
+    "commonConfirmTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인"
+          }
+        }
+      }
+    },
+    "commonMilliliterFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lldml"
+          }
+        }
+      }
+    },
+    "commonWeekdayFridayShort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "금"
+          }
+        }
+      }
+    },
+    "commonWeekdayMondayShort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "월"
+          }
+        }
+      }
+    },
+    "commonMonthFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld월"
+          }
+        }
+      }
+    },
+    "commonPercentFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
+        }
+      }
+    },
+    "commonResetTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "초기화"
+          }
+        }
+      }
+    },
+    "commonWeekdaySaturdayShort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "토"
+          }
+        }
+      }
+    },
+    "commonWeekdaySundayShort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일"
+          }
+        }
+      }
+    },
+    "commonWeekdayThursdayShort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목"
+          }
+        }
+      }
+    },
+    "commonWeekdayTuesdayShort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "화"
+          }
+        }
+      }
+    },
+    "commonWeekdayWednesdayShort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수"
+          }
+        }
+      }
+    },
+    "commonWithdrawTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탈퇴"
+          }
+        }
+      }
+    },
+    "commonYearFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld년"
+          }
+        }
+      }
+    },
+    "drinkTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "섭취"
+          }
+        }
+      }
+    },
+    "drinkWaterButtonReachedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목표 달성!"
+          }
+        }
+      }
+    },
+    "drinkWaterButtonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마시기"
+          }
+        }
+      }
+    },
+    "drinkWaterCompleteLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료!"
+          }
+        }
+      }
+    },
+    "drinkWaterGlassCountFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld잔"
+          }
+        }
+      }
+    },
+    "drinkWaterGoalFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목표: %lldml"
+          }
+        }
+      }
+    },
+    "historyFailedDateRangeError" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날짜 범위를 계산하지 못했습니다."
+          }
+        }
+      }
+    },
+    "historyInvalidDateSelectionError" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "유효하지 않은 날짜 선택입니다."
+          }
+        }
+      }
+    },
+    "historyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기록"
+          }
+        }
+      }
+    },
+    "insightAchievementDaysFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lld일 달성"
+          }
+        }
+      }
+    },
+    "insightAchievementSummaryFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주 달성률 %@, 이번 달 달성률 %@"
+          }
+        }
+      }
+    },
+    "insightChartAverageIntakeAxisTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "평균 섭취량"
+          }
+        }
+      }
+    },
+    "insightChartGoalAxisTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목표"
+          }
+        }
+      }
+    },
+    "insightChartWeekdayAxisTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요일"
+          }
+        }
+      }
+    },
+    "insightDailyGoalFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하루 목표는 %@"
+          }
+        }
+      }
+    },
+    "insightElapsedDaysFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld일 기준"
+          }
+        }
+      }
+    },
+    "insightEmptyDescriptionFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 기록이 쌓이면 주간 평균, 달성률, streak, 요일 패턴을 한 번에 볼 수 있습니다. 오늘 목표는 %@입니다."
+          }
+        }
+      }
+    },
+    "insightEmptyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아직 보여줄 인사이트가 없어요"
+          }
+        }
+      }
+    },
+    "insightGoalRuleDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "점선은 하루 목표량을 뜻합니다."
+          }
+        }
+      }
+    },
+    "insightLeastDrankDayTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가장 적게 마신 날"
+          }
+        }
+      }
+    },
+    "insightLoadingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인사이트 불러오는 중..."
+          }
+        }
+      }
+    },
+    "insightMetricMonthlyAchievementTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "월간 달성률"
+          }
+        }
+      }
+    },
+    "insightMetricMonthlyAverageTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 달 평균"
+          }
+        }
+      }
+    },
+    "insightMetricWeeklyAchievementTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주간 달성률"
+          }
+        }
+      }
+    },
+    "insightMetricWeeklyAverageTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주 평균"
+          }
+        }
+      }
+    },
+    "insightMostDrankDayTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가장 많이 마신 날"
+          }
+        }
+      }
+    },
+    "insightNavigationTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인사이트"
+          }
+        }
+      }
+    },
+    "insightOverviewTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주와 이번 달 흐름"
+          }
+        }
+      }
+    },
+    "insightStreakAchievementLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연속 목표 달성"
+          }
+        }
+      }
+    },
+    "insightStreakCardSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 목표를 아직 채우지 않았다면 어제까지의 연속 달성일을 보여줍니다."
+          }
+        }
+      }
+    },
+    "insightStreakCardTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연속 달성 흐름"
+          }
+        }
+      }
+    },
+    "insightStreakPillTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 streak"
+          }
+        }
+      }
+    },
+    "insightStreakValueFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld일"
+          }
+        }
+      }
+    },
+    "insightThisMonthLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 달"
+          }
+        }
+      }
+    },
+    "insightThisWeekLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주"
+          }
+        }
+      }
+    },
+    "insightWeekdayBadgeValueFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · %lldml"
+          }
+        }
+      }
+    },
+    "insightWeekdayInsightFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@에 평균 %@로 가장 많이 마셨고, %@에는 평균 %@로 가장 적게 마셨어요."
+          }
+        }
+      }
+    },
+    "insightWeekdayInsightInsufficient" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 달 요일별 패턴을 만들 기록이 아직 부족합니다."
+          }
+        }
+      }
+    },
+    "insightWeekdayPatternTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 달 요일 패턴"
+          }
+        }
+      }
+    },
+    "mainAppearanceCloudDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "구름 모양으로 부드럽고 편안한 느낌을 줍니다"
+          }
+        }
+      }
+    },
+    "mainAppearanceCloudName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "구름"
+          }
+        }
+      }
+    },
+    "mainAppearanceDropDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "물방울 모양으로 물의 본질을 표현합니다"
+          }
+        }
+      }
+    },
+    "mainAppearanceDropName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "물방울"
+          }
+        }
+      }
+    },
+    "mainAppearanceHeartDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하트 모양으로 사랑스럽고 친근한 느낌을 줍니다"
+          }
+        }
+      }
+    },
+    "mainAppearanceHeartName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하트"
+          }
+        }
+      }
+    },
+    "recordCalendarMonthPickerAccessibilityHint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기록을 볼 년과 월을 선택합니다"
+          }
+        }
+      }
+    },
+    "recordCalendarMonthPickerAccessibilityLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "년월 선택"
+          }
+        }
+      }
+    },
+    "recordCalendarMonthPickerTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "월"
+          }
+        }
+      }
+    },
+    "recordCalendarMonthlyGoalTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "월 목표"
+          }
+        }
+      }
+    },
+    "recordCalendarSelectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "년/월 선택"
+          }
+        }
+      }
+    },
+    "recordCalendarYearPickerTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "년"
+          }
+        }
+      }
+    },
+    "settingDailyLimitDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하루 동안 마실 물의 목표량을 설정합니다"
+          }
+        }
+      }
+    },
+    "settingDailyLimitTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하루 목표량"
+          }
+        }
+      }
+    },
+    "settingMainShapeDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메인 화면의 디자인을 선택합니다"
+          }
+        }
+      }
+    },
+    "settingMainShapeTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메인 화면 모양"
+          }
+        }
+      }
+    },
+    "settingsDailyLimitSliderTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목표량"
+          }
+        }
+      }
+    },
+    "settingsDailyLimitValueFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld ml"
+          }
+        }
+      }
+    },
+    "settingsTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정"
+          }
+        }
+      }
+    },
+    "settingWithdrawalDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정을 영구적으로 삭제합니다"
+          }
+        }
+      }
+    },
+    "settingWithdrawalTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "회원 탈퇴"
+          }
+        }
+      }
+    },
+    "signInSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강한 수분 섭취를 위해\n로그인이 필요합니다"
+          }
+        }
+      }
+    },
+    "signInTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "물 마시기"
+          }
+        }
+      }
+    },
+    "signInWithAppleTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in with Apple"
+          }
+        }
+      }
+    },
+    "withdrawalActionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "회원 탈퇴하기"
+          }
+        }
+      }
+    },
+    "withdrawalConfirmationMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 작업은 되돌릴 수 없습니다. 모든 데이터가 영구적으로 삭제됩니다."
+          }
+        }
+      }
+    },
+    "withdrawalConfirmationTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정말 탈퇴하시겠습니까?"
+          }
+        }
+      }
+    },
+    "withdrawalDeleteAccountItem" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정 정보 삭제"
+          }
+        }
+      }
+    },
+    "withdrawalDeletePreferencesItem" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개인 설정 정보 삭제"
+          }
+        }
+      }
+    },
+    "withdrawalDeleteRecordsItem" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장된 물 섭취 기록 삭제"
+          }
+        }
+      }
+    },
+    "withdrawalDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정을 삭제하면 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다."
+          }
+        }
+      }
+    },
+    "withdrawalFailureTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탈퇴 실패"
+          }
+        }
+      }
+    },
+    "withdrawalProgressTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탈퇴 처리 중..."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Project/Shared/Localization/Sources/L10n.swift
+++ b/Project/Shared/Localization/Sources/L10n.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public enum L10n {
+    private final class BundleToken {}
+    private static let tableName = "Localizable"
+
+    public static let bundle: Bundle = Bundle(for: BundleToken.self)
+    private static let fallbackBundle: Bundle? = {
+        guard let path = bundle.path(forResource: "ko", ofType: "lproj") else {
+            return nil
+        }
+
+        return Bundle(path: path)
+    }()
+
+    public static func tr(_ key: String) -> String {
+        localizedString(forKey: key)
+    }
+
+    public static func tr(_ key: String, _ arguments: CVarArg...) -> String {
+        String(format: localizedString(forKey: key), locale: .current, arguments: arguments)
+    }
+
+    private static func localizedString(forKey key: String) -> String {
+        let localized = bundle.localizedString(forKey: key, value: nil, table: tableName)
+        if localized != key {
+            return localized
+        }
+
+        guard let fallbackBundle else {
+            return localized
+        }
+
+        return fallbackBundle.localizedString(forKey: key, value: nil, table: tableName)
+    }
+}


### PR DESCRIPTION
## 📝 Summary
Shared 레이어에 `Localization` 모듈을 추가하고, 앱에서 사용하는 문자열을 camelCase 키 기반 String Catalog로 정리했습니다.
또한 `L10n` lookup이 프레임워크 번들에서 `ko.lproj`로 fallback 하도록 보완해 키가 그대로 노출되던 문제를 수정했습니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [x] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [x] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [x] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #116

## 📋 Changes Made
### Added
- `Project/Shared/Localization` 모듈 추가
- `Localizable.xcstrings`와 `L10n` helper 추가

### Changed
- `App`, `PresentationLayer`, `DomainLayerInterface`가 `Shared/Localization`을 참조하도록 의존성 정리
- 앱 표시 문자열을 camelCase 키 기반 String Catalog lookup으로 전환
- `PresentationLayerTests`가 `Localization`을 링크하도록 수정
- 문자열 기대값을 사용하는 테스트를 `L10n.tr(...)` 기준으로 수정

### Fixed
- 기기/시뮬레이터 언어와 무관하게 `Localization.framework`에서 `ko.lproj` fallback이 동작하도록 수정
- 화면에 `drinkTitle` 같은 raw key가 노출되던 문제 수정

### Removed
- Domain 리소스에 둘 필요가 없던 localization 책임을 Shared 모듈로 이동

## 🔍 Technical Details
- `L10n`은 `Bundle(for:)` 기반으로 `Localization.framework`를 읽고, 기본 lookup이 실패하면 `ko.lproj`로 fallback 합니다.
- `Localization` 타깃의 `DEVELOPMENT_LANGUAGE`를 `ko`로 지정했습니다.
- 문자열 포맷 키(`commonMilliliterFormat`, `commonPercentFormat` 등)도 String Catalog로 통일했습니다.

## 📸 Screenshots / Videos
### Before
- 일부 화면에서 localized string 대신 key 값이 그대로 표시됨

### After
- `Localization.framework`의 String Catalog를 통해 한국어 문자열이 정상 표시됨

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS 26.2 Simulator
- Device: iPhone 17
- Xcode Version: 17C529

### Test Results
- `tuist generate` 성공
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,name=iPhone 17'` 통과
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` 성공

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- Widget 문자열은 이번 PR 범위에 포함하지 않았습니다.
- `Localization`은 Shared 모듈이므로 이후 다른 레이어에서도 동일한 방식으로 재사용할 수 있습니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [x] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
