### PR TITLE
feat: add challenge tab foundation

### DIFF
--- a/Project/App/Sources/ContentView.swift
+++ b/Project/App/Sources/ContentView.swift
@@ -35,6 +35,13 @@ struct ContentView: View {
                 Label(L10n.tr("insightNavigationTitle"), systemImage: "chart.bar.xaxis")
             }
 
+            ChallengeView(
+                viewModel: DIContainer.shared.resolve(ChallengeViewModel.self)
+            )
+            .tabItem {
+                Label(L10n.tr("challengeTitle"), systemImage: "trophy")
+            }
+
             ProfileView(
                 settingsViewModel: DIContainer.shared.resolve(SettingsViewModel.self),
                 routineViewModel: DIContainer.shared.resolve(ProfileRoutineViewModel.self)

--- a/Project/Data/Sources/DataSource/ChallengeStorageDataSource.swift
+++ b/Project/Data/Sources/DataSource/ChallengeStorageDataSource.swift
@@ -1,0 +1,39 @@
+import DomainLayerInterface
+import Foundation
+import Utils
+
+public protocol ChallengeStorageDataSource: Sendable {
+    func fetchChallengeStates() -> [HydrationChallengeState]
+    func saveChallengeStates(_ states: [HydrationChallengeState])
+}
+
+public final class ChallengeStorageDataSourceImpl: ChallengeStorageDataSource, @unchecked Sendable {
+    private let userDefaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+    }
+
+    public func fetchChallengeStates() -> [HydrationChallengeState] {
+        guard let data = userDefaults.data(forKey: .hydrationChallengeStates) else {
+            return []
+        }
+
+        do {
+            return try decoder.decode([HydrationChallengeState].self, from: data)
+        } catch {
+            return []
+        }
+    }
+
+    public func saveChallengeStates(_ states: [HydrationChallengeState]) {
+        guard let data = try? encoder.encode(states) else {
+            return
+        }
+
+        userDefaults.set(data, forKey: .hydrationChallengeStates)
+        userDefaults.synchronize()
+    }
+}

--- a/Project/Data/Sources/Repository/ChallengeRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/ChallengeRepositoryImpl.swift
@@ -1,0 +1,18 @@
+import DomainLayerInterface
+import Foundation
+
+public struct ChallengeRepositoryImpl: ChallengeRepository {
+    private let storageDataSource: ChallengeStorageDataSource
+
+    public init(storageDataSource: ChallengeStorageDataSource) {
+        self.storageDataSource = storageDataSource
+    }
+
+    public func fetchChallengeStates() -> [HydrationChallengeState] {
+        storageDataSource.fetchChallengeStates()
+    }
+
+    public func saveChallengeStates(_ states: [HydrationChallengeState]) {
+        storageDataSource.saveChallengeStates(states)
+    }
+}

