### PR TITLE
feat: advance profile routine guidance (#124)

### DIFF
--- a/Project/Presentation/Sources/View/HydrationInsight/HydrationInsightView.swift
+++ b/Project/Presentation/Sources/View/HydrationInsight/HydrationInsightView.swift
@@ -56,19 +56,6 @@ public struct HydrationInsightView: View {
         ScrollView {
             VStack(spacing: 18) {
                 overviewCard
-
-                LazyVGrid(
-                    columns: [
-                        GridItem(.flexible(), spacing: 14),
-                        GridItem(.flexible(), spacing: 14)
-                    ],
-                    spacing: 14
-                ) {
-                    ForEach(viewModel.metrics) { metric in
-                        MetricCard(metric: metric)
-                    }
-                }
-
                 streakCard
                 weekdayPatternCard
             }
@@ -105,30 +92,18 @@ public struct HydrationInsightView: View {
                     Text(L10n.tr("insightDailyGoalFormat", viewModel.dailyGoalText))
                         .font(.title3.weight(.bold))
                         .foregroundStyle(.white)
-                    Text(
-                        L10n.tr(
-                            "insightAchievementSummaryFormat",
-                            viewModel.weeklyAchievementText,
-                            viewModel.monthlyAchievementText
-                        )
-                    )
-                        .font(.subheadline)
-                        .foregroundStyle(.white.opacity(0.88))
-                        .fixedSize(horizontal: false, vertical: true)
                 }
 
-                HStack(spacing: 12) {
-                    PillLabel(
-                        title: L10n.tr("insightStreakPillTitle"),
-                        value: viewModel.streakText
-                    )
-                    PillLabel(
-                        title: L10n.tr("insightThisMonthLabel"),
-                        value: L10n.tr(
-                            "commonMilliliterFormat",
-                            Int(viewModel.monthlyAverageML.rounded())
-                        )
-                    )
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(), spacing: 12),
+                        GridItem(.flexible(), spacing: 12)
+                    ],
+                    spacing: 12
+                ) {
+                    ForEach(viewModel.metrics) { metric in
+                        OverviewMetricTile(metric: metric)
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -308,32 +283,27 @@ private struct InsightCard<Content: View>: View {
     }
 }
 
-private struct MetricCard: View {
+private struct OverviewMetricTile: View {
     let metric: HydrationInsightMetric
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(metric.title)
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.white.opacity(0.78))
 
             Text(metric.value)
                 .font(.title3.weight(.bold))
+                .foregroundStyle(.white)
 
             Text(metric.detail)
                 .font(.footnote)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.white.opacity(0.72))
         }
-        .frame(maxWidth: .infinity, minHeight: 118, alignment: .leading)
-        .padding(18)
-        .background(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(Color(uiColor: .systemBackground))
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .stroke(Color.black.opacity(0.04), lineWidth: 1)
-        }
+        .frame(maxWidth: .infinity, minHeight: 84, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(.white.opacity(0.14), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
     }
 }
 
@@ -377,24 +347,5 @@ private struct BadgeView: View {
             Capsule(style: .continuous)
                 .fill(Color(uiColor: .systemBackground))
         )
-    }
-}
-
-private struct PillLabel: View {
-    let title: String
-    let value: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(title)
-                .font(.caption2)
-                .foregroundStyle(.white.opacity(0.75))
-            Text(value)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.white)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .background(.white.opacity(0.14), in: Capsule(style: .continuous))
     }
 }

--- a/Project/Presentation/Sources/View/Profile/ProfileRoutineView.swift
+++ b/Project/Presentation/Sources/View/Profile/ProfileRoutineView.swift
@@ -117,36 +117,72 @@ public struct ProfileRoutineView: View {
     }
 
     private var guidanceCard: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(viewModel.guidanceSummary.badgeText)
