### PR TITLE
feat: refine routine notification permission UX (#123)

### DIFF
--- a/Project/Data/Sources/Repository/RoutineRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/RoutineRepositoryImpl.swift
@@ -27,30 +27,15 @@ public struct RoutineRepositoryImpl: RoutineRepository {
     }
 
     public func saveRoutine(_ routine: HydrationRoutine) async throws {
-        var routines = storageDataSource.fetchRoutines()
-        var routineToSave = routine
-
-        if routineToSave.isEnabled {
+        if routine.isEnabled {
             let currentStatus = await notificationDataSource.authorizationStatus()
-            let resolvedStatus: RoutineNotificationAuthorizationStatus
-
-            switch currentStatus {
-            case .notDetermined:
-                resolvedStatus = try await notificationDataSource.requestAuthorization()
-            case .denied, .authorized:
-                resolvedStatus = currentStatus
-            }
-
-            if resolvedStatus != .authorized {
-                routineToSave.isEnabled = false
-                routines = upsert(routineToSave, in: routines)
-                storageDataSource.saveRoutines(routines.sorted(by: sortRoutines(lhs:rhs:)))
-                try await notificationDataSource.scheduleNotifications(for: routines.filter(\.isEnabled))
+            guard currentStatus == .authorized else {
                 throw RoutineError.permissionDenied
             }
         }
 
-        routines = upsert(routineToSave, in: routines)
+        var routines = storageDataSource.fetchRoutines()
+        routines = upsert(routine, in: routines)
         storageDataSource.saveRoutines(routines.sorted(by: sortRoutines(lhs:rhs:)))
         try await notificationDataSource.scheduleNotifications(for: routines.filter(\.isEnabled))
     }

--- a/Project/Data/Tests/RoutineRepositoryImplTests.swift
+++ b/Project/Data/Tests/RoutineRepositoryImplTests.swift
@@ -45,10 +45,11 @@ struct RoutineRepositoryImplTests {
         }
     }
 
-    @Test("saveRoutine는 권한이 미정이면 요청 후 스케줄링한다")
-    func saveRoutineRequestsPermissionAndSchedules() async throws {
+    @Test("saveRoutine는 권한이 허용된 활성 루틴을 저장하고 스케줄링한다")
+    func saveRoutineSchedulesAuthorizedRoutine() async throws {
         let storage = SpyRoutineStorageDataSource()
         let notification = SpyRoutineNotificationDataSource()
+        notification.authorizationStatusValue = .authorized
         let repository = RoutineRepositoryImpl(
             storageDataSource: storage,
             notificationDataSource: notification
@@ -63,13 +64,13 @@ struct RoutineRepositoryImplTests {
 
         try await repository.saveRoutine(routine)
 
-        #expect(notification.requestAuthorizationCallCount == 1)
+        #expect(notification.requestAuthorizationCallCount == 0)
         #expect(storage.savedRoutines == [routine])
         #expect(notification.scheduledRoutines == [routine])
     }
 
-    @Test("saveRoutine는 권한이 거부되면 비활성 상태로 저장하고 에러를 던진다")
-    func saveRoutineDisabledWhenPermissionDenied() async {
+    @Test("saveRoutine는 권한이 거부된 활성 루틴을 저장하지 않고 에러를 던진다")
+    func saveRoutineDeniedPermission() async {
         let storage = SpyRoutineStorageDataSource()
         let notification = SpyRoutineNotificationDataSource()
         notification.authorizationStatusValue = .denied
@@ -89,8 +90,33 @@ struct RoutineRepositoryImplTests {
             try await repository.saveRoutine(routine)
         }
 
-        #expect(storage.savedRoutines.count == 1)
-        #expect(storage.savedRoutines[0].isEnabled == false)
+        #expect(storage.savedRoutines.isEmpty)
+        #expect(notification.scheduledRoutines.isEmpty)
+    }
+
+    @Test("saveRoutine는 권한이 미정인 활성 루틴을 저장하지 않고 에러를 던진다")
+    func saveRoutineNotDeterminedPermission() async {
+        let storage = SpyRoutineStorageDataSource()
+        let notification = SpyRoutineNotificationDataSource()
+        notification.authorizationStatusValue = .notDetermined
+        let repository = RoutineRepositoryImpl(
+            storageDataSource: storage,
+            notificationDataSource: notification
+        )
+        let routine = HydrationRoutine(
+            title: "오후 루틴",
+            hour: 15,
+            minute: 0,
+            weekdays: [.wednesday],
+            isEnabled: true
+        )
+
+        await #expect(throws: RoutineError.permissionDenied) {
+            try await repository.saveRoutine(routine)
+        }
+
+        #expect(notification.requestAuthorizationCallCount == 0)
+        #expect(storage.savedRoutines.isEmpty)
         #expect(notification.scheduledRoutines.isEmpty)
     }
 

--- a/Project/Presentation/Sources/View/Profile/ProfileRoutineView.swift
+++ b/Project/Presentation/Sources/View/Profile/ProfileRoutineView.swift
@@ -187,17 +187,19 @@ public struct ProfileRoutineView: View {
         case .denied:
             Section {
                 Button(L10n.tr("profileRoutineOpenSettingsTitle")) {
-                    guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
-                        return
-                    }
-
-                    openURL(settingsURL)
+                    openSettings()
                 }
             } footer: {
                 Text(L10n.tr("profileRoutinePermissionDeniedDescription"))
             }
         case .authorized:
-            EmptyView()
+            Section {
+                Label(
+                    L10n.tr("profileRoutinePermissionAuthorizedDescription"),
+                    systemImage: "checkmark.circle.fill"
+                )
+                .foregroundStyle(.green)
+            }
         }
     }
 
@@ -231,5 +233,13 @@ public struct ProfileRoutineView: View {
         .padding(12)
         .background(Color.secondary.opacity(0.08))
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func openSettings() {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+
+        openURL(settingsURL)
     }
 }

--- a/Project/Presentation/Sources/View/Profile/RoutineEditorView.swift
+++ b/Project/Presentation/Sources/View/Profile/RoutineEditorView.swift
@@ -1,8 +1,10 @@
 import DomainLayerInterface
 import Localization
 import SwiftUI
+import UIKit
 
 struct RoutineEditorView: View {
+    @Environment(\.openURL) private var openURL
     @Bindable private var viewModel: ProfileRoutineViewModel
 
     init(viewModel: ProfileRoutineViewModel) {
@@ -41,6 +43,28 @@ struct RoutineEditorView: View {
                     )
                 }
 
+                if let guidance = viewModel.editorPermissionGuidance {
+                    Section(L10n.tr("profileRoutineEditorPermissionSectionTitle")) {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(guidance.title)
+                                .font(.headline)
+
+                            Text(guidance.description)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+
+                            if guidance.showsOpenSettingsAction {
+                                Button(L10n.tr("profileRoutineOpenSettingsTitle")) {
+                                    openSettings()
+                                }
+                                .padding(.top, 4)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+
                 Section {
                     weekdayGrid
                 } header: {
@@ -71,6 +95,47 @@ struct RoutineEditorView: View {
                     .disabled(!viewModel.canSaveDraft || viewModel.isSaving)
                 }
             }
+        }
+        .alert(
+            viewModel.permissionPromptTitle,
+            isPresented: Binding(
+                get: { viewModel.permissionPrompt != nil },
+                set: { if !$0 { viewModel.dismissPermissionPrompt() } }
+            )
+        ) {
+            switch viewModel.permissionPrompt {
+            case .requestAuthorization:
+                Button(L10n.tr("profileRoutineRequestPermissionTitle")) {
+                    Task {
+                        await viewModel.requestDraftNotificationAuthorization()
+                    }
+                }
+
+                Button(L10n.tr("commonCancelTitle"), role: .cancel) {
+                    viewModel.dismissPermissionPrompt()
+                }
+            case .openSettings:
+                Button(L10n.tr("profileRoutineOpenSettingsTitle")) {
+                    viewModel.dismissPermissionPrompt()
+                    openSettings()
+                }
+
+                Button(L10n.tr("profileRoutineSaveWithoutNotificationsTitle")) {
+                    Task {
+                        await viewModel.saveDraftWithoutNotifications()
+                    }
+                }
+
+                Button(L10n.tr("commonCancelTitle"), role: .cancel) {
+                    viewModel.dismissPermissionPrompt()
+                }
+            case .none:
+                Button(L10n.tr("commonConfirmTitle"), role: .cancel) {
+                    viewModel.dismissPermissionPrompt()
+                }
+            }
+        } message: {
+            Text(viewModel.permissionPromptMessage)
         }
     }
 
@@ -103,5 +168,13 @@ struct RoutineEditorView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    private func openSettings() {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+
+        openURL(settingsURL)
     }
 }

--- a/Project/Presentation/Sources/ViewModel/ProfileRoutineViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/ProfileRoutineViewModel.swift
@@ -19,6 +19,19 @@ struct RoutineGuidanceSummary: Equatable {
     let actualValueText: String?
 }
 
+enum RoutinePermissionPrompt: String, Identifiable, Equatable {
+    case requestAuthorization
+    case openSettings
+
+    var id: String { rawValue }
+}
+
+struct RoutinePermissionGuidance: Equatable {
+    let title: String
+    let description: String
+    let showsOpenSettingsAction: Bool
+}
+
 struct RoutineEditorDraft: Equatable {
     var id: UUID?
     var title: String
@@ -93,6 +106,7 @@ public final class ProfileRoutineViewModel {
     public var isEditorPresented = false
     public var isSaving = false
     public var errorMessage: String?
+    var permissionPrompt: RoutinePermissionPrompt?
     var editorDraft = RoutineEditorDraft()
 
     public init(
@@ -183,6 +197,55 @@ public final class ProfileRoutineViewModel {
         editorDraft.isEditing
     }
 
+    var editorPermissionGuidance: RoutinePermissionGuidance? {
+        guard editorDraft.isEnabled else {
+            return nil
+        }
+
+        switch notificationStatus {
+        case .authorized:
+            return RoutinePermissionGuidance(
+                title: L10n.tr("profileRoutineEditorPermissionAuthorizedTitle"),
+                description: L10n.tr("profileRoutineEditorPermissionAuthorizedDescription"),
+                showsOpenSettingsAction: false
+            )
+        case .notDetermined:
+            return RoutinePermissionGuidance(
+                title: L10n.tr("profileRoutineEditorPermissionPendingTitle"),
+                description: L10n.tr("profileRoutineEditorPermissionPendingDescription"),
+                showsOpenSettingsAction: false
+            )
+        case .denied:
+            return RoutinePermissionGuidance(
+                title: L10n.tr("profileRoutineEditorPermissionDeniedTitle"),
+                description: L10n.tr("profileRoutineEditorPermissionDeniedDescription"),
+                showsOpenSettingsAction: true
+            )
+        }
+    }
+
+    var permissionPromptTitle: String {
+        switch permissionPrompt {
+        case .requestAuthorization:
+            return L10n.tr("profileRoutinePermissionRequestAlertTitle")
+        case .openSettings:
+            return L10n.tr("profileRoutinePermissionDeniedAlertTitle")
+        case .none:
+            return ""
+        }
+    }
+
+    var permissionPromptMessage: String {
+        switch permissionPrompt {
+        case .requestAuthorization:
+            return L10n.tr("profileRoutinePermissionRequestAlertMessage")
+        case .openSettings:
+            return L10n.tr("profileRoutinePermissionDeniedAlertMessage")
+        case .none:
+            return ""
+        }
+    }
+
     var guidanceSummary: RoutineGuidanceSummary {
         let todayRoutines = todayActiveRoutines
 
@@ -245,17 +308,20 @@ public final class ProfileRoutineViewModel {
     }
 
     public func presentCreateRoutine() {
+        permissionPrompt = nil
         editorDraft = RoutineEditorDraft()
         isEditorPresented = true
     }
 
     public func presentEditRoutine(_ routine: HydrationRoutine) {
+        permissionPrompt = nil
         editorDraft = RoutineEditorDraft(routine: routine)
         isEditorPresented = true
     }
 
     public func dismissEditor() {
         isEditorPresented = false
+        permissionPrompt = nil
         editorDraft = RoutineEditorDraft()
     }
 
@@ -273,23 +339,51 @@ public final class ProfileRoutineViewModel {
             return
         }
 
-        isSaving = true
-        defer { isSaving = false }
+        permissionPrompt = nil
+        let routine = editorDraft.makeRoutine()
 
+        guard routine.isEnabled else {
+            await persistDraft(routine)
+            return
+        }
+
+        notificationStatus = await routineUseCase.notificationAuthorizationStatus()
+
+        switch notificationStatus {
+        case .authorized:
+            await persistDraft(routine)
+        case .notDetermined:
+            permissionPrompt = .requestAuthorization
+        case .denied:
+            permissionPrompt = .openSettings
+        }
+    }
+
+    public func requestDraftNotificationAuthorization() async {
         do {
-            try await routineUseCase.saveRoutine(editorDraft.makeRoutine())
-            await load()
-            dismissEditor()
-        } catch let error as RoutineError {
-            await load()
-            dismissEditor()
-            switch error {
-            case .permissionDenied:
-                errorMessage = L10n.tr("profileRoutinePermissionDeniedError")
+            notificationStatus = try await routineUseCase.requestNotificationAuthorization()
+
+            switch notificationStatus {
+            case .authorized:
+                permissionPrompt = nil
+                await persistDraft(editorDraft.makeRoutine())
+            case .notDetermined, .denied:
+                permissionPrompt = .openSettings
             }
         } catch {
-            errorMessage = L10n.tr("profileRoutineSaveError")
+            errorMessage = L10n.tr("profileRoutineAuthorizationRequestError")
         }
+    }
+
+    public func saveDraftWithoutNotifications() async {
+        var routine = editorDraft.makeRoutine()
+        routine.isEnabled = false
+        permissionPrompt = nil
+        await persistDraft(routine)
+    }
+
+    public func dismissPermissionPrompt() {
+        permissionPrompt = nil
     }
 
     public func deleteRoutine(_ routine: HydrationRoutine) async {
@@ -303,6 +397,25 @@ public final class ProfileRoutineViewModel {
 
     public func clearErrorMessage() {
         errorMessage = nil
+    }
+
+    private func persistDraft(_ routine: HydrationRoutine) async {
+        isSaving = true
+        defer { isSaving = false }
+
+        do {
+            try await routineUseCase.saveRoutine(routine)
+            await load()
+            dismissEditor()
+        } catch let error as RoutineError {
+            switch error {
+            case .permissionDenied:
+                notificationStatus = await routineUseCase.notificationAuthorizationStatus()
+                permissionPrompt = .openSettings
+            }
+        } catch {
+            errorMessage = L10n.tr("profileRoutineSaveError")
+        }
     }
 
     private var activeRoutineCountText: String {

--- a/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
+++ b/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
@@ -13,6 +13,7 @@ struct ProfileRoutineViewModelTests {
         var requestAuthorizationResult: Result<RoutineNotificationAuthorizationStatus, Error> = .success(.authorized)
         private(set) var savedRoutine: HydrationRoutine?
         private(set) var deletedRoutineID: UUID?
+        private(set) var requestAuthorizationCallCount = 0
 
         func fetchRoutines() -> [HydrationRoutine] {
             routines
@@ -23,6 +24,7 @@ struct ProfileRoutineViewModelTests {
         }
 
         func requestNotificationAuthorization() async throws -> RoutineNotificationAuthorizationStatus {
+            requestAuthorizationCallCount += 1
             switch requestAuthorizationResult {
             case .success(let status):
                 authorizationStatus = status
@@ -166,6 +168,7 @@ struct ProfileRoutineViewModelTests {
     @Test("saveDraft는 유효한 루틴을 저장하고 시트를 닫는다")
     func saveDraft() async {
         let useCase = SpyRoutineUseCase()
+        useCase.authorizationStatus = .authorized
         let viewModel = makeViewModel(routineUseCase: useCase)
 
         viewModel.presentCreateRoutine()
@@ -177,6 +180,80 @@ struct ProfileRoutineViewModelTests {
         #expect(useCase.savedRoutine?.title == "오후 루틴")
         #expect(viewModel.isEditorPresented == false)
         #expect(viewModel.displayedRoutines.count == 1)
+    }
+
+    @MainActor
+    @Test("saveDraft는 권한이 미정이면 권한 요청 안내를 먼저 노출한다")
+    func saveDraftShowsAuthorizationPromptWhenStatusIsNotDetermined() async {
+        let useCase = SpyRoutineUseCase()
+        useCase.authorizationStatus = .notDetermined
+        let viewModel = makeViewModel(routineUseCase: useCase)
+
+        viewModel.presentCreateRoutine()
+        viewModel.editorDraft.title = "오후 루틴"
+        viewModel.editorDraft.selectedWeekdays = [.monday, .wednesday]
+
+        await viewModel.saveDraft()
+
+        #expect(useCase.savedRoutine == nil)
+        #expect(viewModel.permissionPrompt == .requestAuthorization)
+        #expect(viewModel.isEditorPresented == true)
+    }
+
+    @MainActor
+    @Test("권한 요청이 허용되면 활성 루틴을 저장하고 에디터를 닫는다")
+    func requestDraftAuthorizationAndSave() async {
+        let useCase = SpyRoutineUseCase()
+        useCase.authorizationStatus = .notDetermined
+        useCase.requestAuthorizationResult = .success(.authorized)
+        let viewModel = makeViewModel(routineUseCase: useCase)
+
+        viewModel.presentCreateRoutine()
+        viewModel.editorDraft.title = "오후 루틴"
+        viewModel.editorDraft.selectedWeekdays = [.monday, .wednesday]
+        await viewModel.saveDraft()
+        await viewModel.requestDraftNotificationAuthorization()
+
+        #expect(useCase.requestAuthorizationCallCount == 1)
+        #expect(useCase.savedRoutine?.isEnabled == true)
+        #expect(viewModel.permissionPrompt == nil)
+        #expect(viewModel.isEditorPresented == false)
+    }
+
+    @MainActor
+    @Test("saveDraft는 권한이 거부된 상태면 설정 이동 안내를 노출한다")
+    func saveDraftShowsOpenSettingsPromptWhenDenied() async {
+        let useCase = SpyRoutineUseCase()
+        useCase.authorizationStatus = .denied
+        let viewModel = makeViewModel(routineUseCase: useCase)
+
+        viewModel.presentCreateRoutine()
+        viewModel.editorDraft.title = "오후 루틴"
+        viewModel.editorDraft.selectedWeekdays = [.monday, .wednesday]
+
+        await viewModel.saveDraft()
+
+        #expect(useCase.savedRoutine == nil)
+        #expect(viewModel.permissionPrompt == .openSettings)
+        #expect(viewModel.isEditorPresented == true)
+    }
+
+    @MainActor
+    @Test("알림 없이 저장을 선택하면 비활성 루틴으로 저장한다")
+    func saveDraftWithoutNotifications() async {
+        let useCase = SpyRoutineUseCase()
+        useCase.authorizationStatus = .denied
+        let viewModel = makeViewModel(routineUseCase: useCase)
+
+        viewModel.presentCreateRoutine()
+        viewModel.editorDraft.title = "오후 루틴"
+        viewModel.editorDraft.selectedWeekdays = [.monday, .wednesday]
+        await viewModel.saveDraft()
+        await viewModel.saveDraftWithoutNotifications()
+
+        #expect(useCase.savedRoutine?.isEnabled == false)
+        #expect(viewModel.permissionPrompt == nil)
+        #expect(viewModel.isEditorPresented == false)
     }
 
     @MainActor

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -1134,6 +1134,83 @@
         }
       }
     },
+    "profileRoutineEditorPermissionAuthorizedDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 루틴을 활성 상태로 저장하면 선택한 시간에 알림을 보냅니다."
+          }
+        }
+      }
+    },
+    "profileRoutineEditorPermissionAuthorizedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림이 켜져 있어요"
+          }
+        }
+      }
+    },
+    "profileRoutineEditorPermissionDeniedDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 알림이 거부되어 있어 활성 루틴을 저장할 수 없습니다. 설정에서 허용하거나 알림 없이 저장하세요."
+          }
+        }
+      }
+    },
+    "profileRoutineEditorPermissionDeniedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "먼저 알림 권한을 켜주세요"
+          }
+        }
+      }
+    },
+    "profileRoutineEditorPermissionPendingDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 루틴을 활성 상태로 저장하면 시스템 알림 권한 요청이 표시됩니다."
+          }
+        }
+      }
+    },
+    "profileRoutineEditorPermissionPendingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장할 때 권한을 요청해요"
+          }
+        }
+      }
+    },
+    "profileRoutineEditorPermissionSectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림 안내"
+          }
+        }
+      }
+    },
     "profileRoutineEditorTimeSectionTitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1299,6 +1376,28 @@
         }
       }
     },
+    "profileRoutinePermissionDeniedAlertMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정에서 알림을 허용하면 이 루틴을 활성 상태로 저장할 수 있습니다. 지금은 알림 없이 저장할 수도 있어요."
+          }
+        }
+      }
+    },
+    "profileRoutinePermissionDeniedAlertTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림 권한이 꺼져 있어요"
+          }
+        }
+      }
+    },
     "profileRoutinePermissionDeniedError" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1317,6 +1416,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "루틴을 활성화하려면 알림 권한이 필요합니다."
+          }
+        }
+      }
+    },
+    "profileRoutinePermissionRequestAlertMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성 루틴은 설정한 시간마다 알림을 보내기 위해 권한이 필요합니다."
+          }
+        }
+      }
+    },
+    "profileRoutinePermissionRequestAlertTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "루틴 알림을 허용할까요?"
+          }
+        }
+      }
+    },
+    "profileRoutinePermissionAuthorizedDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림이 허용되어 있어 활성 루틴을 저장하면 바로 스케줄됩니다."
           }
         }
       }
@@ -1383,6 +1515,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "루틴 저장 중 문제가 발생했어요. 잠시 후 다시 시도해주세요."
+          }
+        }
+      }
+    },
+    "profileRoutineSaveWithoutNotificationsTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림 없이 저장"
           }
         }
       }