--- a/Project/Data/Tests/ChallengeStorageDataSourceTests.swift
+++ b/Project/Data/Tests/ChallengeStorageDataSourceTests.swift
@@ -1,0 +1,55 @@
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import DataLayer
+
+@Suite("ChallengeStorageDataSource Tests")
+struct ChallengeStorageDataSourceTests {
+    @Test("challenge state를 저장하고 다시 읽어온다")
+    func saveAndFetchStates() {
+        let suiteName = "ChallengeStorageDataSourceTests.\(UUID().uuidString)"
+        let userDefaults = makeIsolatedUserDefaults(suiteName: suiteName)
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let dataSource = ChallengeStorageDataSourceImpl(userDefaults: userDefaults)
+        let achievedAt = Date(timeIntervalSince1970: 1_710_000_000)
+        let states = [
+            HydrationChallengeState(
+                kind: .streak7,
+                progress: 1,
+                isCompleted: true,
+                achievedAt: achievedAt,
+                updatedAt: achievedAt
+            ),
+            HydrationChallengeState(
+                kind: .goalAchievement30,
+                progress: 0.4,
+                isCompleted: false,
+                achievedAt: nil,
+                updatedAt: achievedAt
+            )
+        ]
+
+        dataSource.saveChallengeStates(states)
+
+        #expect(dataSource.fetchChallengeStates() == states)
+    }
+
+    @Test("저장된 데이터가 없으면 빈 배열을 반환한다")
+    func emptyState() {
+        let suiteName = "ChallengeStorageDataSourceTests.\(UUID().uuidString)"
+        let userDefaults = makeIsolatedUserDefaults(suiteName: suiteName)
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let dataSource = ChallengeStorageDataSourceImpl(userDefaults: userDefaults)
+
+        #expect(dataSource.fetchChallengeStates().isEmpty)
+    }
+
+    private func makeIsolatedUserDefaults(suiteName: String) -> UserDefaults {
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+}

--- a/Project/Domain/Interfaces/Entity/HydrationChallenge.swift
+++ b/Project/Domain/Interfaces/Entity/HydrationChallenge.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+public enum HydrationChallengeKind: String, CaseIterable, Codable, Identifiable, Sendable {
+    case streak7
+    case weeklyAchievement80
+    case goalAchievement30
+
+    public var id: String { rawValue }
+}
+
+public struct HydrationChallenge: Identifiable, Equatable, Sendable {
+    public let kind: HydrationChallengeKind
+    public let progress: Double
+    public let currentValue: Double
+    public let targetValue: Double
+    public let primaryCurrentValue: Int
+    public let primaryTargetValue: Int
+    public let secondaryCurrentValue: Int?
+    public let secondaryTargetValue: Int?
+    public let isCompleted: Bool
+    public let achievedAt: Date?
+
+    public init(
+        kind: HydrationChallengeKind,
+        progress: Double,
+        currentValue: Double,
+        targetValue: Double,
+        primaryCurrentValue: Int,
+        primaryTargetValue: Int,
+        secondaryCurrentValue: Int? = nil,
+        secondaryTargetValue: Int? = nil,
+        isCompleted: Bool,
+        achievedAt: Date?
+    ) {
+        self.kind = kind
+        self.progress = progress
+        self.currentValue = currentValue
+        self.targetValue = targetValue
+        self.primaryCurrentValue = primaryCurrentValue
+        self.primaryTargetValue = primaryTargetValue
+        self.secondaryCurrentValue = secondaryCurrentValue
+        self.secondaryTargetValue = secondaryTargetValue
+        self.isCompleted = isCompleted
+        self.achievedAt = achievedAt
+    }
+
+    public var id: HydrationChallengeKind { kind }
+}
+
+public struct HydrationChallengeState: Identifiable, Codable, Equatable, Sendable {
+    public let kind: HydrationChallengeKind
+    public var progress: Double
+    public var isCompleted: Bool
+    public var achievedAt: Date?
+    public var updatedAt: Date
+
+    public init(
+        kind: HydrationChallengeKind,
+        progress: Double,
+        isCompleted: Bool,
+        achievedAt: Date?,
+        updatedAt: Date
+    ) {
+        self.kind = kind
+        self.progress = progress
+        self.isCompleted = isCompleted
+        self.achievedAt = achievedAt
+        self.updatedAt = updatedAt
+    }
+
+    public var id: HydrationChallengeKind { kind }
+}

--- a/Project/Domain/Interfaces/Entity/HydrationProgressSnapshot.swift
+++ b/Project/Domain/Interfaces/Entity/HydrationProgressSnapshot.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public struct HydrationProgressSnapshot: Equatable, Sendable {
+    public let dailyGoalML: Double
+    public let weeklyAverageML: Double
+    public let monthlyAverageML: Double
+    public let weeklyAchievementRate: Double
+    public let monthlyAchievementRate: Double
+    public let weeklyAchievedDays: Int
+    public let monthlyAchievedDays: Int
+    public let weeklyElapsedDays: Int
+    public let monthlyElapsedDays: Int
+    public let currentStreak: Int
+    public let isEmpty: Bool
+
+    public init(
+        dailyGoalML: Double,
+        weeklyAverageML: Double,
+        monthlyAverageML: Double,
+        weeklyAchievementRate: Double,
+        monthlyAchievementRate: Double,
+        weeklyAchievedDays: Int,
+        monthlyAchievedDays: Int,
+        weeklyElapsedDays: Int,
+        monthlyElapsedDays: Int,
+        currentStreak: Int,
+        isEmpty: Bool
+    ) {
+        self.dailyGoalML = dailyGoalML
+        self.weeklyAverageML = weeklyAverageML
+        self.monthlyAverageML = monthlyAverageML
+        self.weeklyAchievementRate = weeklyAchievementRate
+        self.monthlyAchievementRate = monthlyAchievementRate
+        self.weeklyAchievedDays = weeklyAchievedDays
+        self.monthlyAchievedDays = monthlyAchievedDays
+        self.weeklyElapsedDays = weeklyElapsedDays
+        self.monthlyElapsedDays = monthlyElapsedDays
+        self.currentStreak = currentStreak
+        self.isEmpty = isEmpty
+    }
+
+    public static func empty(dailyGoalML: Double) -> HydrationProgressSnapshot {
+        HydrationProgressSnapshot(
+            dailyGoalML: dailyGoalML,
+            weeklyAverageML: 0,
+            monthlyAverageML: 0,
+            weeklyAchievementRate: 0,
+            monthlyAchievementRate: 0,
+            weeklyAchievedDays: 0,
+            monthlyAchievedDays: 0,
+            weeklyElapsedDays: 0,
+            monthlyElapsedDays: 0,
+            currentStreak: 0,
+            isEmpty: true
+        )
+    }
+}

--- a/Project/Domain/Interfaces/Repository/ChallengeRepository.swift
+++ b/Project/Domain/Interfaces/Repository/ChallengeRepository.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol ChallengeRepository: Sendable {
+    func fetchChallengeStates() -> [HydrationChallengeState]
+    func saveChallengeStates(_ states: [HydrationChallengeState])
+}

--- a/Project/Domain/Interfaces/UseCase/ChallengeUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/ChallengeUseCase.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol ChallengeUseCase: Sendable {
+    func fetchChallenges(referenceDate: Date, calendar: Calendar) async -> [HydrationChallenge]
+}

--- a/Project/Domain/Interfaces/UseCase/HydrationProgressUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/HydrationProgressUseCase.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol HydrationProgressUseCase: Sendable {
+    func progressSnapshot(referenceDate: Date, calendar: Calendar) async -> HydrationProgressSnapshot
+}

--- a/Project/Domain/Sources/UseCase/ChallengeUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/ChallengeUseCaseImpl.swift
@@ -1,0 +1,159 @@
+import DomainLayerInterface
+import Foundation
+
+public struct ChallengeUseCaseImpl: ChallengeUseCase {
+    private let progressUseCase: HydrationProgressUseCase
+    private let challengeRepository: ChallengeRepository
+    private let drinkWaterRepository: DrinkWaterRepository
+
+    public init(
+        progressUseCase: HydrationProgressUseCase,
+        challengeRepository: ChallengeRepository,
+        drinkWaterRepository: DrinkWaterRepository
+    ) {
+        self.progressUseCase = progressUseCase
+        self.challengeRepository = challengeRepository
+        self.drinkWaterRepository = drinkWaterRepository
+    }
+
+    public func fetchChallenges(referenceDate: Date, calendar: Calendar) async -> [HydrationChallenge] {
+        let snapshot = await progressUseCase.progressSnapshot(
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+        let persistedStatesByKind = Dictionary(
+            uniqueKeysWithValues: challengeRepository.fetchChallengeStates().map { ($0.kind, $0) }
+        )
+        let totalAchievedDays = await totalAchievedDayCount(
+            upTo: referenceDate,
+            calendar: calendar,
+            dailyGoalML: snapshot.dailyGoalML
+        )
+
+        let challenges = [
+            makeStreakChallenge(from: snapshot),
+            makeWeeklyAchievementChallenge(from: snapshot),
+            makeGoalAchievementChallenge(totalAchievedDays: totalAchievedDays)
+        ].map { challenge in
+            mergedChallenge(
+                challenge,
+                persistedState: persistedStatesByKind[challenge.kind],
+                referenceDate: referenceDate
+            )
+        }
+
+        challengeRepository.saveChallengeStates(
+            challenges.map {
+                HydrationChallengeState(
+                    kind: $0.kind,
+                    progress: $0.progress,
+                    isCompleted: $0.isCompleted,
+                    achievedAt: $0.achievedAt,
+                    updatedAt: referenceDate
+                )
+            }
+        )
+
+        return challenges
+    }
+
+    private func mergedChallenge(
+        _ challenge: HydrationChallenge,
+        persistedState: HydrationChallengeState?,
+        referenceDate: Date
+    ) -> HydrationChallenge {
+        let completedAt = persistedState?.achievedAt ?? (challenge.progress >= 1 ? referenceDate : nil)
+        let isCompleted = persistedState?.isCompleted == true || challenge.progress >= 1
+
+        return HydrationChallenge(
+            kind: challenge.kind,
+            progress: isCompleted ? 1 : challenge.progress,
+            currentValue: challenge.currentValue,
+            targetValue: challenge.targetValue,
+            primaryCurrentValue: challenge.primaryCurrentValue,
+            primaryTargetValue: challenge.primaryTargetValue,
+            secondaryCurrentValue: challenge.secondaryCurrentValue,
+            secondaryTargetValue: challenge.secondaryTargetValue,
+            isCompleted: isCompleted,
+            achievedAt: completedAt
+        )
+    }
+
+    private func makeStreakChallenge(from snapshot: HydrationProgressSnapshot) -> HydrationChallenge {
+        let target = 7
+        return HydrationChallenge(
+            kind: .streak7,
+            progress: progress(current: Double(snapshot.currentStreak), target: Double(target)),
+            currentValue: Double(snapshot.currentStreak),
+            targetValue: Double(target),
+            primaryCurrentValue: snapshot.currentStreak,
+            primaryTargetValue: target,
+            isCompleted: false,
+            achievedAt: nil
+        )
+    }
+
+    private func makeWeeklyAchievementChallenge(from snapshot: HydrationProgressSnapshot) -> HydrationChallenge {
+        let targetRate = 0.8
+        return HydrationChallenge(
+            kind: .weeklyAchievement80,
+            progress: progress(current: snapshot.weeklyAchievementRate, target: targetRate),
+            currentValue: snapshot.weeklyAchievementRate,
+            targetValue: targetRate,
+            primaryCurrentValue: Int((snapshot.weeklyAchievementRate * 100).rounded()),
+            primaryTargetValue: 80,
+            secondaryCurrentValue: snapshot.weeklyAchievedDays,
+            secondaryTargetValue: max(snapshot.weeklyElapsedDays, 1),
+            isCompleted: false,
+            achievedAt: nil
+        )
+    }
+
+    private func makeGoalAchievementChallenge(totalAchievedDays: Int) -> HydrationChallenge {
+        let target = 30
+        return HydrationChallenge(
+            kind: .goalAchievement30,
+            progress: progress(current: Double(totalAchievedDays), target: Double(target)),
+            currentValue: Double(totalAchievedDays),
+            targetValue: Double(target),
+            primaryCurrentValue: totalAchievedDays,
+            primaryTargetValue: target,
+            isCompleted: false,
+            achievedAt: nil
+        )
+    }
+
+    private func progress(current: Double, target: Double) -> Double {
+        guard target > 0 else {
+            return 0
+        }
+
+        return min(max(current / target, 0), 1)
+    }
+
+    private func totalAchievedDayCount(
+        upTo referenceDate: Date,
+        calendar: Calendar,
+        dailyGoalML: Double
+    ) async -> Int {
+        guard dailyGoalML > 0 else {
+            return 0
+        }
+
+        let intervalEnd = calendar.date(
+            byAdding: .day,
+            value: 1,
+            to: calendar.startOfDay(for: referenceDate)
+        ) ?? referenceDate
+
+        let events = await drinkWaterRepository.hydrationEvents(
+            in: DateInterval(start: .distantPast, end: intervalEnd)
+        )
+        let totals = events.reduce(into: [Date: Double]()) { partialResult, event in
+            let day = calendar.startOfDay(for: event.consumedAt)
+            partialResult[day, default: 0] += Double(event.volumeML)
+        }
+
+        return totals.values.filter { $0 >= dailyGoalML }.count
+    }
+}

--- a/Project/Domain/Sources/UseCase/HydrationProgressUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/HydrationProgressUseCaseImpl.swift
@@ -1,0 +1,135 @@
+import DomainLayerInterface
+import Foundation
+
+public struct HydrationProgressUseCaseImpl: HydrationProgressUseCase {
+    private let drinkWaterRepository: DrinkWaterRepository
+    private let userPreferencesRepository: UserPreferencesRepository
+
+    public init(
+        drinkWaterRepository: DrinkWaterRepository,
+        userPreferencesRepository: UserPreferencesRepository
+    ) {
+        self.drinkWaterRepository = drinkWaterRepository
+        self.userPreferencesRepository = userPreferencesRepository
+    }
+
+    public func progressSnapshot(referenceDate: Date, calendar: Calendar) async -> HydrationProgressSnapshot {
+        let dailyGoalML = userPreferencesRepository.getDailyWaterLimit()
+
+        guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: referenceDate),
+              let monthInterval = calendar.dateInterval(of: .month, for: referenceDate) else {
+            return .empty(dailyGoalML: dailyGoalML)
+        }
+
+        let elapsedWeekInterval = elapsedInterval(from: weekInterval, upTo: referenceDate, calendar: calendar)
+        let elapsedMonthInterval = elapsedInterval(from: monthInterval, upTo: referenceDate, calendar: calendar)
+
+        async let weeklyEvents = drinkWaterRepository.hydrationEvents(in: elapsedWeekInterval)
+        async let monthlyEvents = drinkWaterRepository.hydrationEvents(in: elapsedMonthInterval)
+
+        let (resolvedWeeklyEvents, resolvedMonthlyEvents) = await (weeklyEvents, monthlyEvents)
+        let weeklyTotals = dailyTotals(from: resolvedWeeklyEvents, calendar: calendar)
+        let monthlyTotals = dailyTotals(from: resolvedMonthlyEvents, calendar: calendar)
+
+        let weeklyElapsedDays = elapsedDayCount(in: elapsedWeekInterval, calendar: calendar)
+        let monthlyElapsedDays = elapsedDayCount(in: elapsedMonthInterval, calendar: calendar)
+        let weeklyAchievedDays = achievedDayCount(in: weeklyTotals, dailyGoalML: dailyGoalML)
+        let monthlyAchievedDays = achievedDayCount(in: monthlyTotals, dailyGoalML: dailyGoalML)
+
+        return HydrationProgressSnapshot(
+            dailyGoalML: dailyGoalML,
+            weeklyAverageML: averageIntake(from: weeklyTotals, dayCount: weeklyElapsedDays),
+            monthlyAverageML: averageIntake(from: monthlyTotals, dayCount: monthlyElapsedDays),
+            weeklyAchievementRate: achievementRate(achievedDays: weeklyAchievedDays, dayCount: weeklyElapsedDays),
+            monthlyAchievementRate: achievementRate(achievedDays: monthlyAchievedDays, dayCount: monthlyElapsedDays),
+            weeklyAchievedDays: weeklyAchievedDays,
+            monthlyAchievedDays: monthlyAchievedDays,
+            weeklyElapsedDays: weeklyElapsedDays,
+            monthlyElapsedDays: monthlyElapsedDays,
+            currentStreak: await calculateCurrentStreak(
+                referenceDate: referenceDate,
+                calendar: calendar,
+                dailyGoalML: dailyGoalML
+            ),
+            isEmpty: resolvedWeeklyEvents.isEmpty && resolvedMonthlyEvents.isEmpty
+        )
+    }
+
+    private func elapsedInterval(from interval: DateInterval, upTo referenceDate: Date, calendar: Calendar) -> DateInterval {
+        let intervalEnd = calendar.date(
+            byAdding: .day,
+            value: 1,
+            to: calendar.startOfDay(for: referenceDate)
+        ) ?? interval.end
+
+        return DateInterval(start: interval.start, end: min(interval.end, intervalEnd))
+    }
+
+    private func elapsedDayCount(in interval: DateInterval, calendar: Calendar) -> Int {
+        max(calendar.dateComponents([.day], from: interval.start, to: interval.end).day ?? 0, 1)
+    }
+
+    private func dailyTotals(from events: [HydrationEvent], calendar: Calendar) -> [Date: Double] {
+        events.reduce(into: [:]) { partialResult, event in
+            let day = calendar.startOfDay(for: event.consumedAt)
+            partialResult[day, default: 0] += Double(event.volumeML)
+        }
+    }
+
+    private func achievedDayCount(in totals: [Date: Double], dailyGoalML: Double) -> Int {
+        guard dailyGoalML > 0 else {
+            return 0
+        }
+
+        return totals.values.filter { $0 >= dailyGoalML }.count
+    }
+
+    private func averageIntake(from totals: [Date: Double], dayCount: Int) -> Double {
+        guard dayCount > 0 else {
+            return 0
+        }
+
+        return totals.values.reduce(0, +) / Double(dayCount)
+    }
+
+    private func achievementRate(achievedDays: Int, dayCount: Int) -> Double {
+        guard dayCount > 0 else {
+            return 0
+        }
+
+        return Double(achievedDays) / Double(dayCount)
+    }
+
+    private func calculateCurrentStreak(referenceDate: Date, calendar: Calendar, dailyGoalML: Double) async -> Int {
+        guard dailyGoalML > 0 else {
+            return 0
+        }
+
+        var date = calendar.startOfDay(for: referenceDate)
+        if await totalIntake(on: date, calendar: calendar) < dailyGoalML {
+            guard let previousDate = calendar.date(byAdding: .day, value: -1, to: date) else {
+                return 0
+            }
+            date = previousDate
+        }
+
+        var streak = 0
+
+        while await totalIntake(on: date, calendar: calendar) >= dailyGoalML {
+            streak += 1
+
+            guard let previousDate = calendar.date(byAdding: .day, value: -1, to: date) else {
+                break
+            }
+            date = previousDate
+        }
+
+        return streak
+    }
+
+    private func totalIntake(on date: Date, calendar: Calendar) async -> Double {
+        (await drinkWaterRepository.hydrationEvents(on: date)).reduce(0) { partialResult, event in
+            partialResult + Double(event.volumeML)
+        }
+    }
+}

--- a/Project/Domain/Tests/ChallengeUseCaseTests.swift
+++ b/Project/Domain/Tests/ChallengeUseCaseTests.swift
@@ -1,0 +1,134 @@
+import DomainLayer
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import DomainLayer
+
+@Suite("ChallengeUseCase Tests")
+struct ChallengeUseCaseTests {
+    @Test("3종 챌린지를 계산하고 신규 완료 상태를 저장한다")
+    func fetchChallenges() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let progressUseCase = MockHydrationProgressUseCase()
+        progressUseCase.snapshot = HydrationProgressSnapshot(
+            dailyGoalML: 2000,
+            weeklyAverageML: 1900,
+            monthlyAverageML: 1800,
+            weeklyAchievementRate: 0.75,
+            monthlyAchievementRate: 0.4,
+            weeklyAchievedDays: 3,
+            monthlyAchievedDays: 5,
+            weeklyElapsedDays: 4,
+            monthlyElapsedDays: 12,
+            currentStreak: 7,
+            isEmpty: false
+        )
+
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        drinkWaterRepository.setHydrationEvents(makeGoalAchievementEvents(calendar: calendar))
+        let challengeRepository = MockChallengeRepository()
+
+        let useCase = ChallengeUseCaseImpl(
+            progressUseCase: progressUseCase,
+            challengeRepository: challengeRepository,
+            drinkWaterRepository: drinkWaterRepository
+        )
+
+        let challenges = await useCase.fetchChallenges(referenceDate: referenceDate, calendar: calendar)
+
+        #expect(challenges.count == 3)
+
+        let streak = challenges.first { $0.kind == .streak7 }
+        #expect(streak?.isCompleted == true)
+        #expect(streak?.progress == 1)
+        #expect(streak?.achievedAt == referenceDate)
+
+        let weekly = challenges.first { $0.kind == .weeklyAchievement80 }
+        #expect(weekly?.isCompleted == false)
+        #expect(weekly?.primaryCurrentValue == 75)
+        #expect(weekly?.secondaryCurrentValue == 3)
+        #expect(weekly?.secondaryTargetValue == 4)
+
+        let count = challenges.first { $0.kind == .goalAchievement30 }
+        #expect(count?.primaryCurrentValue == 12)
+        #expect(count?.primaryTargetValue == 30)
+        #expect(count?.isCompleted == false)
+
+        #expect(challengeRepository.saveChallengeStatesCallCount == 1)
+        #expect(challengeRepository.lastSavedStates.count == 3)
+    }
+
+    @Test("이미 완료한 챌린지는 진행도가 떨어져도 완료 상태와 달성 시점을 유지한다")
+    func keepsPersistedCompletion() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let achievedAt = calendar.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 8))!
+        let progressUseCase = MockHydrationProgressUseCase()
+        progressUseCase.snapshot = HydrationProgressSnapshot(
+            dailyGoalML: 2000,
+            weeklyAverageML: 1200,
+            monthlyAverageML: 1200,
+            weeklyAchievementRate: 0.25,
+            monthlyAchievementRate: 0.25,
+            weeklyAchievedDays: 1,
+            monthlyAchievedDays: 3,
+            weeklyElapsedDays: 4,
+            monthlyElapsedDays: 12,
+            currentStreak: 1,
+            isEmpty: false
+        )
+
+        let challengeRepository = MockChallengeRepository()
+        challengeRepository.setChallengeStates(
+            [
+                HydrationChallengeState(
+                    kind: .weeklyAchievement80,
+                    progress: 1,
+                    isCompleted: true,
+                    achievedAt: achievedAt,
+                    updatedAt: achievedAt
+                )
+            ]
+        )
+
+        let useCase = ChallengeUseCaseImpl(
+            progressUseCase: progressUseCase,
+            challengeRepository: challengeRepository,
+            drinkWaterRepository: MockDrinkWaterRepository()
+        )
+
+        let challenges = await useCase.fetchChallenges(referenceDate: referenceDate, calendar: calendar)
+        let weekly = challenges.first { $0.kind == .weeklyAchievement80 }
+
+        #expect(weekly?.isCompleted == true)
+        #expect(weekly?.progress == 1)
+        #expect(weekly?.achievedAt == achievedAt)
+    }
+
+    private func makeGoalAchievementEvents(calendar: Calendar) -> [HydrationEvent] {
+        let achievedDays = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+
+        return achievedDays.compactMap { day in
+            guard let date = calendar.date(from: DateComponents(year: 2026, month: 3, day: day, hour: 9)) else {
+                return nil
+            }
+
+            return HydrationEvent(
+                id: UUID(),
+                consumedAt: date,
+                volumeML: 2000
+            )
+        }
+    }
+
+    private func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.firstWeekday = 2
+        calendar.minimumDaysInFirstWeek = 4
+        return calendar
+    }
+}