+        let summary = viewModel.guidanceSummary
+
+        return VStack(alignment: .leading, spacing: 16) {
+            Text(summary.badgeText)
                 .font(.caption)
                 .fontWeight(.semibold)
-                .foregroundColor(.accentColor)
+                .foregroundColor(guidanceToneColor(summary.tone))
 
-            Text(viewModel.guidanceSummary.headline)
+            Text(summary.headline)
                 .font(.headline)
 
-            Text(viewModel.guidanceSummary.description)
+            Text(summary.description)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            if let recommendedValueText = viewModel.guidanceSummary.recommendedValueText,
-               let actualValueText = viewModel.guidanceSummary.actualValueText {
-                HStack(spacing: 12) {
-                    guidanceMetric(
-                        title: L10n.tr("profileRoutineGuidanceRecommendedTitle"),
-                        value: recommendedValueText
+            if !summary.metrics.isEmpty {
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(), spacing: 10),
+                        GridItem(.flexible(), spacing: 10),
+                        GridItem(.flexible(), spacing: 10)
+                    ],
+                    spacing: 10
+                ) {
+                    ForEach(summary.metrics) { metric in
+                        guidanceMetric(metric)
+                    }
+                }
+            }
+
+            if let nextRoutineValueText = summary.nextRoutineValueText,
+               let remainingRoutineValueText = summary.remainingRoutineValueText {
+                HStack(spacing: 10) {
+                    guidanceInfoCard(
+                        title: L10n.tr("profileRoutineGuidanceNextRoutineTitle"),
+                        value: nextRoutineValueText,
+                        systemImage: "clock"
                     )
 
-                    guidanceMetric(
-                        title: L10n.tr("profileRoutineGuidanceActualTitle"),
-                        value: actualValueText
+                    guidanceInfoCard(
+                        title: L10n.tr("profileRoutineGuidanceRemainingTitle"),
+                        value: remainingRoutineValueText,
+                        systemImage: "list.bullet"
                     )
                 }
             }
 
-            Text(viewModel.guidanceSummary.footnote)
+            if !summary.slots.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(L10n.tr("profileRoutineGuidanceTimelineTitle"))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(summary.slots) { slot in
+                                guidanceSlotChip(slot)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            }
+
+            Text(summary.footnote)
                 .font(.footnote)
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -184,20 +220,98 @@ public struct ProfileRoutineView: View {
         }
     }
 
-    private func guidanceMetric(title: String, value: String) -> some View {
+    private func guidanceMetric(_ metric: RoutineGuidanceMetric) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(title)
+            Text(metric.title)
                 .font(.caption)
                 .foregroundColor(.secondary)
 
-            Text(value)
+            Text(metric.value)
                 .font(.headline)
-                .foregroundColor(.primary)
+                .foregroundColor(guidanceToneColor(metric.tone))
+
+            Text(metric.detail)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(12)
         .background(Color.secondary.opacity(0.08))
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func guidanceInfoCard(title: String, value: String, systemImage: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: systemImage)
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Text(value)
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.secondary.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func guidanceSlotChip(_ slot: RoutineGuidanceSlot) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(slot.timeText)
+                .font(.caption.weight(.semibold))
+                .foregroundColor(guidanceSlotColor(slot.status))
+
+            Text(slot.title)
+                .font(.caption2)
+                .foregroundColor(.primary)
+                .lineLimit(1)
+
+            Text(guidanceSlotStatusText(slot.status))
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(guidanceSlotColor(slot.status).opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func guidanceToneColor(_ tone: RoutineGuidanceTone) -> Color {
+        switch tone {
+        case .neutral:
+            return .secondary
+        case .onTrack:
+            return .accentColor
+        case .behind:
+            return .orange
+        case .ahead:
+            return .blue
+        }
+    }
+
+    private func guidanceSlotColor(_ status: RoutineGuidanceSlotStatus) -> Color {
+        switch status {
+        case .elapsed:
+            return .accentColor
+        case .next:
+            return .orange
+        case .upcoming:
+            return .secondary
+        }
+    }
+
+    private func guidanceSlotStatusText(_ status: RoutineGuidanceSlotStatus) -> String {
+        switch status {
+        case .elapsed:
+            return L10n.tr("profileRoutineGuidanceSlotElapsedTitle")
+        case .next:
+            return L10n.tr("profileRoutineGuidanceSlotNextTitle")
+        case .upcoming:
+            return L10n.tr("profileRoutineGuidanceSlotUpcomingTitle")
+        }
     }
 
     private func openSettings() {

--- a/Project/Presentation/Sources/ViewModel/HydrationInsightViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationInsightViewModel.swift
@@ -108,14 +108,6 @@ public final class HydrationInsightViewModel {
         volumeText(dailyGoalML)
     }
 
-    var weeklyAchievementText: String {
-        percentText(weeklyAchievementRate)
-    }
-
-    var monthlyAchievementText: String {
-        percentText(monthlyAchievementRate)
-    }
-
     var weekdayInsightText: String {
         guard let bestWeekday, let leastWeekday else {
             return L10n.tr("insightWeekdayInsightInsufficient")

--- a/Project/Presentation/Sources/ViewModel/ProfileRoutineViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/ProfileRoutineViewModel.swift
@@ -3,13 +3,44 @@ import Foundation
 import Localization
 import Observation
 
+enum RoutineGuidanceTone: Equatable {
+    case neutral
+    case onTrack
+    case behind
+    case ahead
+}
+
+struct RoutineGuidanceMetric: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let value: String
+    let detail: String
+    let tone: RoutineGuidanceTone
+}
+
+enum RoutineGuidanceSlotStatus: Equatable {
+    case elapsed
+    case next
+    case upcoming
+}
+
+struct RoutineGuidanceSlot: Identifiable, Equatable {
+    let id: UUID
+    let title: String
+    let timeText: String
+    let status: RoutineGuidanceSlotStatus
+}
+
 struct RoutineGuidanceSummary: Equatable {
     let badgeText: String
     let headline: String
     let description: String
     let footnote: String
-    let recommendedValueText: String?
-    let actualValueText: String?
+    let tone: RoutineGuidanceTone
+    let metrics: [RoutineGuidanceMetric]
+    let nextRoutineValueText: String?
+    let remainingRoutineValueText: String?
+    let slots: [RoutineGuidanceSlot]
 }
 
 enum RoutinePermissionPrompt: String, Identifiable, Equatable {
@@ -219,36 +250,84 @@ public final class ProfileRoutineViewModel {
                 headline: L10n.tr("profileRoutineGuidanceNoScheduleHeadline"),
                 description: L10n.tr("profileRoutineGuidanceNoScheduleDescription"),
                 footnote: L10n.tr("profileRoutineGuidanceNoScheduleFootnote"),
-                recommendedValueText: nil,
-                actualValueText: nil
+                tone: .neutral,
+                metrics: [],
+                nextRoutineValueText: nil,
+                remainingRoutineValueText: nil,
+                slots: []
             )
         }
 
         let elapsedCount = elapsedRoutineCount(for: todayRoutines)
+        let nextRoutine = nextRoutine(for: todayRoutines)
+        let remainingCount = remainingRoutineCount(for: todayRoutines)
         let actualIntakeML = currentWaterCount * 250
         let recommendedIntakeML = recommendedIntakeML(
             elapsedCount: elapsedCount,
             totalCount: todayRoutines.count
         )
+        let tone = guidanceTone(
+            elapsedCount: elapsedCount,
+            recommendedIntakeML: recommendedIntakeML,
+            actualIntakeML: actualIntakeML
+        )
+        let recommendedValueText = L10n.tr("commonMilliliterFormat", recommendedIntakeML)
+        let actualValueText = L10n.tr("commonMilliliterFormat", actualIntakeML)
+        let gapValueText = L10n.tr("commonMilliliterFormat", abs(actualIntakeML - recommendedIntakeML))
 
         return RoutineGuidanceSummary(
             badgeText: L10n.tr(
-                "profileRoutineGuidanceProgressFormat",
-                Int(routineProgressPercentage(elapsedCount: elapsedCount, totalCount: todayRoutines.count).rounded())
+                "profileRoutineGuidanceProgressCountFormat",
+                elapsedCount,
+                todayRoutines.count
             ),
             headline: guidanceHeadline(
                 elapsedCount: elapsedCount,
                 recommendedIntakeML: recommendedIntakeML,
                 actualIntakeML: actualIntakeML
             ),
-            description: L10n.tr(
-                "profileRoutineGuidanceDescriptionFormat",
-                L10n.tr("commonMilliliterFormat", recommendedIntakeML),
-                L10n.tr("commonMilliliterFormat", actualIntakeML)
+            description: guidanceDescription(
+                elapsedCount: elapsedCount,
+                nextRoutine: nextRoutine,
+                remainingCount: remainingCount
             ),
-            footnote: L10n.tr("profileRoutineGuidanceFootnoteFormat", todayRoutines.count, elapsedCount),
-            recommendedValueText: L10n.tr("commonMilliliterFormat", recommendedIntakeML),
-            actualValueText: L10n.tr("commonMilliliterFormat", actualIntakeML)
+            footnote: L10n.tr(
+                "profileRoutineGuidanceFootnoteDetailFormat",
+                L10n.tr("commonMilliliterFormat", dailyWaterLimitML),
+                todayRoutines.count
+            ),
+            tone: tone,
+            metrics: [
+                RoutineGuidanceMetric(
+                    id: "recommended",
+                    title: L10n.tr("profileRoutineGuidanceRecommendedTitle"),
+                    value: recommendedValueText,
+                    detail: L10n.tr("profileRoutineGuidanceRecommendedDetail"),
+                    tone: .neutral
+                ),
+                RoutineGuidanceMetric(
+                    id: "actual",
+                    title: L10n.tr("profileRoutineGuidanceActualTitle"),
+                    value: actualValueText,
+                    detail: L10n.tr("profileRoutineGuidanceActualDetail"),
+                    tone: .neutral
+                ),
+                RoutineGuidanceMetric(
+                    id: "difference",
+                    title: L10n.tr("profileRoutineGuidanceDifferenceTitle"),
+                    value: gapValueText,
+                    detail: differenceDetailText(
+                        elapsedCount: elapsedCount,
+                        tone: tone
+                    ),
+                    tone: tone
+                )
+            ],
+            nextRoutineValueText: nextRoutine.map {
+                L10n.tr("profileRoutineGuidanceNextRoutineValueFormat", $0.timeText, $0.title)
+            } ?? L10n.tr("profileRoutineGuidanceNextRoutineDoneValue"),
+            remainingRoutineValueText: L10n.tr("profileRoutineGuidanceRemainingCountFormat", remainingCount),
+            slots: guidanceSlots(for: todayRoutines, nextRoutineID: nextRoutine?.id)
         )
     }
 
@@ -411,6 +490,21 @@ public final class ProfileRoutineViewModel {
         .count
     }
 
+    private func nextRoutine(for routines: [HydrationRoutine]) -> HydrationRoutine? {
+        let currentMinutes = minuteOfDay(for: nowProvider())
+        return routines.first { routine in
+            minuteOfDay(hour: routine.hour, minute: routine.minute) > currentMinutes
+        }
+    }
+
+    private func remainingRoutineCount(for routines: [HydrationRoutine]) -> Int {
+        let currentMinutes = minuteOfDay(for: nowProvider())
+        return routines.filter { routine in
+            minuteOfDay(hour: routine.hour, minute: routine.minute) > currentMinutes
+        }
+        .count
+    }
+
     private func recommendedIntakeML(elapsedCount: Int, totalCount: Int) -> Int {
         guard totalCount > 0 else {
             return 0
@@ -419,12 +513,20 @@ public final class ProfileRoutineViewModel {
         return Int((Double(dailyWaterLimitML) * Double(elapsedCount) / Double(totalCount)).rounded())
     }
 
-    private func routineProgressPercentage(elapsedCount: Int, totalCount: Int) -> Double {
-        guard totalCount > 0 else {
-            return 0
+    private func guidanceTone(
+        elapsedCount: Int,
+        recommendedIntakeML: Int,
+        actualIntakeML: Int
+    ) -> RoutineGuidanceTone {
+        if elapsedCount == 0 {
+            return .neutral
         }
 
-        return Double(elapsedCount) / Double(totalCount) * 100
+        if actualIntakeML == recommendedIntakeML {
+            return .onTrack
+        }
+
+        return actualIntakeML < recommendedIntakeML ? .behind : .ahead
     }
 
     private func guidanceHeadline(
@@ -448,6 +550,71 @@ public final class ProfileRoutineViewModel {
         }
 
         return L10n.tr("profileRoutineGuidanceAheadHeadlineFormat", gapText)
+    }
+
+    private func guidanceDescription(
+        elapsedCount: Int,
+        nextRoutine: HydrationRoutine?,
+        remainingCount: Int
+    ) -> String {
+        if elapsedCount == 0, let nextRoutine {
+            return L10n.tr(
+                "profileRoutineGuidanceBeforeStartDescriptionFormat",
+                L10n.tr("profileRoutineGuidanceNextRoutineValueFormat", nextRoutine.timeText, nextRoutine.title),
+                remainingCount
+            )
+        }
+
+        if let nextRoutine {
+            return L10n.tr(
+                "profileRoutineGuidanceUpcomingDescriptionFormat",
+                L10n.tr("profileRoutineGuidanceNextRoutineValueFormat", nextRoutine.timeText, nextRoutine.title),
+                remainingCount
+            )
+        }
+
+        return L10n.tr("profileRoutineGuidanceCompletedDescription")
+    }
+
+    private func differenceDetailText(
+        elapsedCount: Int,
+        tone: RoutineGuidanceTone
+    ) -> String {
+        if elapsedCount == 0 {
+            return L10n.tr("profileRoutineGuidanceDifferencePendingDetail")
+        }
+
+        switch tone {
+        case .neutral, .onTrack:
+            return L10n.tr("profileRoutineGuidanceDifferenceOnTrackDetail")
+        case .behind:
+            return L10n.tr("profileRoutineGuidanceDifferenceBehindDetail")
+        case .ahead:
+            return L10n.tr("profileRoutineGuidanceDifferenceAheadDetail")
+        }
+    }
+
+    private func guidanceSlots(
+        for routines: [HydrationRoutine],
+        nextRoutineID: UUID?
+    ) -> [RoutineGuidanceSlot] {
+        routines.map { routine in
+            let status: RoutineGuidanceSlotStatus
+            if let nextRoutineID, routine.id == nextRoutineID {
+                status = .next
+            } else if nextRoutineID == nil || minuteOfDay(hour: routine.hour, minute: routine.minute) < minuteOfDay(for: nowProvider()) {
+                status = .elapsed
+            } else {
+                status = .upcoming
+            }
+
+            return RoutineGuidanceSlot(
+                id: routine.id,
+                title: routine.title,
+                timeText: routine.timeText,
+                status: status
+            )
+        }
     }
 
     private func minuteOfDay(for date: Date) -> Int {

--- a/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
+++ b/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
@@ -270,23 +270,22 @@ struct ProfileRoutineViewModelTests {
     @MainActor
     @Test("오늘 활성 루틴과 현재 섭취량으로 권장 섭취 가이드를 계산한다")
     func guidanceSummary() async {
+        let morningRoutine = HydrationRoutine(
+            title: "오전 루틴",
+            hour: 9,
+            minute: 0,
+            weekdays: [.monday],
+            isEnabled: true
+        )
+        let eveningRoutine = HydrationRoutine(
+            title: "오후 루틴",
+            hour: 18,
+            minute: 0,
+            weekdays: [.monday],
+            isEnabled: true
+        )
         let routineUseCase = SpyRoutineUseCase()
-        routineUseCase.routines = [
-            HydrationRoutine(
-                title: "오전 루틴",
-                hour: 9,
-                minute: 0,
-                weekdays: [.monday],
-                isEnabled: true
-            ),
-            HydrationRoutine(
-                title: "오후 루틴",
-                hour: 18,
-                minute: 0,
-                weekdays: [.monday],
-                isEnabled: true
-            )
-        ]
+        routineUseCase.routines = [morningRoutine, eveningRoutine]
         let drinkWaterUseCase = SpyDrinkWaterUseCase()
         drinkWaterUseCase.currentWaterValue = 3
         let userPreferencesUseCase = SpyUserPreferencesUseCase()
@@ -301,11 +300,32 @@ struct ProfileRoutineViewModelTests {
 
         await viewModel.load()
 
-        #expect(viewModel.guidanceSummary.badgeText == L10n.tr("profileRoutineGuidanceProgressFormat", 50))
+        #expect(viewModel.guidanceSummary.badgeText == L10n.tr("profileRoutineGuidanceProgressCountFormat", 1, 2))
         #expect(viewModel.guidanceSummary.headline == L10n.tr("profileRoutineGuidanceBehindHeadlineFormat", L10n.tr("commonMilliliterFormat", 250)))
-        #expect(viewModel.guidanceSummary.description == L10n.tr("profileRoutineGuidanceDescriptionFormat", L10n.tr("commonMilliliterFormat", 1000), L10n.tr("commonMilliliterFormat", 750)))
-        #expect(viewModel.guidanceSummary.recommendedValueText == L10n.tr("commonMilliliterFormat", 1000))
-        #expect(viewModel.guidanceSummary.actualValueText == L10n.tr("commonMilliliterFormat", 750))
+        #expect(
+            viewModel.guidanceSummary.description ==
+                L10n.tr(
+                    "profileRoutineGuidanceUpcomingDescriptionFormat",
+                    L10n.tr("profileRoutineGuidanceNextRoutineValueFormat", eveningRoutine.timeText, eveningRoutine.title),
+                    1
+                )
+        )
+        #expect(
+            viewModel.guidanceSummary.footnote ==
+                L10n.tr("profileRoutineGuidanceFootnoteDetailFormat", L10n.tr("commonMilliliterFormat", 2000), 2)
+        )
+        #expect(viewModel.guidanceSummary.tone == .behind)
+        #expect(viewModel.guidanceSummary.metrics.count == 3)
+        #expect(viewModel.guidanceSummary.metrics[0].value == L10n.tr("commonMilliliterFormat", 1000))
+        #expect(viewModel.guidanceSummary.metrics[1].value == L10n.tr("commonMilliliterFormat", 750))
+        #expect(viewModel.guidanceSummary.metrics[2].title == L10n.tr("profileRoutineGuidanceDifferenceTitle"))
+        #expect(viewModel.guidanceSummary.metrics[2].detail == L10n.tr("profileRoutineGuidanceDifferenceBehindDetail"))
+        #expect(
+            viewModel.guidanceSummary.nextRoutineValueText ==
+                L10n.tr("profileRoutineGuidanceNextRoutineValueFormat", eveningRoutine.timeText, eveningRoutine.title)
+        )
+        #expect(viewModel.guidanceSummary.remainingRoutineValueText == L10n.tr("profileRoutineGuidanceRemainingCountFormat", 1))
+        #expect(viewModel.guidanceSummary.slots.map(\.status) == [.elapsed, .next])
     }
 
     @MainActor
@@ -327,7 +347,78 @@ struct ProfileRoutineViewModelTests {
 
         #expect(viewModel.guidanceSummary.badgeText == L10n.tr("profileRoutineGuidanceNoScheduleBadge"))
         #expect(viewModel.guidanceSummary.headline == L10n.tr("profileRoutineGuidanceNoScheduleHeadline"))
-        #expect(viewModel.guidanceSummary.recommendedValueText == nil)
-        #expect(viewModel.guidanceSummary.actualValueText == nil)
+        #expect(viewModel.guidanceSummary.metrics.isEmpty)
+        #expect(viewModel.guidanceSummary.nextRoutineValueText == nil)
+        #expect(viewModel.guidanceSummary.remainingRoutineValueText == nil)
+        #expect(viewModel.guidanceSummary.slots.isEmpty)
+    }
+
+    @MainActor
+    @Test("첫 루틴 전에는 다음 루틴과 예정 슬롯을 함께 안내한다")
+    func guidanceSummaryBeforeFirstRoutine() async {
+        let morningRoutine = HydrationRoutine(
+            title: "오전 루틴",
+            hour: 9,
+            minute: 0,
+            weekdays: [.monday],
+            isEnabled: true
+        )
+        let eveningRoutine = HydrationRoutine(
+            title: "오후 루틴",
+            hour: 18,
+            minute: 0,
+            weekdays: [.monday],
+            isEnabled: true
+        )
+        let routineUseCase = SpyRoutineUseCase()
+        routineUseCase.routines = [morningRoutine, eveningRoutine]
+        let now = makeDate(year: 2026, month: 3, day: 16, hour: 8, minute: 30)
+        let viewModel = makeViewModel(routineUseCase: routineUseCase, now: now)
+
+        await viewModel.load()
+
+        #expect(viewModel.guidanceSummary.tone == .neutral)
+        #expect(viewModel.guidanceSummary.headline == L10n.tr("profileRoutineGuidanceBeforeStartHeadline"))
+        #expect(
+            viewModel.guidanceSummary.description ==
+                L10n.tr(
+                    "profileRoutineGuidanceBeforeStartDescriptionFormat",
+                    L10n.tr("profileRoutineGuidanceNextRoutineValueFormat", morningRoutine.timeText, morningRoutine.title),
+                    2
+                )
+        )
+        #expect(viewModel.guidanceSummary.metrics[2].detail == L10n.tr("profileRoutineGuidanceDifferencePendingDetail"))
+        #expect(viewModel.guidanceSummary.slots.map(\.status) == [.next, .upcoming])
+    }
+
+    @MainActor
+    @Test("오늘 루틴 시간이 모두 지나면 남은 루틴 없음 상태를 계산한다")
+    func guidanceSummaryAfterAllRoutines() async {
+        let routineUseCase = SpyRoutineUseCase()
+        routineUseCase.routines = [
+            HydrationRoutine(
+                title: "오전 루틴",
+                hour: 9,
+                minute: 0,
+                weekdays: [.monday],
+                isEnabled: true
+            ),
+            HydrationRoutine(
+                title: "오후 루틴",
+                hour: 18,
+                minute: 0,
+                weekdays: [.monday],
+                isEnabled: true
+            )
+        ]
+        let now = makeDate(year: 2026, month: 3, day: 16, hour: 21, minute: 0)
+        let viewModel = makeViewModel(routineUseCase: routineUseCase, now: now)
+
+        await viewModel.load()
+
+        #expect(viewModel.guidanceSummary.description == L10n.tr("profileRoutineGuidanceCompletedDescription"))
+        #expect(viewModel.guidanceSummary.nextRoutineValueText == L10n.tr("profileRoutineGuidanceNextRoutineDoneValue"))
+        #expect(viewModel.guidanceSummary.remainingRoutineValueText == L10n.tr("profileRoutineGuidanceRemainingCountFormat", 0))
+        #expect(viewModel.guidanceSummary.slots.map(\.status) == [.elapsed, .elapsed])
     }
 }

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -1002,6 +1002,17 @@
         }
       }
     },
+    "profileRoutineGuidanceActualDetail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 누적 섭취"
+          }
+        }
+      }
+    },
     "profileRoutineGuidanceActualTitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1020,6 +1031,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "권장량보다 %@ 앞서 있어요"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceBeforeStartDescriptionFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첫 루틴은 %@부터 시작되고, 오늘 %lld개가 예정돼 있어요."
           }
         }
       }