### PR DESCRIPTION
## 📝 Summary
루틴 알림 저장 흐름의 권한 UX를 상태별로 정리했습니다. 저장 시점에 권한 요청/설정 이동/알림 없이 저장 선택지를 명시적으로 제공하고, repository는 권한 요청이 아닌 저장 가능 여부 판단에만 집중하도록 조정했습니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [x] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #123
- Related to #94

## 📋 Changes Made
### Added
- 루틴 에디터 권한 안내 섹션과 상태별 alert UX
- 알림 없이 저장 선택지와 권한 요청 후 재저장 흐름
- 권한 상태별 저장 정책 테스트

### Changed
- `ProfileRoutineViewModel`에서 저장/권한 요청/설정 이동 흐름을 직접 제어하도록 조정
- `RoutineRepositoryImpl`은 권한 요청을 직접 수행하지 않고 활성 루틴 저장 가능 여부만 판단하도록 변경
- 프로필 루틴 화면의 권한 섹션에 허용 상태 안내를 추가

### Fixed
- `notDetermined` 상태에서 저장이 바로 진행되던 흐름을 명시적 권한 요청 UX로 수정
- `denied` 상태에서 비활성 저장으로 바로 떨어지던 흐름을 설정 이동 또는 알림 없이 저장 선택으로 분리