--- a/Project/Domain/Tests/HydrationProgressUseCaseTests.swift
+++ b/Project/Domain/Tests/HydrationProgressUseCaseTests.swift
@@ -1,0 +1,79 @@
+import DomainLayer
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import DomainLayer
+
+@Suite("HydrationProgressUseCase Tests")
+struct HydrationProgressUseCaseTests {
+    @Test("주간/월간 진행 스냅샷과 streak를 계산한다")
+    func progressSnapshot() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        let userPreferencesRepository = MockUserPreferencesRepository()
+        userPreferencesRepository.setDailyWaterLimit(2000)
+        var events: [HydrationEvent] = []
+
+        appendTotal(2500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 9))!, into: &events)
+        appendTotal(1000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!, into: &events)
+        appendTotal(1500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 7, hour: 9))!, into: &events)
+        appendTotal(2000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 9, hour: 9))!, into: &events)
+        appendTotal(2500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 9))!, into: &events)
+        appendTotal(2000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 11, hour: 9))!, into: &events)
+        appendTotal(1000, on: referenceDate, into: &events)
+        drinkWaterRepository.setHydrationEvents(events)
+
+        let useCase = HydrationProgressUseCaseImpl(
+            drinkWaterRepository: drinkWaterRepository,
+            userPreferencesRepository: userPreferencesRepository
+        )
+
+        let snapshot = await useCase.progressSnapshot(referenceDate: referenceDate, calendar: calendar)
+
+        #expect(snapshot.dailyGoalML == 2000)
+        #expect(snapshot.weeklyElapsedDays == 4)
+        #expect(snapshot.monthlyElapsedDays == 12)
+        #expect(snapshot.weeklyAchievedDays == 3)
+        #expect(snapshot.monthlyAchievedDays == 4)
+        #expect(snapshot.weeklyAverageML == 1875)
+        #expect(snapshot.monthlyAverageML == (12500.0 / 12.0))
+        #expect(snapshot.weeklyAchievementRate == 0.75)
+        #expect(snapshot.monthlyAchievementRate == (4.0 / 12.0))
+        #expect(snapshot.currentStreak == 3)
+        #expect(snapshot.isEmpty == false)
+    }
+
+    @Test("최근 기록이 없으면 empty 스냅샷을 반환한다")
+    func progressSnapshotEmptyState() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let useCase = HydrationProgressUseCaseImpl(
+            drinkWaterRepository: MockDrinkWaterRepository(),
+            userPreferencesRepository: MockUserPreferencesRepository()
+        )
+
+        let snapshot = await useCase.progressSnapshot(referenceDate: referenceDate, calendar: calendar)
+
+        #expect(snapshot.isEmpty == true)
+        #expect(snapshot.weeklyAverageML == 0)
+        #expect(snapshot.monthlyAverageML == 0)
+        #expect(snapshot.currentStreak == 0)
+    }
+
+    private func appendTotal(_ volumeML: Int, on date: Date, into events: inout [HydrationEvent]) {
+        events.append(
+            HydrationEvent(id: UUID(), consumedAt: date, volumeML: volumeML)
+        )
+    }
+
+    private func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.firstWeekday = 2
+        calendar.minimumDaysInFirstWeek = 4
+        return calendar
+    }
+}

--- a/Project/Domain/Tests/Mock/MockChallengeRepository.swift
+++ b/Project/Domain/Tests/Mock/MockChallengeRepository.swift
@@ -1,0 +1,25 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockChallengeRepository: ChallengeRepository, @unchecked Sendable {
+    private var states: [HydrationChallengeState] = []
+
+    private(set) var fetchChallengeStatesCallCount = 0
+    private(set) var saveChallengeStatesCallCount = 0
+    private(set) var lastSavedStates: [HydrationChallengeState] = []
+
+    func fetchChallengeStates() -> [HydrationChallengeState] {
+        fetchChallengeStatesCallCount += 1
+        return states
+    }
+
+    func saveChallengeStates(_ states: [HydrationChallengeState]) {
+        saveChallengeStatesCallCount += 1
+        self.states = states
+        lastSavedStates = states
+    }
+
+    func setChallengeStates(_ states: [HydrationChallengeState]) {
+        self.states = states
+    }
+}

--- a/Project/Domain/Tests/Mock/MockHydrationProgressUseCase.swift
+++ b/Project/Domain/Tests/Mock/MockHydrationProgressUseCase.swift
@@ -1,0 +1,10 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockHydrationProgressUseCase: HydrationProgressUseCase, @unchecked Sendable {
+    var snapshot = HydrationProgressSnapshot.empty(dailyGoalML: 2000)
+
+    func progressSnapshot(referenceDate: Date, calendar: Calendar) async -> HydrationProgressSnapshot {
+        snapshot
+    }
+}