@@ -1046,6 +1068,17 @@
         }
       }
     },
+    "profileRoutineGuidanceCompletedDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 루틴 시간대가 모두 지났어요."
+          }
+        }
+      }
+    },
     "profileRoutineGuidanceDescriptionFormat" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1053,6 +1086,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "지금까지 권장 %@ · 현재 섭취 %@"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceDifferenceAheadDetail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "권장량보다 앞섰어요"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceDifferenceBehindDetail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "권장량보다 부족해요"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceDifferenceOnTrackDetail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "권장량과 같아요"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceDifferencePendingDetail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첫 루틴 전이에요"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceDifferenceTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "권장 대비 차이"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceFootnoteDetailFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하루 목표 %@를 오늘 활성 루틴 %lld개 기준으로 나눠 계산했어요."
           }
         }
       }
@@ -1112,6 +1211,39 @@
         }
       }
     },
+    "profileRoutineGuidanceNextRoutineDoneValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 일정 종료"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceNextRoutineTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음 루틴"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceNextRoutineValueFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · %@"
+          }
+        }
+      }
+    },
     "profileRoutineGuidanceOnTrackHeadline" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1119,6 +1251,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "지금까지 루틴을 잘 따라가고 있어요"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceProgressCountFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 %lld/%lld 루틴 경과"
           }
         }
       }