### Removed
- repository 내부의 implicit notification permission request

## 🔍 Technical Details
- 권한 프롬프트 상태를 `ProfileRoutineViewModel`의 presentation state로 추가했습니다.
- 저장 전 현재 권한 상태를 조회하고 `authorized`, `notDetermined`, `denied`를 각각 다른 액션으로 분기합니다.
- repository는 활성 루틴 저장 시 권한이 없으면 `RoutineError.permissionDenied`만 반환합니다.

## 📸 Screenshots / Videos
### Before
- 활성 루틴 저장 시 repository 내부에서 바로 권한 요청 또는 비활성 저장 처리
- 거절 상태에서 사용자가 다음 액션을 선택하기 어려움

### After
- 에디터에서 현재 권한 상태를 먼저 안내
- 저장 시 권한 요청, 설정 이동, 알림 없이 저장 흐름을 명시적으로 선택 가능

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [x] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS Simulator 26.2
- Device: iPhone 17
- Xcode Version: 17C529

### Test Results
- `tuist generate`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination "platform=iOS Simulator,name=iPhone 17"`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme DataLayer -destination "platform=iOS Simulator,name=iPhone 17"`
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- 권한 고도화는 루틴 저장 시점 UX에 집중했고, 설정 앱 복귀 후 상태 갱신은 기존 `didBecomeActive` 갱신 흐름을 유지합니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