--- a/Project/Presentation/Sources/View/Challenge/ChallengeView.swift
+++ b/Project/Presentation/Sources/View/Challenge/ChallengeView.swift
@@ -1,0 +1,167 @@
+import DesignSystem
+import Localization
+import SwiftUI
+
+public struct ChallengeView: View {
+    @State private var viewModel: ChallengeViewModel
+
+    public init(viewModel: ChallengeViewModel) {
+        self._viewModel = State(wrappedValue: viewModel)
+    }
+
+    public var body: some View {
+        NavigationStack {
+            ZStack {
+                LinearGradient(
+                    colors: [
+                        Color.background,
+                        Color.orange.opacity(0.06),
+                        Color.background
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .ignoresSafeArea()
+
+                Group {
+                    if viewModel.isLoading {
+                        ProgressView(L10n.tr("challengeLoadingTitle"))
+                    } else if viewModel.isEmpty {
+                        emptyState
+                    } else {
+                        challengeContent
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+            .navigationTitle(L10n.tr("challengeTitle"))
+            .task {
+                await viewModel.loadChallenges()
+            }
+            .refreshable {
+                await viewModel.loadChallenges()
+            }
+        }
+    }
+
+    private var challengeContent: some View {
+        let summary = viewModel.streakSummary
+
+        return ScrollView {
+            VStack(spacing: 18) {
+                ChallengeCard {
+                    VStack(alignment: .leading, spacing: 18) {
+                        Text(summary.badgeText)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(challengeBadgeColor)
+
+                        Text(summary.title)
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+
+                        HStack(alignment: .firstTextBaseline, spacing: 10) {
+                            Text(summary.valueText)
+                                .font(.system(size: 36, weight: .bold, design: .rounded))
+                                .foregroundStyle(.primary)
+
+                            Text(L10n.tr("challengeCurrentStreakLabel"))
+                                .font(.headline)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Text(summary.description)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        ProgressView(value: summary.progress, total: 1)
+                            .tint(challengeBadgeColor)
+
+                        LazyVGrid(
+                            columns: [
+                                GridItem(.flexible(), spacing: 10),
+                                GridItem(.flexible(), spacing: 10)
+                            ],
+                            spacing: 10
+                        ) {
+                            ForEach(summary.metrics) { metric in
+                                ChallengeMetricTile(metric: metric)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 20)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 18) {
+            Spacer()
+
+            Image(systemName: "trophy")
+                .font(.system(size: 44))
+                .foregroundStyle(Color.orange)
+
+            VStack(spacing: 8) {
+                Text(L10n.tr("challengeEmptyTitle"))
+                    .font(.title3.weight(.bold))
+
+                Text(L10n.tr("challengeEmptyDescription"))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var challengeBadgeColor: Color {
+        viewModel.currentStreak >= 7 ? .orange : .accentColor
+    }
+}
+
+private struct ChallengeCard<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            content
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color(uiColor: .secondarySystemBackground).opacity(0.95))
+        )
+    }
+}
+
+private struct ChallengeMetricTile: View {
+    let metric: ChallengeMetric
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(metric.title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(metric.value)
+                .font(.headline.weight(.bold))
+                .foregroundStyle(.primary)
+
+            Text(metric.detail)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+}

--- a/Project/Presentation/Sources/View/HydrationInsight/HydrationInsightView.swift
+++ b/Project/Presentation/Sources/View/HydrationInsight/HydrationInsightView.swift
@@ -56,7 +56,6 @@ public struct HydrationInsightView: View {
         ScrollView {
             VStack(spacing: 18) {
                 overviewCard
-                streakCard
                 weekdayPatternCard
             }
             .padding(.vertical, 20)
@@ -111,44 +110,6 @@ public struct HydrationInsightView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .shadow(color: .black.opacity(0.08), radius: 20, x: 0, y: 14)
-    }
-
-    private var streakCard: some View {
-        InsightCard(
-            title: L10n.tr("insightStreakCardTitle"),
-            subtitle: L10n.tr("insightStreakCardSubtitle")
-        ) {
-            VStack(alignment: .leading, spacing: 16) {
-                HStack(alignment: .firstTextBaseline, spacing: 10) {
-                    Text(viewModel.streakText)
-                        .font(.system(size: 36, weight: .bold, design: .rounded))
-                    Text(L10n.tr("insightStreakAchievementLabel"))
-                        .font(.headline)
-                        .foregroundStyle(.secondary)
-                }
-
-                VStack(alignment: .leading, spacing: 10) {
-                    AchievementProgressRow(
-                        title: L10n.tr("insightThisWeekLabel"),
-                        detail: L10n.tr(
-                            "insightAchievementDaysFormat",
-                            viewModel.weeklyAchievedDays,
-                            max(viewModel.weeklyElapsedDays, 1)
-                        ),
-                        progress: viewModel.weeklyAchievementRate
-                    )
-                    AchievementProgressRow(
-                        title: L10n.tr("insightThisMonthLabel"),
-                        detail: L10n.tr(
-                            "insightAchievementDaysFormat",
-                            viewModel.monthlyAchievedDays,
-                            max(viewModel.monthlyElapsedDays, 1)
-                        ),
-                        progress: viewModel.monthlyAchievementRate
-                    )
-                }
-            }
-        }
     }
 
     private var weekdayPatternCard: some View {
@@ -304,28 +265,6 @@ private struct OverviewMetricTile: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
         .background(.white.opacity(0.14), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-    }
-}
-
-private struct AchievementProgressRow: View {
-    let title: String
-    let detail: String
-    let progress: Double
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text(title)
-                    .font(.subheadline.weight(.semibold))
-                Spacer()
-                Text(detail)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-
-            ProgressView(value: progress, total: 1)
-                .tint(Color.accent)
-        }
     }
 }
 

--- a/Project/Presentation/Sources/ViewModel/ChallengeViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/ChallengeViewModel.swift
@@ -1,0 +1,227 @@
+import DomainLayerInterface
+import Foundation
+import Localization
+import Observation
+
+struct ChallengeMetric: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let value: String
+    let detail: String
+}
+
+struct ChallengeStreakSummary: Equatable {
+    let badgeText: String
+    let title: String
+    let valueText: String
+    let description: String
+    let progress: Double
+    let metrics: [ChallengeMetric]
+}
+
+@MainActor
+@Observable
+public final class ChallengeViewModel {
+    public private(set) var isLoading = false
+    public private(set) var isEmpty = false
+    public private(set) var dailyGoalML: Double
+    public private(set) var weeklyAchievementRate: Double = 0
+    public private(set) var monthlyAchievementRate: Double = 0
+    public private(set) var weeklyAchievedDays: Int = 0
+    public private(set) var monthlyAchievedDays: Int = 0
+    public private(set) var weeklyElapsedDays: Int = 0
+    public private(set) var monthlyElapsedDays: Int = 0
+    public private(set) var currentStreak: Int = 0
+
+    private let waterUseCase: DrinkWaterUseCase
+    private let userPreferencesUseCase: UserPreferencesUseCase
+    private let calendar: Calendar
+    private let currentDateProvider: @Sendable () -> Date
+    private let streakGoal = 7
+
+    public init(
+        waterUseCase: DrinkWaterUseCase,
+        userPreferencesUseCase: UserPreferencesUseCase,
+        calendar: Calendar = .autoupdatingCurrent,
+        currentDateProvider: @escaping @Sendable () -> Date = { .now }
+    ) {
+        self.waterUseCase = waterUseCase
+        self.userPreferencesUseCase = userPreferencesUseCase
+        self.calendar = calendar
+        self.currentDateProvider = currentDateProvider
+        self.dailyGoalML = userPreferencesUseCase.getDailyWaterLimit()
+    }
+
+    var streakSummary: ChallengeStreakSummary {
+        let isCompleted = currentStreak >= streakGoal
+        let remainingDays = max(streakGoal - currentStreak, 0)
+
+        return ChallengeStreakSummary(
+            badgeText: isCompleted ? L10n.tr("challengeCompletedBadge") : L10n.tr("challengeInProgressBadge"),
+            title: L10n.tr("challengeStreakCardTitle"),
+            valueText: currentStreak > 0
+                ? L10n.tr("challengeCurrentStreakValueFormat", currentStreak)
+                : L10n.tr("challengeCurrentStreakEmptyValue"),
+            description: challengeDescription(isCompleted: isCompleted, remainingDays: remainingDays),
+            progress: min(Double(currentStreak) / Double(streakGoal), 1),
+            metrics: [
+                ChallengeMetric(
+                    id: "weekly",
+                    title: L10n.tr("challengeMetricWeeklyTitle"),
+                    value: percentText(weeklyAchievementRate),
+                    detail: L10n.tr(
+                        "challengeAchievementDaysFormat",
+                        weeklyAchievedDays,
+                        max(weeklyElapsedDays, 1)
+                    )
+                ),
+                ChallengeMetric(
+                    id: "monthly",
+                    title: L10n.tr("challengeMetricMonthlyTitle"),
+                    value: percentText(monthlyAchievementRate),
+                    detail: L10n.tr(
+                        "challengeAchievementDaysFormat",
+                        monthlyAchievedDays,
+                        max(monthlyElapsedDays, 1)
+                    )
+                )
+            ]
+        )
+    }
+
+    public func loadChallenges() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        let referenceDate = currentDateProvider()
+        dailyGoalML = userPreferencesUseCase.getDailyWaterLimit()
+
+        guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: referenceDate),
+              let monthInterval = calendar.dateInterval(of: .month, for: referenceDate) else {
+            resetState()
+            return
+        }
+
+        let elapsedWeekInterval = elapsedInterval(from: weekInterval, upTo: referenceDate)
+        let elapsedMonthInterval = elapsedInterval(from: monthInterval, upTo: referenceDate)
+
+        async let weeklyEvents = waterUseCase.hydrationEvents(in: elapsedWeekInterval)
+        async let monthlyEvents = waterUseCase.hydrationEvents(in: elapsedMonthInterval)
+
+        let (resolvedWeeklyEvents, resolvedMonthlyEvents) = await (weeklyEvents, monthlyEvents)
+        let weeklyTotals = dailyTotals(from: resolvedWeeklyEvents)
+        let monthlyTotals = dailyTotals(from: resolvedMonthlyEvents)
+
+        weeklyElapsedDays = elapsedDayCount(in: elapsedWeekInterval)
+        monthlyElapsedDays = elapsedDayCount(in: elapsedMonthInterval)
+        weeklyAchievedDays = achievedDayCount(in: weeklyTotals)
+        monthlyAchievedDays = achievedDayCount(in: monthlyTotals)
+        weeklyAchievementRate = achievementRate(achievedDays: weeklyAchievedDays, dayCount: weeklyElapsedDays)
+        monthlyAchievementRate = achievementRate(achievedDays: monthlyAchievedDays, dayCount: monthlyElapsedDays)
+        currentStreak = await calculateCurrentStreak(referenceDate: referenceDate)
+        isEmpty = resolvedWeeklyEvents.isEmpty && resolvedMonthlyEvents.isEmpty
+    }
+
+    private func resetState() {
+        isEmpty = true
+        weeklyAchievementRate = 0
+        monthlyAchievementRate = 0
+        weeklyAchievedDays = 0
+        monthlyAchievedDays = 0
+        weeklyElapsedDays = 0
+        monthlyElapsedDays = 0
+        currentStreak = 0
+    }
+
+    private func challengeDescription(isCompleted: Bool, remainingDays: Int) -> String {
+        if currentStreak == 0 {
+            return L10n.tr("challengeStreakStartDescription")
+        }
+
+        if isCompleted {
+            return L10n.tr("challengeCompletedDescription")
+        }
+
+        return L10n.tr("challengeRemainingDaysFormat", remainingDays)
+    }
+
+    private func elapsedInterval(from interval: DateInterval, upTo referenceDate: Date) -> DateInterval {
+        let intervalEnd = calendar.date(
+            byAdding: .day,
+            value: 1,
+            to: calendar.startOfDay(for: referenceDate)
+        ) ?? interval.end
+
+        return DateInterval(
+            start: interval.start,
+            end: min(interval.end, intervalEnd)
+        )
+    }
+
+    private func elapsedDayCount(in interval: DateInterval) -> Int {
+        max(
+            calendar.dateComponents([.day], from: interval.start, to: interval.end).day ?? 0,
+            1
+        )
+    }
+
+    private func dailyTotals(from events: [HydrationEvent]) -> [Date: Double] {
+        events.reduce(into: [:]) { partialResult, event in
+            let day = calendar.startOfDay(for: event.consumedAt)
+            partialResult[day, default: 0] += Double(event.volumeML)
+        }
+    }
+
+    private func achievedDayCount(in totals: [Date: Double]) -> Int {
+        guard dailyGoalML > 0 else {
+            return 0
+        }
+
+        return totals.values.filter { $0 >= dailyGoalML }.count
+    }
+
+    private func achievementRate(achievedDays: Int, dayCount: Int) -> Double {
+        guard dayCount > 0 else {
+            return 0
+        }
+
+        return Double(achievedDays) / Double(dayCount)
+    }
+
+    private func calculateCurrentStreak(referenceDate: Date) async -> Int {
+        guard dailyGoalML > 0 else {
+            return 0
+        }
+
+        var date = calendar.startOfDay(for: referenceDate)
+        if await totalIntake(on: date) < dailyGoalML {
+            guard let previousDate = calendar.date(byAdding: .day, value: -1, to: date) else {
+                return 0
+            }
+            date = previousDate
+        }
+
+        var streak = 0
+
+        while await totalIntake(on: date) >= dailyGoalML {
+            streak += 1
+
+            guard let previousDate = calendar.date(byAdding: .day, value: -1, to: date) else {
+                break
+            }
+            date = previousDate
+        }
+
+        return streak
+    }
+
+    private func totalIntake(on date: Date) async -> Double {
+        (await waterUseCase.hydrationEvents(on: date)).reduce(0) { partialResult, event in
+            partialResult + Double(event.volumeML)
+        }
+    }
+
+    private func percentText(_ ratio: Double) -> String {
+        L10n.tr("commonPercentFormat", Int((ratio * 100).rounded()))
+    }
+}

--- a/Project/Presentation/Sources/ViewModel/ChallengeViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/ChallengeViewModel.swift
@@ -24,7 +24,7 @@ struct ChallengeStreakSummary: Equatable {
 public final class ChallengeViewModel {
     public private(set) var isLoading = false
     public private(set) var isEmpty = false
-    public private(set) var dailyGoalML: Double
+    public private(set) var dailyGoalML: Double = 0
     public private(set) var weeklyAchievementRate: Double = 0
     public private(set) var monthlyAchievementRate: Double = 0
     public private(set) var weeklyAchievedDays: Int = 0
@@ -33,23 +33,19 @@ public final class ChallengeViewModel {
     public private(set) var monthlyElapsedDays: Int = 0
     public private(set) var currentStreak: Int = 0
 
-    private let waterUseCase: DrinkWaterUseCase
-    private let userPreferencesUseCase: UserPreferencesUseCase
+    private let progressUseCase: HydrationProgressUseCase
     private let calendar: Calendar
     private let currentDateProvider: @Sendable () -> Date
     private let streakGoal = 7
 
     public init(
-        waterUseCase: DrinkWaterUseCase,
-        userPreferencesUseCase: UserPreferencesUseCase,
+        progressUseCase: HydrationProgressUseCase,
         calendar: Calendar = .autoupdatingCurrent,
         currentDateProvider: @escaping @Sendable () -> Date = { .now }
     ) {
-        self.waterUseCase = waterUseCase
-        self.userPreferencesUseCase = userPreferencesUseCase
+        self.progressUseCase = progressUseCase
         self.calendar = calendar
         self.currentDateProvider = currentDateProvider
-        self.dailyGoalML = userPreferencesUseCase.getDailyWaterLimit()
     }
 
     var streakSummary: ChallengeStreakSummary {
@@ -93,44 +89,20 @@ public final class ChallengeViewModel {
         isLoading = true
         defer { isLoading = false }
 
-        let referenceDate = currentDateProvider()
-        dailyGoalML = userPreferencesUseCase.getDailyWaterLimit()
+        let snapshot = await progressUseCase.progressSnapshot(
+            referenceDate: currentDateProvider(),
+            calendar: calendar
+        )
 
-        guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: referenceDate),
-              let monthInterval = calendar.dateInterval(of: .month, for: referenceDate) else {
-            resetState()
-            return
-        }
-
-        let elapsedWeekInterval = elapsedInterval(from: weekInterval, upTo: referenceDate)
-        let elapsedMonthInterval = elapsedInterval(from: monthInterval, upTo: referenceDate)
-
-        async let weeklyEvents = waterUseCase.hydrationEvents(in: elapsedWeekInterval)
-        async let monthlyEvents = waterUseCase.hydrationEvents(in: elapsedMonthInterval)
-
-        let (resolvedWeeklyEvents, resolvedMonthlyEvents) = await (weeklyEvents, monthlyEvents)
-        let weeklyTotals = dailyTotals(from: resolvedWeeklyEvents)
-        let monthlyTotals = dailyTotals(from: resolvedMonthlyEvents)
-
-        weeklyElapsedDays = elapsedDayCount(in: elapsedWeekInterval)
-        monthlyElapsedDays = elapsedDayCount(in: elapsedMonthInterval)
-        weeklyAchievedDays = achievedDayCount(in: weeklyTotals)
-        monthlyAchievedDays = achievedDayCount(in: monthlyTotals)
-        weeklyAchievementRate = achievementRate(achievedDays: weeklyAchievedDays, dayCount: weeklyElapsedDays)
-        monthlyAchievementRate = achievementRate(achievedDays: monthlyAchievedDays, dayCount: monthlyElapsedDays)
-        currentStreak = await calculateCurrentStreak(referenceDate: referenceDate)
-        isEmpty = resolvedWeeklyEvents.isEmpty && resolvedMonthlyEvents.isEmpty
-    }
-
-    private func resetState() {
-        isEmpty = true
-        weeklyAchievementRate = 0
-        monthlyAchievementRate = 0
-        weeklyAchievedDays = 0
-        monthlyAchievedDays = 0
-        weeklyElapsedDays = 0
-        monthlyElapsedDays = 0
-        currentStreak = 0
+        dailyGoalML = snapshot.dailyGoalML
+        weeklyAchievementRate = snapshot.weeklyAchievementRate
+        monthlyAchievementRate = snapshot.monthlyAchievementRate
+        weeklyAchievedDays = snapshot.weeklyAchievedDays
+        monthlyAchievedDays = snapshot.monthlyAchievedDays
+        weeklyElapsedDays = snapshot.weeklyElapsedDays
+        monthlyElapsedDays = snapshot.monthlyElapsedDays
+        currentStreak = snapshot.currentStreak
+        isEmpty = snapshot.isEmpty
     }
 
     private func challengeDescription(isCompleted: Bool, remainingDays: Int) -> String {
@@ -143,82 +115,6 @@ public final class ChallengeViewModel {
         }
 
         return L10n.tr("challengeRemainingDaysFormat", remainingDays)
-    }
-
-    private func elapsedInterval(from interval: DateInterval, upTo referenceDate: Date) -> DateInterval {
-        let intervalEnd = calendar.date(
-            byAdding: .day,
-            value: 1,
-            to: calendar.startOfDay(for: referenceDate)
-        ) ?? interval.end
-
-        return DateInterval(
-            start: interval.start,
-            end: min(interval.end, intervalEnd)
-        )
-    }
-
-    private func elapsedDayCount(in interval: DateInterval) -> Int {
-        max(
-            calendar.dateComponents([.day], from: interval.start, to: interval.end).day ?? 0,
-            1
-        )
-    }
-
-    private func dailyTotals(from events: [HydrationEvent]) -> [Date: Double] {
-        events.reduce(into: [:]) { partialResult, event in
-            let day = calendar.startOfDay(for: event.consumedAt)
-            partialResult[day, default: 0] += Double(event.volumeML)
-        }
-    }
-
-    private func achievedDayCount(in totals: [Date: Double]) -> Int {
-        guard dailyGoalML > 0 else {
-            return 0
-        }
-
-        return totals.values.filter { $0 >= dailyGoalML }.count
-    }
-
-    private func achievementRate(achievedDays: Int, dayCount: Int) -> Double {
-        guard dayCount > 0 else {
-            return 0
-        }
-
-        return Double(achievedDays) / Double(dayCount)
-    }
-
-    private func calculateCurrentStreak(referenceDate: Date) async -> Int {
-        guard dailyGoalML > 0 else {
-            return 0
-        }
-
-        var date = calendar.startOfDay(for: referenceDate)
-        if await totalIntake(on: date) < dailyGoalML {
-            guard let previousDate = calendar.date(byAdding: .day, value: -1, to: date) else {
-                return 0
-            }
-            date = previousDate
-        }
-
-        var streak = 0
-
-        while await totalIntake(on: date) >= dailyGoalML {
-            streak += 1
-
-            guard let previousDate = calendar.date(byAdding: .day, value: -1, to: date) else {
-                break
-            }
-            date = previousDate
-        }
-
-        return streak
-    }
-
-    private func totalIntake(on date: Date) async -> Double {
-        (await waterUseCase.hydrationEvents(on: date)).reduce(0) { partialResult, event in
-            partialResult + Double(event.volumeML)
-        }
     }
 
     private func percentText(_ ratio: Double) -> String {

--- a/Project/Presentation/Sources/ViewModel/HydrationInsightViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationInsightViewModel.swift
@@ -8,6 +8,7 @@
 import DomainLayerInterface
 import Foundation
 import Localization
+import Observation
 
 struct HydrationInsightMetric: Identifiable, Equatable {
     let id: String
@@ -31,36 +32,30 @@ struct HydrationInsightWeekdayDistribution: Identifiable, Equatable {
 public final class HydrationInsightViewModel {
     public private(set) var isLoading: Bool = false
     public private(set) var isEmpty: Bool = false
-    public private(set) var dailyGoalML: Double
+    public private(set) var dailyGoalML: Double = 0
     public private(set) var weeklyAverageML: Double = 0
     public private(set) var monthlyAverageML: Double = 0
-    public private(set) var weeklyAchievementRate: Double = 0
-    public private(set) var monthlyAchievementRate: Double = 0
-    public private(set) var weeklyAchievedDays: Int = 0
-    public private(set) var monthlyAchievedDays: Int = 0
     public private(set) var weeklyElapsedDays: Int = 0
     public private(set) var monthlyElapsedDays: Int = 0
-    public private(set) var currentStreak: Int = 0
     private(set) var bestWeekday: HydrationInsightWeekdayDistribution?
     private(set) var leastWeekday: HydrationInsightWeekdayDistribution?
     private(set) var weekdayDistributions: [HydrationInsightWeekdayDistribution] = []
 
     private let waterUseCase: DrinkWaterUseCase
-    private let userPreferencesUseCase: UserPreferencesUseCase
+    private let progressUseCase: HydrationProgressUseCase
     private let calendar: Calendar
     private let currentDateProvider: @Sendable () -> Date
 
     public init(
         waterUseCase: DrinkWaterUseCase,
-        userPreferencesUseCase: UserPreferencesUseCase,
+        progressUseCase: HydrationProgressUseCase,
         calendar: Calendar = .autoupdatingCurrent,
         currentDateProvider: @escaping @Sendable () -> Date = { .now }
     ) {
         self.waterUseCase = waterUseCase
-        self.userPreferencesUseCase = userPreferencesUseCase
+        self.progressUseCase = progressUseCase
         self.calendar = calendar
         self.currentDateProvider = currentDateProvider
-        self.dailyGoalML = userPreferencesUseCase.getDailyWaterLimit()
     }
 
     var metrics: [HydrationInsightMetric] {
@@ -76,32 +71,8 @@ public final class HydrationInsightViewModel {
                 title: L10n.tr("insightMetricMonthlyAverageTitle"),
                 value: volumeText(monthlyAverageML),
                 detail: L10n.tr("insightElapsedDaysFormat", monthlyElapsedDays)
-            ),
-            HydrationInsightMetric(
-                id: "weeklyAchievement",
-                title: L10n.tr("insightMetricWeeklyAchievementTitle"),
-                value: percentText(weeklyAchievementRate),
-                detail: L10n.tr(
-                    "insightAchievementDaysFormat",
-                    weeklyAchievedDays,
-                    max(weeklyElapsedDays, 1)
-                )
-            ),
-            HydrationInsightMetric(
-                id: "monthlyAchievement",
-                title: L10n.tr("insightMetricMonthlyAchievementTitle"),
-                value: percentText(monthlyAchievementRate),
-                detail: L10n.tr(
-                    "insightAchievementDaysFormat",
-                    monthlyAchievedDays,
-                    max(monthlyElapsedDays, 1)
-                )
             )
         ]
-    }
-
-    var streakText: String {
-        L10n.tr("insightStreakValueFormat", currentStreak)
     }
 
     var dailyGoalText: String {
@@ -132,37 +103,33 @@ public final class HydrationInsightViewModel {
         defer { isLoading = false }
 
         let referenceDate = currentDateProvider()
-        dailyGoalML = userPreferencesUseCase.getDailyWaterLimit()
-
-        guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: referenceDate),
-              let monthInterval = calendar.dateInterval(of: .month, for: referenceDate) else {
+        guard let monthInterval = calendar.dateInterval(of: .month, for: referenceDate) else {
             resetInsightState()
             return
         }
 
-        let elapsedWeekInterval = elapsedInterval(from: weekInterval, upTo: referenceDate)
         let elapsedMonthInterval = elapsedInterval(from: monthInterval, upTo: referenceDate)
 
-        async let weeklyEvents = waterUseCase.hydrationEvents(in: elapsedWeekInterval)
+        async let progressSnapshot = progressUseCase.progressSnapshot(
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
         async let monthlyEvents = waterUseCase.hydrationEvents(in: elapsedMonthInterval)
 
-        let (resolvedWeeklyEvents, resolvedMonthlyEvents) = await (weeklyEvents, monthlyEvents)
-        let weeklyTotals = dailyTotals(from: resolvedWeeklyEvents)
-        let monthlyTotals = dailyTotals(from: resolvedMonthlyEvents)
+        let (snapshot, resolvedMonthlyEvents) = await (progressSnapshot, monthlyEvents)
+        dailyGoalML = snapshot.dailyGoalML
+        weeklyAverageML = snapshot.weeklyAverageML
+        monthlyAverageML = snapshot.monthlyAverageML
+        weeklyElapsedDays = snapshot.weeklyElapsedDays
+        monthlyElapsedDays = snapshot.monthlyElapsedDays
+        isEmpty = snapshot.isEmpty
 
-        weeklyElapsedDays = elapsedDayCount(in: elapsedWeekInterval)
-        monthlyElapsedDays = elapsedDayCount(in: elapsedMonthInterval)
-        weeklyAchievedDays = achievedDayCount(in: weeklyTotals)
-        monthlyAchievedDays = achievedDayCount(in: monthlyTotals)
-        weeklyAverageML = averageIntake(from: weeklyTotals, dayCount: weeklyElapsedDays)
-        monthlyAverageML = averageIntake(from: monthlyTotals, dayCount: monthlyElapsedDays)
-        weeklyAchievementRate = achievementRate(achievedDays: weeklyAchievedDays, dayCount: weeklyElapsedDays)
-        monthlyAchievementRate = achievementRate(achievedDays: monthlyAchievedDays, dayCount: monthlyElapsedDays)
         if resolvedMonthlyEvents.isEmpty {
             weekdayDistributions = []
             bestWeekday = nil
             leastWeekday = nil
         } else {
+            let monthlyTotals = dailyTotals(from: resolvedMonthlyEvents)
             weekdayDistributions = makeWeekdayDistributions(
                 from: monthlyTotals,
                 in: elapsedMonthInterval
@@ -174,21 +141,15 @@ public final class HydrationInsightViewModel {
                 lhs.averageIntakeML < rhs.averageIntakeML
             }
         }
-        currentStreak = await calculateCurrentStreak(referenceDate: referenceDate)
-        isEmpty = resolvedWeeklyEvents.isEmpty && resolvedMonthlyEvents.isEmpty
     }
 
     private func resetInsightState() {
         isEmpty = true
+        dailyGoalML = 0
         weeklyAverageML = 0
         monthlyAverageML = 0
-        weeklyAchievementRate = 0
-        monthlyAchievementRate = 0
-        weeklyAchievedDays = 0
-        monthlyAchievedDays = 0
         weeklyElapsedDays = 0
         monthlyElapsedDays = 0
-        currentStreak = 0
         bestWeekday = nil
         leastWeekday = nil
         weekdayDistributions = []
@@ -207,43 +168,11 @@ public final class HydrationInsightViewModel {
         )
     }
 
-    private func elapsedDayCount(in interval: DateInterval) -> Int {
-        max(
-            calendar.dateComponents([.day], from: interval.start, to: interval.end).day ?? 0,
-            1
-        )
-    }
-
     private func dailyTotals(from events: [HydrationEvent]) -> [Date: Double] {
         events.reduce(into: [:]) { partialResult, event in
             let day = calendar.startOfDay(for: event.consumedAt)
             partialResult[day, default: 0] += Double(event.volumeML)
         }
-    }
-
-    private func achievedDayCount(in totals: [Date: Double]) -> Int {
-        guard dailyGoalML > 0 else {
-            return 0
-        }
-
-        return totals.values.filter { $0 >= dailyGoalML }.count
-    }
-
-    private func averageIntake(from totals: [Date: Double], dayCount: Int) -> Double {
-        guard dayCount > 0 else {
-            return 0
-        }
-
-        let totalIntake = totals.values.reduce(0, +)
-        return totalIntake / Double(dayCount)
-    }
-
-    private func achievementRate(achievedDays: Int, dayCount: Int) -> Double {
-        guard dayCount > 0 else {
-            return 0
-        }
-
-        return Double(achievedDays) / Double(dayCount)
     }
 
     private func makeWeekdayDistributions(
@@ -294,44 +223,7 @@ public final class HydrationInsightViewModel {
         return formatter.shortWeekdaySymbols
     }
 
-    private func calculateCurrentStreak(referenceDate: Date) async -> Int {
-        guard dailyGoalML > 0 else {
-            return 0
-        }
-
-        var date = calendar.startOfDay(for: referenceDate)
-        if await totalIntake(on: date) < dailyGoalML {
-            guard let previousDate = calendar.date(byAdding: .day, value: -1, to: date) else {
-                return 0
-            }
-            date = previousDate
-        }
-
-        var streak = 0
-
-        while await totalIntake(on: date) >= dailyGoalML {
-            streak += 1
-
-            guard let previousDate = calendar.date(byAdding: .day, value: -1, to: date) else {
-                break
-            }
-            date = previousDate
-        }
-
-        return streak
-    }
-
-    private func totalIntake(on date: Date) async -> Double {
-        (await waterUseCase.hydrationEvents(on: date)).reduce(0) { partialResult, event in
-            partialResult + Double(event.volumeML)
-        }
-    }
-
     private func volumeText(_ volumeML: Double) -> String {
         L10n.tr("commonMilliliterFormat", Int(volumeML.rounded()))
-    }
-
-    private func percentText(_ ratio: Double) -> String {
-        L10n.tr("commonPercentFormat", Int((ratio * 100).rounded()))
     }
 }

--- a/Project/Presentation/Tests/ChallengeViewModelTests.swift
+++ b/Project/Presentation/Tests/ChallengeViewModelTests.swift
@@ -8,25 +8,27 @@ import Testing
 @Suite("ChallengeViewModel Tests")
 struct ChallengeViewModelTests {
     @MainActor
-    @Test("loadChallenges는 streak와 주간/월간 달성률을 계산한다")
+    @Test("loadChallenges는 진행 스냅샷을 챌린지 상태로 매핑한다")
     func loadChallenges() async {
         let calendar = makeCalendar()
         let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
-        let waterUseCase = MockDrinkWaterUseCase()
-        let userPreferencesUseCase = MockUserPreferencesUseCase()
-        userPreferencesUseCase.dailyWaterLimitValue = 2000
-
-        setTotal(2500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 9))!, using: waterUseCase)
-        setTotal(1000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!, using: waterUseCase)
-        setTotal(1500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 7, hour: 9))!, using: waterUseCase)
-        setTotal(2000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 9, hour: 9))!, using: waterUseCase)
-        setTotal(2500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 9))!, using: waterUseCase)
-        setTotal(2000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 11, hour: 9))!, using: waterUseCase)
-        setTotal(1000, on: referenceDate, using: waterUseCase)
+        let progressUseCase = MockHydrationProgressUseCase()
+        progressUseCase.snapshot = HydrationProgressSnapshot(
+            dailyGoalML: 2000,
+            weeklyAverageML: 1875,
+            monthlyAverageML: 12500.0 / 12.0,
+            weeklyAchievementRate: 0.75,
+            monthlyAchievementRate: 4.0 / 12.0,
+            weeklyAchievedDays: 3,
+            monthlyAchievedDays: 4,
+            weeklyElapsedDays: 4,
+            monthlyElapsedDays: 12,
+            currentStreak: 3,
+            isEmpty: false
+        )
 
         let viewModel = ChallengeViewModel(
-            waterUseCase: waterUseCase,
-            userPreferencesUseCase: userPreferencesUseCase,
+            progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
         )
@@ -43,6 +45,7 @@ struct ChallengeViewModelTests {
         #expect(viewModel.streakSummary.progress == (3.0 / 7.0))
         #expect(viewModel.streakSummary.metrics[0].detail == L10n.tr("challengeAchievementDaysFormat", 3, 4))
         #expect(viewModel.streakSummary.metrics[1].detail == L10n.tr("challengeAchievementDaysFormat", 4, 12))
+        #expect(progressUseCase.requestedReferenceDate == referenceDate)
     }
 
     @MainActor
@@ -50,9 +53,11 @@ struct ChallengeViewModelTests {
     func loadChallengesEmptyState() async {
         let calendar = makeCalendar()
         let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let progressUseCase = MockHydrationProgressUseCase()
+        progressUseCase.snapshot = .empty(dailyGoalML: 2000)
+
         let viewModel = ChallengeViewModel(
-            waterUseCase: MockDrinkWaterUseCase(),
-            userPreferencesUseCase: MockUserPreferencesUseCase(),
+            progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
         )
@@ -69,18 +74,23 @@ struct ChallengeViewModelTests {
     func completedStreakChallenge() async {
         let calendar = makeCalendar()
         let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
-        let waterUseCase = MockDrinkWaterUseCase()
-        let userPreferencesUseCase = MockUserPreferencesUseCase()
-        userPreferencesUseCase.dailyWaterLimitValue = 2000
-
-        for day in 6...12 {
-            let date = calendar.date(from: DateComponents(year: 2026, month: 3, day: day, hour: 9))!
-            setTotal(2000, on: date, using: waterUseCase)
-        }
+        let progressUseCase = MockHydrationProgressUseCase()
+        progressUseCase.snapshot = HydrationProgressSnapshot(
+            dailyGoalML: 2000,
+            weeklyAverageML: 2000,
+            monthlyAverageML: 2000,
+            weeklyAchievementRate: 1,
+            monthlyAchievementRate: 1,
+            weeklyAchievedDays: 7,
+            monthlyAchievedDays: 12,
+            weeklyElapsedDays: 7,
+            monthlyElapsedDays: 12,
+            currentStreak: 7,
+            isEmpty: false
+        )
 
         let viewModel = ChallengeViewModel(
-            waterUseCase: waterUseCase,
-            userPreferencesUseCase: userPreferencesUseCase,
+            progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
         )
@@ -91,13 +101,6 @@ struct ChallengeViewModelTests {
         #expect(viewModel.streakSummary.badgeText == L10n.tr("challengeCompletedBadge"))
         #expect(viewModel.streakSummary.progress == 1)
         #expect(viewModel.streakSummary.description == L10n.tr("challengeCompletedDescription"))
-    }
-
-    private func setTotal(_ volumeML: Int, on date: Date, using useCase: MockDrinkWaterUseCase) {
-        useCase.setHydrationEvents(
-            [HydrationEvent(id: UUID(), consumedAt: date, volumeML: volumeML)],
-            on: date
-        )
     }
 
     private func makeCalendar() -> Calendar {

--- a/Project/Presentation/Tests/ChallengeViewModelTests.swift
+++ b/Project/Presentation/Tests/ChallengeViewModelTests.swift
@@ -1,0 +1,111 @@
+import DomainLayerInterface
+import Foundation
+import Localization
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("ChallengeViewModel Tests")
+struct ChallengeViewModelTests {
+    @MainActor
+    @Test("loadChallenges는 streak와 주간/월간 달성률을 계산한다")
+    func loadChallenges() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let waterUseCase = MockDrinkWaterUseCase()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 2000
+
+        setTotal(2500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 9))!, using: waterUseCase)
+        setTotal(1000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!, using: waterUseCase)
+        setTotal(1500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 7, hour: 9))!, using: waterUseCase)
+        setTotal(2000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 9, hour: 9))!, using: waterUseCase)
+        setTotal(2500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 10, hour: 9))!, using: waterUseCase)
+        setTotal(2000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 11, hour: 9))!, using: waterUseCase)
+        setTotal(1000, on: referenceDate, using: waterUseCase)
+
+        let viewModel = ChallengeViewModel(
+            waterUseCase: waterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            calendar: calendar,
+            currentDateProvider: { referenceDate }
+        )
+
+        await viewModel.loadChallenges()
+
+        #expect(viewModel.isEmpty == false)
+        #expect(viewModel.currentStreak == 3)
+        #expect(viewModel.weeklyAchievementRate == 0.75)
+        #expect(viewModel.monthlyAchievementRate == (4.0 / 12.0))
+        #expect(viewModel.streakSummary.badgeText == L10n.tr("challengeInProgressBadge"))
+        #expect(viewModel.streakSummary.valueText == L10n.tr("challengeCurrentStreakValueFormat", 3))
+        #expect(viewModel.streakSummary.description == L10n.tr("challengeRemainingDaysFormat", 4))
+        #expect(viewModel.streakSummary.progress == (3.0 / 7.0))
+        #expect(viewModel.streakSummary.metrics[0].detail == L10n.tr("challengeAchievementDaysFormat", 3, 4))
+        #expect(viewModel.streakSummary.metrics[1].detail == L10n.tr("challengeAchievementDaysFormat", 4, 12))
+    }
+
+    @MainActor
+    @Test("loadChallenges는 최근 기록이 없으면 empty state를 노출한다")
+    func loadChallengesEmptyState() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let viewModel = ChallengeViewModel(
+            waterUseCase: MockDrinkWaterUseCase(),
+            userPreferencesUseCase: MockUserPreferencesUseCase(),
+            calendar: calendar,
+            currentDateProvider: { referenceDate }
+        )
+
+        await viewModel.loadChallenges()
+
+        #expect(viewModel.isEmpty == true)
+        #expect(viewModel.currentStreak == 0)
+        #expect(viewModel.streakSummary.valueText == L10n.tr("challengeCurrentStreakEmptyValue"))
+    }
+
+    @MainActor
+    @Test("7일 streak를 채우면 완료 상태를 노출한다")
+    func completedStreakChallenge() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let waterUseCase = MockDrinkWaterUseCase()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 2000
+
+        for day in 6...12 {
+            let date = calendar.date(from: DateComponents(year: 2026, month: 3, day: day, hour: 9))!
+            setTotal(2000, on: date, using: waterUseCase)
+        }
+
+        let viewModel = ChallengeViewModel(
+            waterUseCase: waterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            calendar: calendar,
+            currentDateProvider: { referenceDate }
+        )
+
+        await viewModel.loadChallenges()
+
+        #expect(viewModel.currentStreak == 7)
+        #expect(viewModel.streakSummary.badgeText == L10n.tr("challengeCompletedBadge"))
+        #expect(viewModel.streakSummary.progress == 1)
+        #expect(viewModel.streakSummary.description == L10n.tr("challengeCompletedDescription"))
+    }
+
+    private func setTotal(_ volumeML: Int, on date: Date, using useCase: MockDrinkWaterUseCase) {
+        useCase.setHydrationEvents(
+            [HydrationEvent(id: UUID(), consumedAt: date, volumeML: volumeML)],
+            on: date
+        )
+    }
+
+    private func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.firstWeekday = 2
+        calendar.minimumDaysInFirstWeek = 4
+        return calendar
+    }
+}