@@ -1134,6 +1277,17 @@
         }
       }
     },
+    "profileRoutineGuidanceRecommendedDetail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "경과한 루틴 기준"
+          }
+        }
+      }
+    },
     "profileRoutineGuidanceRecommendedTitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1145,6 +1299,28 @@
         }
       }
     },
+    "profileRoutineGuidanceRemainingCountFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld개"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceRemainingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "남은 루틴"
+          }
+        }
+      }
+    },
     "profileRoutineGuidanceSectionTitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1152,6 +1328,61 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "오늘 루틴 가이드"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceSlotElapsedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지남"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceSlotNextTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceSlotUpcomingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예정"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceTimelineTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 루틴 흐름"
+          }
+        }
+      }
+    },
+    "profileRoutineGuidanceUpcomingDescriptionFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음 루틴은 %@이고, 오늘 %lld개가 남아 있어요."
           }
         }
       }


### PR DESCRIPTION
## 📝 Summary
루틴 가이드 카드를 시간대 진행 흐름 중심으로 확장했습니다.
현재 섭취량과 지금까지 권장량의 차이, 다음 루틴, 남은 루틴, 오늘 슬롯 상태를 한 카드에서 확인할 수 있게 정리했습니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #124
- Related to #94

## 📋 Changes Made
### Added
- 루틴 가이드 요약 모델에 다음 루틴, 남은 루틴, 권장 대비 차이, 슬롯 상태 계산 추가
- 첫 루틴 전/진행 중/오늘 종료 상태별 ViewModel 테스트 추가
- 루틴 가이드용 로컬라이즈 문자열 추가

