### PR TITLE
fix: polish settings menu labels and navigation

### DIFF
--- a/Project/Presentation/Sources/View/Settings/SettingDetailView.swift
+++ b/Project/Presentation/Sources/View/Settings/SettingDetailView.swift
@@ -32,6 +32,7 @@ public struct SettingDetailView: View {
                 WithdrawalSettingView(viewModel: viewModel)
             }
         }
+        .toolbar(.hidden, for: .tabBar)
     }
 }
 

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -777,7 +777,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "메인 화면 모양"
+            "value" : "메인 아이콘"
           }
         }
       }


### PR DESCRIPTION
## 📝 Summary
설정 탭의 메뉴 표현과 상세 화면 내비게이션 동작을 정리했습니다.
메뉴 명칭을 `메인 아이콘`으로 수정하고, 설정 상세 화면 진입 시 탭 바가 숨겨지도록 조정했습니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [x] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [x] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [ ] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Related to #80

## 📋 Changes Made
### Added
-

### Changed
- 설정 메뉴의 `메인 화면 모양` 표시명을 `메인 아이콘`으로 변경
- `SettingDetailView` 진입 시 탭 바가 숨겨지도록 변경

### Fixed
- 설정 상세 화면에서 하단 탭 바가 계속 노출되던 UI 동작 수정

### Removed
-

## 🔍 Technical Details
- `SettingDetailView`에 `.toolbar(.hidden, for: .tabBar)`를 적용했습니다.
- localization key는 유지하고 `settingMainShapeTitle`의 한국어 값만 수정했습니다.

## 📸 Screenshots / Videos
### Before
- 설정 상세 화면 진입 후에도 탭 바가 계속 표시됨
- 메뉴명이 `메인 화면 모양`으로 노출됨

### After
- 설정 상세 화면에서 탭 바가 숨겨짐
- 메뉴명이 `메인 아이콘`으로 표시됨

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS 26.2 Simulator
- Device: iPhone 17
- Xcode Version: 17C529

### Test Results
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` 성공

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- 이번 PR은 설정 탭 UX 정리 성격의 소규모 후속 수정입니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [x] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