--- a/Project/Presentation/Tests/HydrationInsightViewModelTests.swift
+++ b/Project/Presentation/Tests/HydrationInsightViewModelTests.swift
@@ -7,13 +7,25 @@ import Testing
 @Suite("HydrationInsightViewModel Tests")
 struct HydrationInsightViewModelTests {
     @MainActor
-    @Test("loadInsights는 주간/월간 지표와 streak를 계산한다")
+    @Test("loadInsights는 공통 진행 스냅샷과 요일 패턴을 함께 반영한다")
     func loadInsights() async {
         let calendar = makeCalendar()
         let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
         let waterUseCase = MockDrinkWaterUseCase()
-        let userPreferencesUseCase = MockUserPreferencesUseCase()
-        userPreferencesUseCase.dailyWaterLimitValue = 2000
+        let progressUseCase = MockHydrationProgressUseCase()
+        progressUseCase.snapshot = HydrationProgressSnapshot(
+            dailyGoalML: 2000,
+            weeklyAverageML: 1875,
+            monthlyAverageML: 12500.0 / 12.0,
+            weeklyAchievementRate: 0.75,
+            monthlyAchievementRate: 4.0 / 12.0,
+            weeklyAchievedDays: 3,
+            monthlyAchievedDays: 4,
+            weeklyElapsedDays: 4,
+            monthlyElapsedDays: 12,
+            currentStreak: 3,
+            isEmpty: false
+        )
 
         setTotal(2500, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 9))!, using: waterUseCase)
         setTotal(1000, on: calendar.date(from: DateComponents(year: 2026, month: 3, day: 6, hour: 9))!, using: waterUseCase)