### Changed
- 프로필 루틴 가이드 카드를 메트릭 3종, 다음/남은 루틴 정보, 오늘 루틴 흐름 캡슐 구조로 변경
- 진행 배지를 퍼센트 대신 경과 루틴 수 기준으로 표시하도록 변경
- 권장량 대비 부족/초과 상태를 텍스트와 컬러 톤으로 더 직접적으로 표현

### Fixed
- 텍스트 위주 안내라 다음 루틴과 남은 일정이 바로 보이지 않던 문제
- 권장량 대비 차이를 한눈에 파악하기 어려웠던 문제

### Removed
- 없음

## 🔍 Technical Details
ProfileRoutineViewModel에서 오늘 활성 루틴을 기준으로 시간대 경과 상태를 계산하고, UI는 RoutineGuidanceSummary가 제공하는 메트릭/슬롯 모델만 소비하도록 정리했습니다.

## 📸 Screenshots / Videos
### Before
- 텍스트 중심 가이드와 2개 메트릭만 노출

### After
- 권장/현재/차이 메트릭, 다음/남은 루틴, 슬롯 흐름을 한 카드에서 노출

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS 18.0 Simulator
- Device: iPhone 17
- Xcode Version: Xcode 17

### Test Results
- xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination "platform=iOS Simulator,name=iPhone 17" 통과
- xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO 통과

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
뷰모델 테스트는 시간대별 상태 계산을 고정 시각 기준으로 검증합니다. 리뷰 시 카드 정보 밀도와 문구 톤을 중점적으로 봐주시면 됩니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