@@ -25,7 +37,7 @@ struct HydrationInsightViewModelTests {
 
         let viewModel = HydrationInsightViewModel(
             waterUseCase: waterUseCase,
-            userPreferencesUseCase: userPreferencesUseCase,
+            progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
         )
@@ -36,18 +48,14 @@ struct HydrationInsightViewModelTests {
         #expect(viewModel.dailyGoalML == 2000)
         #expect(viewModel.weeklyElapsedDays == 4)
         #expect(viewModel.monthlyElapsedDays == 12)
-        #expect(viewModel.weeklyAchievedDays == 3)
-        #expect(viewModel.monthlyAchievedDays == 4)
         #expect(viewModel.weeklyAverageML == 1875)
         #expect(viewModel.monthlyAverageML == (12500.0 / 12.0))
-        #expect(viewModel.weeklyAchievementRate == 0.75)
-        #expect(viewModel.monthlyAchievementRate == (4.0 / 12.0))
-        #expect(viewModel.currentStreak == 3)
         #expect(viewModel.weekdayDistributions.count == 7)
         #expect(viewModel.bestWeekday?.weekday == 2)
         #expect(viewModel.bestWeekday?.averageIntakeML == 2250)
         #expect(viewModel.leastWeekday?.weekday == 1)
         #expect(viewModel.leastWeekday?.averageIntakeML == 0)
+        #expect(progressUseCase.requestedReferenceDate == referenceDate)
     }
 
     @MainActor
@@ -55,9 +63,12 @@ struct HydrationInsightViewModelTests {
     func loadInsightsEmptyState() async {
         let calendar = makeCalendar()
         let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let progressUseCase = MockHydrationProgressUseCase()
+        progressUseCase.snapshot = .empty(dailyGoalML: 2000)
+
         let viewModel = HydrationInsightViewModel(
             waterUseCase: MockDrinkWaterUseCase(),
-            userPreferencesUseCase: MockUserPreferencesUseCase(),
+            progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
         )
@@ -68,7 +79,7 @@ struct HydrationInsightViewModelTests {
         #expect(viewModel.weeklyAverageML == 0)
         #expect(viewModel.monthlyAverageML == 0)
         #expect(viewModel.weekdayDistributions.isEmpty)
-        #expect(viewModel.currentStreak == 0)
+        #expect(viewModel.dailyGoalML == 2000)
     }
 
     private func setTotal(_ volumeML: Int, on date: Date, using useCase: MockDrinkWaterUseCase) {

--- a/Project/Presentation/Tests/Mock/MockHydrationProgressUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockHydrationProgressUseCase.swift
@@ -1,0 +1,27 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockHydrationProgressUseCase: HydrationProgressUseCase, @unchecked Sendable {
+    var snapshot = HydrationProgressSnapshot(
+        dailyGoalML: 2000,
+        weeklyAverageML: 0,
+        monthlyAverageML: 0,
+        weeklyAchievementRate: 0,
+        monthlyAchievementRate: 0,
+        weeklyAchievedDays: 0,
+        monthlyAchievedDays: 0,
+        weeklyElapsedDays: 0,
+        monthlyElapsedDays: 0,
+        currentStreak: 0,
+        isEmpty: true
+    )
+
+    private(set) var requestedReferenceDate: Date?
+    private(set) var requestedCalendar: Calendar?
+
+    func progressSnapshot(referenceDate: Date, calendar: Calendar) async -> HydrationProgressSnapshot {
+        requestedReferenceDate = referenceDate
+        requestedCalendar = calendar
+        return snapshot
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockHydrationProgressUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockHydrationProgressUseCase.swift
@@ -1,0 +1,28 @@
+import DomainLayerInterface
+import Foundation
+
+public final class MockHydrationProgressUseCase: HydrationProgressUseCase, @unchecked Sendable {
+    public var snapshot: HydrationProgressSnapshot
+
+    public init(
+        snapshot: HydrationProgressSnapshot = HydrationProgressSnapshot(
+            dailyGoalML: 2000,
+            weeklyAverageML: 1750,
+            monthlyAverageML: 1680,
+            weeklyAchievementRate: 0.75,
+            monthlyAchievementRate: 0.58,
+            weeklyAchievedDays: 3,
+            monthlyAchievedDays: 7,
+            weeklyElapsedDays: 4,
+            monthlyElapsedDays: 12,
+            currentStreak: 3,
+            isEmpty: false
+        )
+    ) {
+        self.snapshot = snapshot
+    }
+
+    public func progressSnapshot(referenceDate: Date, calendar: Calendar) async -> HydrationProgressSnapshot {
+        snapshot
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -25,6 +25,9 @@ public final class PreviewAssembly: Assembly {
         container.register(UserPreferencesUseCase.self) { _ in
             MockUserPreferencesUseCase()
         }
+        container.register(HydrationProgressUseCase.self) { _ in
+            MockHydrationProgressUseCase()
+        }
 
         container.register(SignInUseCase.self) { _ in
             MockSignInUseCase()
@@ -54,15 +57,14 @@ public final class PreviewAssembly: Assembly {
         container.register(HydrationInsightViewModel.self) { resolver in
             HydrationInsightViewModel(
                 waterUseCase: resolver.resolve(DrinkWaterUseCase.self)!,
-                userPreferencesUseCase: resolver.resolve(UserPreferencesUseCase.self)!
+                progressUseCase: resolver.resolve(HydrationProgressUseCase.self)!
             )
         }
         .inObjectScope(.container)
 
         container.register(ChallengeViewModel.self) { resolver in
             ChallengeViewModel(
-                waterUseCase: resolver.resolve(DrinkWaterUseCase.self)!,
-                userPreferencesUseCase: resolver.resolve(UserPreferencesUseCase.self)!
+                progressUseCase: resolver.resolve(HydrationProgressUseCase.self)!
             )
         }
         .inObjectScope(.container)

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -59,6 +59,14 @@ public final class PreviewAssembly: Assembly {
         }
         .inObjectScope(.container)
 
+        container.register(ChallengeViewModel.self) { resolver in
+            ChallengeViewModel(
+                waterUseCase: resolver.resolve(DrinkWaterUseCase.self)!,
+                userPreferencesUseCase: resolver.resolve(UserPreferencesUseCase.self)!
+            )
+        }
+        .inObjectScope(.container)
+
         container.register(ProfileRoutineViewModel.self) { resolver in
             let routineUseCase = resolver.resolve(RoutineUseCase.self)!
             let drinkWaterUseCase = resolver.resolve(DrinkWaterUseCase.self)!

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewViewModelFactory.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewViewModelFactory.swift
@@ -25,6 +25,12 @@ public struct PreviewViews {
         return HydrationRecordListView(viewModel: viewModel)
     }
 
+    /// ChallengeView Preview 생성
+    public static var challenge: some View {
+        let viewModel = DIContainer.preview.resolve(ChallengeViewModel.self)
+        return ChallengeView(viewModel: viewModel)
+    }
+
     /// ProfileView Preview 생성
     public static var profile: some View {
         let settingsViewModel = DIContainer.preview.resolve(SettingsViewModel.self)

--- a/Project/Shared/DependencyInjection/Sources/Preview/ViewPreviews.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/ViewPreviews.swift
@@ -29,6 +29,11 @@ import SwiftUI
     HydrationInsightView(viewModel: viewModel)
 }
 
+#Preview("ChallengeView") {
+    let viewModel = DIContainer.preview.resolve(ChallengeViewModel.self)
+    ChallengeView(viewModel: viewModel)
+}
+
 // MARK: - ProfileView Preview
 #Preview("ProfileView") {
     let settingsViewModel = DIContainer.preview.resolve(SettingsViewModel.self)

--- a/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
@@ -66,6 +66,17 @@ public final class DataAssembly: Assembly {
             )
         }
 
+        // MARK: - Challenge
+        container.register(ChallengeStorageDataSource.self) { _ in
+            ChallengeStorageDataSourceImpl(userDefaults: .appGroup)
+        }
+
+        container.register(ChallengeRepository.self) { resolver in
+            ChallengeRepositoryImpl(
+                storageDataSource: resolver.resolve(ChallengeStorageDataSource.self)!
+            )
+        }
+
         // MARK: - Authentication
         container.register(KeyChainDataSource.self) { resolver in
             KeyChainDataSourceImpl()

--- a/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
@@ -17,6 +17,12 @@ public final class DomainAssembly: Assembly {
                 repository: resolver.resolve(DrinkWaterRepository.self)!
             )
         }
+        container.register(HydrationProgressUseCase.self) { resolver in
+            HydrationProgressUseCaseImpl(
+                drinkWaterRepository: resolver.resolve(DrinkWaterRepository.self)!,
+                userPreferencesRepository: resolver.resolve(UserPreferencesRepository.self)!
+            )
+        }
         
         // MARK: - HealthKit
         container.register(HealthKitUseCase.self) { resolver in

--- a/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
@@ -23,6 +23,13 @@ public final class DomainAssembly: Assembly {
                 userPreferencesRepository: resolver.resolve(UserPreferencesRepository.self)!
             )
         }
+        container.register(ChallengeUseCase.self) { resolver in
+            ChallengeUseCaseImpl(
+                progressUseCase: resolver.resolve(HydrationProgressUseCase.self)!,
+                challengeRepository: resolver.resolve(ChallengeRepository.self)!,
+                drinkWaterRepository: resolver.resolve(DrinkWaterRepository.self)!
+            )
+        }
         
         // MARK: - HealthKit
         container.register(HealthKitUseCase.self) { resolver in

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -53,25 +53,23 @@ public final class PresentationAssembly: Assembly {
 
         container.register(HydrationInsightViewModel.self) { resolver in
             let waterUseCase = resolver.resolve(DrinkWaterUseCase.self)!
-            let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
+            let progressUseCase = resolver.resolve(HydrationProgressUseCase.self)!
 
             return MainActor.assumeIsolated {
                 HydrationInsightViewModel(
                     waterUseCase: waterUseCase,
-                    userPreferencesUseCase: userPreferencesUseCase
+                    progressUseCase: progressUseCase
                 )
             }
         }
         .inObjectScope(.container)
 
         container.register(ChallengeViewModel.self) { resolver in
-            let waterUseCase = resolver.resolve(DrinkWaterUseCase.self)!
-            let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
+            let progressUseCase = resolver.resolve(HydrationProgressUseCase.self)!
 
             return MainActor.assumeIsolated {
                 ChallengeViewModel(
-                    waterUseCase: waterUseCase,
-                    userPreferencesUseCase: userPreferencesUseCase
+                    progressUseCase: progressUseCase
                 )
             }
         }

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -64,6 +64,19 @@ public final class PresentationAssembly: Assembly {
         }
         .inObjectScope(.container)
 
+        container.register(ChallengeViewModel.self) { resolver in
+            let waterUseCase = resolver.resolve(DrinkWaterUseCase.self)!
+            let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
+
+            return MainActor.assumeIsolated {
+                ChallengeViewModel(
+                    waterUseCase: waterUseCase,
+                    userPreferencesUseCase: userPreferencesUseCase
+                )
+            }
+        }
+        .inObjectScope(.container)
+
         container.register(ProfileRoutineViewModel.self) { resolver in
             let routineUseCase = resolver.resolve(RoutineUseCase.self)!
             let drinkWaterUseCase = resolver.resolve(DrinkWaterUseCase.self)!

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockHydrationProgressUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockHydrationProgressUseCaseForTesting.swift
@@ -1,0 +1,28 @@
+import DomainLayerInterface
+import Foundation
+
+public final class MockHydrationProgressUseCaseForTesting: HydrationProgressUseCase, @unchecked Sendable {
+    public var snapshot: HydrationProgressSnapshot
+
+    public init(
+        snapshot: HydrationProgressSnapshot = HydrationProgressSnapshot(
+            dailyGoalML: 2000,
+            weeklyAverageML: 0,
+            monthlyAverageML: 0,
+            weeklyAchievementRate: 0,
+            monthlyAchievementRate: 0,
+            weeklyAchievedDays: 0,
+            monthlyAchievedDays: 0,
+            weeklyElapsedDays: 0,
+            monthlyElapsedDays: 0,
+            currentStreak: 0,
+            isEmpty: true
+        )
+    ) {
+        self.snapshot = snapshot
+    }
+
+    public func progressSnapshot(referenceDate: Date, calendar: Calendar) async -> HydrationProgressSnapshot {
+        snapshot
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Testing/TestingAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/TestingAssembly.swift
@@ -24,6 +24,9 @@ public final class TestingAssembly: Assembly {
         container.register(UserPreferencesUseCase.self) { _ in
             MockUserPreferencesUseCaseForTesting()
         }
+        container.register(HydrationProgressUseCase.self) { _ in
+            MockHydrationProgressUseCaseForTesting()
+        }
 
         container.register(RoutineUseCase.self) { _ in
             MockRoutineUseCaseForTesting()

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -12,6 +12,182 @@
         }
       }
     },
+    "challengeAchievementDaysFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lld일 달성"
+          }
+        }
+      }
+    },
+    "challengeCompletedBadge" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료"
+          }
+        }
+      }
+    },
+    "challengeCompletedDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7일 연속 챌린지를 달성했어요."
+          }
+        }
+      }
+    },
+    "challengeCurrentStreakEmptyValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0일"
+          }
+        }
+      }
+    },
+    "challengeCurrentStreakLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 streak"
+          }
+        }
+      }
+    },
+    "challengeCurrentStreakValueFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld일"
+          }
+        }
+      }
+    },
+    "challengeEmptyDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 목표를 달성하면 연속 달성 챌린지 진행이 여기에 표시됩니다."
+          }
+        }
+      }
+    },
+    "challengeEmptyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아직 챌린지가 시작되지 않았어요"
+          }
+        }
+      }
+    },
+    "challengeInProgressBadge" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "진행 중"
+          }
+        }
+      }
+    },
+    "challengeLoadingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "챌린지를 불러오는 중..."
+          }
+        }
+      }
+    },
+    "challengeMetricMonthlyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 달 달성률"
+          }
+        }
+      }
+    },
+    "challengeMetricWeeklyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주 달성률"
+          }
+        }
+      }
+    },
+    "challengeRemainingDaysFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7일 챌린지까지 %lld일 남았어요."
+          }
+        }
+      }
+    },
+    "challengeStreakCardTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7일 연속 목표 달성"
+          }
+        }
+      }
+    },
+    "challengeStreakStartDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 목표를 달성하면 streak가 시작돼요."
+          }
+        }
+      }
+    },
+    "challengeTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "챌린지"
+          }
+        }
+      }
+    },
     "commonCancelTitle" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Project/Shared/Utils/Sources/String+Extensions.swift
+++ b/Project/Shared/Utils/Sources/String+Extensions.swift
@@ -24,4 +24,5 @@ public extension String {
     static let mainAppearance: String = "mainAppearance"
     static let dailyWaterLimit: String = "dailyWaterLimit"
     static let hydrationRoutines: String = "hydrationRoutines"
+    static let hydrationChallengeStates: String = "hydrationChallengeStates"
 }


### PR DESCRIPTION
## 📝 Summary
챌린지 탭의 foundation 작업을 먼저 올립니다.
인사이트 탭의 streak를 분리하고, 챌린지 탭 골격과 공통 진행 계산 계층, 챌린지 상태 영속화 레이어를 추가했습니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [x] ♻️ Refactoring (코드 리팩토링)
- [x] 🧪 Test (테스트 추가/수정)

## 🔗 Related Issues
- Closes #
- Related to #95

## 📋 Changes Made
### Added
- 챌린지 탭 기본 화면 및 ViewModel 골격 추가
- 공통 진행 계산용 `HydrationProgressUseCase` 및 snapshot 모델 추가
- 챌린지 상태 저장용 repository/data source 계층 추가
- Domain/Data/Presentation 테스트 추가

### Changed
- 인사이트 탭에서 streak 섹션을 제거하고 평균 중심 지표로 역할을 정리
- Challenge/Insight가 중복 계산 대신 공통 진행 snapshot을 사용하도록 변경
- DI 등록에 challenge/progress use case 및 persistence 경로 추가

### Fixed
- 진행 계산 테스트에서 이벤트 누적이 덮어써지던 헬퍼 문제 수정

### Removed
- 인사이트 탭 streak 카드

## 🔍 Technical Details
- `HydrationProgressUseCase`가 주간/월간 평균, 달성률, streak 계산을 공통 제공
- `ChallengeUseCase`와 `ChallengeRepository`를 추가해 챌린지 완료 상태를 저장할 수 있는 기반을 만들었습니다
- 현재 PR은 foundation 단계까지 포함하며, 3종 챌린지 카드 UI 마무리는 이어서 진행 예정입니다

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [x] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS 18.0 Simulator
- Device: iPhone 17
- Xcode Version: 17C529

### Test Results
- `tuist generate`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer -destination "platform=iOS Simulator,name=iPhone 17"`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination "platform=iOS Simulator,name=iPhone 17"`
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- 드래프트 PR입니다. `#95`의 4단계 UI 마감 전 단계까지를 먼저 공유합니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
