### PR TITLE
feat: separate challenge earned UI

### DIFF
--- a/Project/Presentation/Sources/View/Challenge/ChallengeView.swift
+++ b/Project/Presentation/Sources/View/Challenge/ChallengeView.swift
@@ -15,7 +15,7 @@ public struct ChallengeView: View {
                 LinearGradient(
                     colors: [
                         Color.background,
-                        Color.orange.opacity(0.06),
+                        Color.orange.opacity(0.05),
                         Color.background
                     ],
                     startPoint: .topLeading,
@@ -45,48 +45,30 @@ public struct ChallengeView: View {
     }
 
     private var challengeContent: some View {
-        let summary = viewModel.streakSummary
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                if viewModel.inProgressChallenges.isEmpty == false {
+                    ChallengeSectionHeader(
+                        title: L10n.tr("challengeInProgressSectionTitle"),
+                        subtitle: L10n.tr("challengeInProgressSectionDescription")
+                    )
 
-        return ScrollView {
-            VStack(spacing: 18) {
-                ChallengeCard {
-                    VStack(alignment: .leading, spacing: 18) {
-                        Text(summary.badgeText)
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(challengeBadgeColor)
-
-                        Text(summary.title)
-                            .font(.headline)
-                            .foregroundStyle(.primary)
-
-                        HStack(alignment: .firstTextBaseline, spacing: 10) {
-                            Text(summary.valueText)
-                                .font(.system(size: 36, weight: .bold, design: .rounded))
-                                .foregroundStyle(.primary)
-
-                            Text(L10n.tr("challengeCurrentStreakLabel"))
-                                .font(.headline)
-                                .foregroundStyle(.secondary)
+                    VStack(spacing: 14) {
+                        ForEach(viewModel.inProgressChallenges) { challenge in
+                            ChallengeCard(challenge: challenge)
                         }
+                    }
+                }
 
-                        Text(summary.description)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
+                if viewModel.completedChallenges.isEmpty == false {
+                    ChallengeSectionHeader(
+                        title: L10n.tr("challengeCompletedSectionTitle"),
+                        subtitle: L10n.tr("challengeCompletedSectionDescription")
+                    )
 
-                        ProgressView(value: summary.progress, total: 1)
-                            .tint(challengeBadgeColor)
-
-                        LazyVGrid(
-                            columns: [
-                                GridItem(.flexible(), spacing: 10),
-                                GridItem(.flexible(), spacing: 10)
-                            ],
-                            spacing: 10
-                        ) {
-                            ForEach(summary.metrics) { metric in
-                                ChallengeMetricTile(metric: metric)
-                            }
+                    VStack(spacing: 14) {
+                        ForEach(viewModel.completedChallenges) { challenge in
+                            ChallengeCard(challenge: challenge)
                         }
                     }
                 }
@@ -117,51 +99,139 @@ public struct ChallengeView: View {
         }
         .frame(maxWidth: .infinity)
     }
+}
 
-    private var challengeBadgeColor: Color {
-        viewModel.currentStreak >= 7 ? .orange : .accentColor
+private struct ChallengeSectionHeader: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.title3.weight(.bold))
+                .foregroundStyle(.primary)
+
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
     }
 }
 
-private struct ChallengeCard<Content: View>: View {
-    let content: Content
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
+private struct ChallengeCard: View {
+    let challenge: ChallengeCardModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            content
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 10) {
+                    ChallengeBadge(
+                        title: challenge.badgeText,
+                        color: accentColor
+                    )
+
+                    Text(challenge.title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+
+                    Text(challenge.description)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 12)
+
+                Image(systemName: challenge.symbolName)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(accentColor)
+                    .frame(width: 42, height: 42)
+                    .background(
+                        Circle()
+                            .fill(accentColor.opacity(challenge.isCompleted ? 0.18 : 0.12))
+                    )
+            }
+
+            HStack(alignment: .lastTextBaseline, spacing: 10) {
+                Text(challenge.valueText)
+                    .font(.system(size: 32, weight: .bold, design: .rounded))
+                    .foregroundStyle(.primary)
+
+                Text(challenge.progressText)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            ProgressView(value: challenge.progress, total: 1)
+                .tint(accentColor)
+
+            if let achievedAtText = challenge.achievedAtText {
+                Label(achievedAtText, systemImage: "checkmark.seal.fill")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(accentColor)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .fill(Color(uiColor: .secondarySystemBackground).opacity(0.95))
-        )
+        .background(cardBackground)
+        .overlay(alignment: .topTrailing) {
+            if challenge.isCompleted {
+                Image(systemName: "sparkles")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(accentColor.opacity(0.9))
+                    .padding(16)
+            }
+        }
+    }
+
+    private var accentColor: Color {
+        switch challenge.kind {
+        case .streak7:
+            return .orange
+        case .weeklyAchievement80:
+            return .mint
+        case .goalAchievement30:
+            return .blue
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 24, style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: challenge.isCompleted
+                        ? [
+                            accentColor.opacity(0.22),
+                            Color(uiColor: .secondarySystemBackground).opacity(0.96)
+                        ]
+                        : [
+                            Color(uiColor: .secondarySystemBackground).opacity(0.98),
+                            accentColor.opacity(0.06)
+                        ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .stroke(accentColor.opacity(challenge.isCompleted ? 0.22 : 0.08), lineWidth: 1)
+            )
     }
 }
 
-private struct ChallengeMetricTile: View {
-    let metric: ChallengeMetric
+private struct ChallengeBadge: View {
+    let title: String
+    let color: Color
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(metric.title)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Text(metric.value)
-                .font(.headline.weight(.bold))
-                .foregroundStyle(.primary)
-
-            Text(metric.detail)
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
-        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(color.opacity(0.12))
+            )
     }
 }

--- a/Project/Presentation/Sources/ViewModel/ChallengeViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/ChallengeViewModel.swift
@@ -3,121 +3,213 @@ import Foundation
 import Localization
 import Observation
 
-struct ChallengeMetric: Identifiable, Equatable {
-    let id: String
-    let title: String
-    let value: String
-    let detail: String
-}
-
-struct ChallengeStreakSummary: Equatable {
+struct ChallengeCardModel: Identifiable, Equatable {
+    let id: HydrationChallengeKind
+    let kind: HydrationChallengeKind
     let badgeText: String
     let title: String
+    let symbolName: String
     let valueText: String
     let description: String
     let progress: Double
-    let metrics: [ChallengeMetric]
+    let progressText: String
+    let achievedAt: Date?
+    let achievedAtText: String?
+    let isCompleted: Bool
 }
 
 @MainActor
 @Observable
 public final class ChallengeViewModel {
-    public private(set) var isLoading = false
-    public private(set) var isEmpty = false
-    public private(set) var dailyGoalML: Double = 0
-    public private(set) var weeklyAchievementRate: Double = 0
-    public private(set) var monthlyAchievementRate: Double = 0
-    public private(set) var weeklyAchievedDays: Int = 0
-    public private(set) var monthlyAchievedDays: Int = 0
-    public private(set) var weeklyElapsedDays: Int = 0
-    public private(set) var monthlyElapsedDays: Int = 0
-    public private(set) var currentStreak: Int = 0
+    private(set) var isLoading = false
+    private(set) var isEmpty = false
+    private(set) var inProgressChallenges: [ChallengeCardModel] = []
+    private(set) var completedChallenges: [ChallengeCardModel] = []
 
+    private let challengeUseCase: ChallengeUseCase
     private let progressUseCase: HydrationProgressUseCase
     private let calendar: Calendar
     private let currentDateProvider: @Sendable () -> Date
-    private let streakGoal = 7
 
     public init(
+        challengeUseCase: ChallengeUseCase,
         progressUseCase: HydrationProgressUseCase,
         calendar: Calendar = .autoupdatingCurrent,
         currentDateProvider: @escaping @Sendable () -> Date = { .now }
     ) {
+        self.challengeUseCase = challengeUseCase
         self.progressUseCase = progressUseCase
         self.calendar = calendar
         self.currentDateProvider = currentDateProvider
-    }
-
-    var streakSummary: ChallengeStreakSummary {
-        let isCompleted = currentStreak >= streakGoal
-        let remainingDays = max(streakGoal - currentStreak, 0)
-
-        return ChallengeStreakSummary(
-            badgeText: isCompleted ? L10n.tr("challengeCompletedBadge") : L10n.tr("challengeInProgressBadge"),
-            title: L10n.tr("challengeStreakCardTitle"),
-            valueText: currentStreak > 0
-                ? L10n.tr("challengeCurrentStreakValueFormat", currentStreak)
-                : L10n.tr("challengeCurrentStreakEmptyValue"),
-            description: challengeDescription(isCompleted: isCompleted, remainingDays: remainingDays),
-            progress: min(Double(currentStreak) / Double(streakGoal), 1),
-            metrics: [
-                ChallengeMetric(
-                    id: "weekly",
-                    title: L10n.tr("challengeMetricWeeklyTitle"),
-                    value: percentText(weeklyAchievementRate),
-                    detail: L10n.tr(
-                        "challengeAchievementDaysFormat",
-                        weeklyAchievedDays,
-                        max(weeklyElapsedDays, 1)
-                    )
-                ),
-                ChallengeMetric(
-                    id: "monthly",
-                    title: L10n.tr("challengeMetricMonthlyTitle"),
-                    value: percentText(monthlyAchievementRate),
-                    detail: L10n.tr(
-                        "challengeAchievementDaysFormat",
-                        monthlyAchievedDays,
-                        max(monthlyElapsedDays, 1)
-                    )
-                )
-            ]
-        )
     }
 
     public func loadChallenges() async {
         isLoading = true
         defer { isLoading = false }
 
+        let referenceDate = currentDateProvider()
         let snapshot = await progressUseCase.progressSnapshot(
-            referenceDate: currentDateProvider(),
+            referenceDate: referenceDate,
             calendar: calendar
         )
 
-        dailyGoalML = snapshot.dailyGoalML
-        weeklyAchievementRate = snapshot.weeklyAchievementRate
-        monthlyAchievementRate = snapshot.monthlyAchievementRate
-        weeklyAchievedDays = snapshot.weeklyAchievedDays
-        monthlyAchievedDays = snapshot.monthlyAchievedDays
-        weeklyElapsedDays = snapshot.weeklyElapsedDays
-        monthlyElapsedDays = snapshot.monthlyElapsedDays
-        currentStreak = snapshot.currentStreak
         isEmpty = snapshot.isEmpty
-    }
-
-    private func challengeDescription(isCompleted: Bool, remainingDays: Int) -> String {
-        if currentStreak == 0 {
-            return L10n.tr("challengeStreakStartDescription")
+        guard snapshot.isEmpty == false else {
+            inProgressChallenges = []
+            completedChallenges = []
+            return
         }
 
-        if isCompleted {
-            return L10n.tr("challengeCompletedDescription")
-        }
+        let challenges = await challengeUseCase.fetchChallenges(
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
 
-        return L10n.tr("challengeRemainingDaysFormat", remainingDays)
+        let cards = challenges.map(makeCardModel)
+
+        inProgressChallenges = cards
+            .filter { $0.isCompleted == false }
+            .sorted(by: inProgressSort)
+        completedChallenges = cards
+            .filter(\.isCompleted)
+            .sorted(by: completedSort)
     }
 
-    private func percentText(_ ratio: Double) -> String {
-        L10n.tr("commonPercentFormat", Int((ratio * 100).rounded()))
+    private func makeCardModel(from challenge: HydrationChallenge) -> ChallengeCardModel {
+        ChallengeCardModel(
+            id: challenge.kind,
+            kind: challenge.kind,
+            badgeText: challenge.isCompleted
+                ? L10n.tr("challengeEarnedBadge")
+                : L10n.tr("challengeInProgressBadge"),
+            title: title(for: challenge.kind),
+            symbolName: symbolName(for: challenge.kind),
+            valueText: valueText(for: challenge),
+            description: description(for: challenge),
+            progress: challenge.progress,
+            progressText: progressText(for: challenge),
+            achievedAt: challenge.achievedAt,
+            achievedAtText: challenge.achievedAt.map(achievedAtText),
+            isCompleted: challenge.isCompleted
+        )
+    }
+
+    private func title(for kind: HydrationChallengeKind) -> String {
+        switch kind {
+        case .streak7:
+            return L10n.tr("challengeStreakCardTitle")
+        case .weeklyAchievement80:
+            return L10n.tr("challengeWeeklyCardTitle")
+        case .goalAchievement30:
+            return L10n.tr("challengeGoalCardTitle")
+        }
+    }
+
+    private func symbolName(for kind: HydrationChallengeKind) -> String {
+        switch kind {
+        case .streak7:
+            return "flame.fill"
+        case .weeklyAchievement80:
+            return "calendar.badge.checkmark"
+        case .goalAchievement30:
+            return "target"
+        }
+    }
+
+    private func valueText(for challenge: HydrationChallenge) -> String {
+        switch challenge.kind {
+        case .streak7:
+            return challenge.primaryCurrentValue > 0
+                ? L10n.tr("challengeCurrentStreakValueFormat", challenge.primaryCurrentValue)
+                : L10n.tr("challengeCurrentStreakEmptyValue")
+        case .weeklyAchievement80:
+            return L10n.tr("commonPercentFormat", challenge.primaryCurrentValue)
+        case .goalAchievement30:
+            return L10n.tr("challengeGoalValueFormat", challenge.primaryCurrentValue)
+        }
+    }
+
+    private func description(for challenge: HydrationChallenge) -> String {
+        switch challenge.kind {
+        case .streak7:
+            let remainingDays = max(challenge.primaryTargetValue - challenge.primaryCurrentValue, 0)
+            if challenge.isCompleted {
+                return L10n.tr("challengeCompletedDescription")
+            }
+            if challenge.primaryCurrentValue == 0 {
+                return L10n.tr("challengeStreakStartDescription")
+            }
+            return L10n.tr("challengeRemainingDaysFormat", remainingDays)
+
+        case .weeklyAchievement80:
+            let achievedDays = challenge.secondaryCurrentValue ?? 0
+            let elapsedDays = max(challenge.secondaryTargetValue ?? 1, 1)
+
+            if challenge.isCompleted {
+                return L10n.tr("challengeWeeklyCompletedDescription")
+            }
+            return L10n.tr("challengeWeeklyProgressDescriptionFormat", achievedDays, elapsedDays)
+
+        case .goalAchievement30:
+            let remainingCount = max(challenge.primaryTargetValue - challenge.primaryCurrentValue, 0)
+
+            if challenge.isCompleted {
+                return L10n.tr("challengeGoalCompletedDescription")
+            }
+            if challenge.primaryCurrentValue == 0 {
+                return L10n.tr("challengeGoalStartDescription")
+            }
+            return L10n.tr("challengeGoalRemainingCountFormat", remainingCount)
+        }
+    }
+
+    private func progressText(for challenge: HydrationChallenge) -> String {
+        switch challenge.kind {
+        case .streak7:
+            return L10n.tr(
+                "challengeProgressDaysFormat",
+                challenge.primaryCurrentValue,
+                challenge.primaryTargetValue
+            )
+        case .weeklyAchievement80:
+            return L10n.tr(
+                "challengeAchievementDaysFormat",
+                challenge.secondaryCurrentValue ?? 0,
+                max(challenge.secondaryTargetValue ?? 1, 1)
+            )
+        case .goalAchievement30:
+            return L10n.tr(
+                "challengeProgressCountFormat",
+                challenge.primaryCurrentValue,
+                challenge.primaryTargetValue
+            )
+        }
+    }
+
+    private func achievedAtText(for date: Date) -> String {
+        let formattedDate = date.formatted(
+            .dateTime
+                .locale(Locale(identifier: "ko_KR"))
+                .month(.wide)
+                .day()
+        )
+        return L10n.tr("challengeAchievedAtFormat", formattedDate)
+    }
+
+    private func inProgressSort(lhs: ChallengeCardModel, rhs: ChallengeCardModel) -> Bool {
+        if lhs.progress != rhs.progress {
+            return lhs.progress > rhs.progress
+        }
+
+        return lhs.kind.rawValue < rhs.kind.rawValue
+    }
+
+    private func completedSort(lhs: ChallengeCardModel, rhs: ChallengeCardModel) -> Bool {
+        switch (lhs.achievedAt, rhs.achievedAt) {
+        case let (left?, right?) where left != right:
+            return left > right
+        default:
+            return lhs.kind.rawValue < rhs.kind.rawValue
+        }
     }
 }

--- a/Project/Presentation/Tests/ChallengeViewModelTests.swift
+++ b/Project/Presentation/Tests/ChallengeViewModelTests.swift
@@ -8,7 +8,7 @@ import Testing
 @Suite("ChallengeViewModel Tests")
 struct ChallengeViewModelTests {
     @MainActor
-    @Test("loadChallenges는 진행 스냅샷을 챌린지 상태로 매핑한다")
+    @Test("loadChallenges는 진행 중 챌린지와 획득한 챌린지를 분리한다")
     func loadChallenges() async {
         let calendar = makeCalendar()
         let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
@@ -26,8 +26,44 @@ struct ChallengeViewModelTests {
             currentStreak: 3,
             isEmpty: false
         )
+        let challengeUseCase = MockChallengeUseCase()
+        challengeUseCase.challenges = [
+            HydrationChallenge(
+                kind: .streak7,
+                progress: 3.0 / 7.0,
+                currentValue: 3,
+                targetValue: 7,
+                primaryCurrentValue: 3,
+                primaryTargetValue: 7,
+                isCompleted: false,
+                achievedAt: nil
+            ),
+            HydrationChallenge(
+                kind: .weeklyAchievement80,
+                progress: 1,
+                currentValue: 0.8,
+                targetValue: 0.8,
+                primaryCurrentValue: 80,
+                primaryTargetValue: 80,
+                secondaryCurrentValue: 4,
+                secondaryTargetValue: 5,
+                isCompleted: true,
+                achievedAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 11))
+            ),
+            HydrationChallenge(
+                kind: .goalAchievement30,
+                progress: 12.0 / 30.0,
+                currentValue: 12,
+                targetValue: 30,
+                primaryCurrentValue: 12,
+                primaryTargetValue: 30,
+                isCompleted: false,
+                achievedAt: nil
+            )
+        ]
 
         let viewModel = ChallengeViewModel(
+            challengeUseCase: challengeUseCase,
             progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
@@ -36,16 +72,15 @@ struct ChallengeViewModelTests {
         await viewModel.loadChallenges()
 
         #expect(viewModel.isEmpty == false)
-        #expect(viewModel.currentStreak == 3)
-        #expect(viewModel.weeklyAchievementRate == 0.75)
-        #expect(viewModel.monthlyAchievementRate == (4.0 / 12.0))
-        #expect(viewModel.streakSummary.badgeText == L10n.tr("challengeInProgressBadge"))
-        #expect(viewModel.streakSummary.valueText == L10n.tr("challengeCurrentStreakValueFormat", 3))
-        #expect(viewModel.streakSummary.description == L10n.tr("challengeRemainingDaysFormat", 4))
-        #expect(viewModel.streakSummary.progress == (3.0 / 7.0))
-        #expect(viewModel.streakSummary.metrics[0].detail == L10n.tr("challengeAchievementDaysFormat", 3, 4))
-        #expect(viewModel.streakSummary.metrics[1].detail == L10n.tr("challengeAchievementDaysFormat", 4, 12))
-        #expect(progressUseCase.requestedReferenceDate == referenceDate)
+        #expect(viewModel.inProgressChallenges.count == 2)
+        #expect(viewModel.completedChallenges.count == 1)
+        #expect(viewModel.inProgressChallenges.first?.kind == .streak7)
+        #expect(viewModel.completedChallenges.first?.kind == .weeklyAchievement80)
+        #expect(viewModel.completedChallenges.first?.badgeText == L10n.tr("challengeEarnedBadge"))
+        #expect(viewModel.completedChallenges.first?.achievedAtText != nil)
+        #expect(viewModel.inProgressChallenges.first?.description == L10n.tr("challengeRemainingDaysFormat", 4))
+        #expect(viewModel.inProgressChallenges.last?.title == L10n.tr("challengeGoalCardTitle"))
+        #expect(challengeUseCase.requestedReferenceDate == referenceDate)
     }
 
     @MainActor
@@ -55,8 +90,10 @@ struct ChallengeViewModelTests {
         let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
         let progressUseCase = MockHydrationProgressUseCase()
         progressUseCase.snapshot = .empty(dailyGoalML: 2000)
+        let challengeUseCase = MockChallengeUseCase()
 
         let viewModel = ChallengeViewModel(
+            challengeUseCase: challengeUseCase,
             progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
@@ -65,13 +102,14 @@ struct ChallengeViewModelTests {
         await viewModel.loadChallenges()
 
         #expect(viewModel.isEmpty == true)
-        #expect(viewModel.currentStreak == 0)
-        #expect(viewModel.streakSummary.valueText == L10n.tr("challengeCurrentStreakEmptyValue"))
+        #expect(viewModel.inProgressChallenges.isEmpty)
+        #expect(viewModel.completedChallenges.isEmpty)
+        #expect(challengeUseCase.requestedReferenceDate == nil)
     }
 
     @MainActor
-    @Test("7일 streak를 채우면 완료 상태를 노출한다")
-    func completedStreakChallenge() async {
+    @Test("획득한 챌린지는 최근 획득 순으로 정렬한다")
+    func completedChallengesAreSortedByAchievedAt() async {
         let calendar = makeCalendar()
         let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
         let progressUseCase = MockHydrationProgressUseCase()
@@ -82,14 +120,38 @@ struct ChallengeViewModelTests {
             weeklyAchievementRate: 1,
             monthlyAchievementRate: 1,
             weeklyAchievedDays: 7,
-            monthlyAchievedDays: 12,
+            monthlyAchievedDays: 20,
             weeklyElapsedDays: 7,
-            monthlyElapsedDays: 12,
+            monthlyElapsedDays: 20,
             currentStreak: 7,
             isEmpty: false
         )
+        let challengeUseCase = MockChallengeUseCase()
+        challengeUseCase.challenges = [
+            HydrationChallenge(
+                kind: .goalAchievement30,
+                progress: 1,
+                currentValue: 30,
+                targetValue: 30,
+                primaryCurrentValue: 30,
+                primaryTargetValue: 30,
+                isCompleted: true,
+                achievedAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 10))
+            ),
+            HydrationChallenge(
+                kind: .streak7,
+                progress: 1,
+                currentValue: 7,
+                targetValue: 7,
+                primaryCurrentValue: 7,
+                primaryTargetValue: 7,
+                isCompleted: true,
+                achievedAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 12))
+            )
+        ]
 
         let viewModel = ChallengeViewModel(
+            challengeUseCase: challengeUseCase,
             progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
@@ -97,10 +159,13 @@ struct ChallengeViewModelTests {
 
         await viewModel.loadChallenges()
 
-        #expect(viewModel.currentStreak == 7)
-        #expect(viewModel.streakSummary.badgeText == L10n.tr("challengeCompletedBadge"))
-        #expect(viewModel.streakSummary.progress == 1)
-        #expect(viewModel.streakSummary.description == L10n.tr("challengeCompletedDescription"))
+        #expect(
+            viewModel.completedChallenges.map { $0.kind } == [
+                HydrationChallengeKind.streak7,
+                HydrationChallengeKind.goalAchievement30
+            ]
+        )
+        #expect(viewModel.completedChallenges.first?.description == L10n.tr("challengeCompletedDescription"))
     }
 
     private func makeCalendar() -> Calendar {

--- a/Project/Presentation/Tests/Mock/MockChallengeUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockChallengeUseCase.swift
@@ -1,0 +1,12 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockChallengeUseCase: ChallengeUseCase, @unchecked Sendable {
+    var challenges: [HydrationChallenge] = []
+    private(set) var requestedReferenceDate: Date?
+
+    func fetchChallenges(referenceDate: Date, calendar: Calendar) async -> [HydrationChallenge] {
+        requestedReferenceDate = referenceDate
+        return challenges
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockChallengeUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockChallengeUseCase.swift
@@ -1,0 +1,49 @@
+import DomainLayerInterface
+import Foundation
+
+public final class MockChallengeUseCase: ChallengeUseCase, @unchecked Sendable {
+    public var challenges: [HydrationChallenge]
+
+    public init(
+        challenges: [HydrationChallenge] = [
+            HydrationChallenge(
+                kind: .streak7,
+                progress: 4.0 / 7.0,
+                currentValue: 4,
+                targetValue: 7,
+                primaryCurrentValue: 4,
+                primaryTargetValue: 7,
+                isCompleted: false,
+                achievedAt: nil
+            ),
+            HydrationChallenge(
+                kind: .weeklyAchievement80,
+                progress: 1,
+                currentValue: 0.8,
+                targetValue: 0.8,
+                primaryCurrentValue: 80,
+                primaryTargetValue: 80,
+                secondaryCurrentValue: 4,
+                secondaryTargetValue: 5,
+                isCompleted: true,
+                achievedAt: Date()
+            ),
+            HydrationChallenge(
+                kind: .goalAchievement30,
+                progress: 12.0 / 30.0,
+                currentValue: 12,
+                targetValue: 30,
+                primaryCurrentValue: 12,
+                primaryTargetValue: 30,
+                isCompleted: false,
+                achievedAt: nil
+            )
+        ]
+    ) {
+        self.challenges = challenges
+    }
+
+    public func fetchChallenges(referenceDate: Date, calendar: Calendar) async -> [HydrationChallenge] {
+        challenges
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -28,6 +28,9 @@ public final class PreviewAssembly: Assembly {
         container.register(HydrationProgressUseCase.self) { _ in
             MockHydrationProgressUseCase()
         }
+        container.register(ChallengeUseCase.self) { _ in
+            MockChallengeUseCase()
+        }
 
         container.register(SignInUseCase.self) { _ in
             MockSignInUseCase()
@@ -64,6 +67,7 @@ public final class PreviewAssembly: Assembly {
 
         container.register(ChallengeViewModel.self) { resolver in
             ChallengeViewModel(
+                challengeUseCase: resolver.resolve(ChallengeUseCase.self)!,
                 progressUseCase: resolver.resolve(HydrationProgressUseCase.self)!
             )
         }

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -58,10 +58,12 @@ public final class PresentationAssembly: Assembly {
         .inObjectScope(.container)
 
         container.register(ChallengeViewModel.self) { resolver in
+            let challengeUseCase = resolver.resolve(ChallengeUseCase.self)!
             let progressUseCase = resolver.resolve(HydrationProgressUseCase.self)!
 
             return MainActor.assumeIsolated {
                 ChallengeViewModel(
+                    challengeUseCase: challengeUseCase,
                     progressUseCase: progressUseCase
                 )
             }

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockChallengeUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockChallengeUseCaseForTesting.swift
@@ -1,0 +1,10 @@
+import DomainLayerInterface
+import Foundation
+
+public final class MockChallengeUseCaseForTesting: ChallengeUseCase, @unchecked Sendable {
+    public init() {}
+
+    public func fetchChallenges(referenceDate: Date, calendar: Calendar) async -> [HydrationChallenge] {
+        []
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Testing/TestingAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/TestingAssembly.swift
@@ -27,6 +27,9 @@ public final class TestingAssembly: Assembly {
         container.register(HydrationProgressUseCase.self) { _ in
             MockHydrationProgressUseCaseForTesting()
         }
+        container.register(ChallengeUseCase.self) { _ in
+            MockChallengeUseCaseForTesting()
+        }
 
         container.register(RoutineUseCase.self) { _ in
             MockRoutineUseCaseForTesting()

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -23,6 +23,17 @@
         }
       }
     },
+    "challengeAchievedAtFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "획득일 %@"
+          }
+        }
+      }
+    },
     "challengeCompletedBadge" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -41,6 +52,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "7일 연속 챌린지를 달성했어요."
+          }
+        }
+      }
+    },
+    "challengeCompletedSectionDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "달성한 챌린지를 다시 확인할 수 있어요."
+          }
+        }
+      }
+    },
+    "challengeCompletedSectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "획득한 챌린지"
           }
         }
       }
@@ -78,6 +111,17 @@
         }
       }
     },
+    "challengeEarnedBadge" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "획득 완료"
+          }
+        }
+      }
+    },
     "challengeEmptyDescription" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -100,6 +144,61 @@
         }
       }
     },
+    "challengeGoalCardTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목표 달성 30회"
+          }
+        }
+      }
+    },
+    "challengeGoalCompletedDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목표 달성 챌린지를 획득했어요."
+          }
+        }
+      }
+    },
+    "challengeGoalRemainingCountFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30회까지 %lld회 남았어요."
+          }
+        }
+      }
+    },
+    "challengeGoalStartDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목표를 달성한 날이 누적되면 챌린지를 획득해요."
+          }
+        }
+      }
+    },
+    "challengeGoalValueFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld회"
+          }
+        }
+      }
+    },
     "challengeInProgressBadge" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -107,6 +206,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "진행 중"
+          }
+        }
+      }
+    },
+    "challengeInProgressSectionDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지금 달성 중인 챌린지를 확인하고 다음 목표를 이어가세요."
+          }
+        }
+      }
+    },
+    "challengeInProgressSectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "진행 중 챌린지"
           }
         }
       }
@@ -155,6 +276,28 @@
         }
       }
     },
+    "challengeProgressCountFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lld회"
+          }
+        }
+      }
+    },
+    "challengeProgressDaysFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lld일"
+          }
+        }
+      }
+    },
     "challengeStreakCardTitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -173,6 +316,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "오늘 목표를 달성하면 streak가 시작돼요."
+          }
+        }
+      }
+    },
+    "challengeWeeklyCardTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주간 달성률 80%"
+          }
+        }
+      }
+    },
+    "challengeWeeklyCompletedDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주 80% 챌린지를 달성했어요."
+          }
+        }
+      }
+    },
+    "challengeWeeklyProgressDescriptionFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주 %lld/%lld일 목표를 달성했어요."
           }
         }
       }


### PR DESCRIPTION
## 📝 Summary
챌린지 탭에서 진행 중인 카드와 획득한 카드를 분리하고, 완료 카드의 시각적 구분과 획득일 노출을 추가합니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #137
- Related to #95

## 📋 Changes Made
### Added
- 챌린지 완료 섹션용 배지/획득일/강조 스타일
- ChallengeUseCase preview/testing mock
- 챌린지 완료 분리 테스트 케이스

### Changed
- ChallengeViewModel이 ChallengeUseCase 기반으로 진행/완료 챌린지를 분리하도록 변경
- ChallengeView를 진행 중/획득한 챌린지 섹션 구조로 재구성
- 로컬라이징 문자열 추가 및 챌린지 카드 문구 정리

### Fixed
- 챌린지 탭이 실제 영속 상태 대신 단일 streak 요약만 보여주던 구조를 정리

### Removed
- 단일 streak summary 중심 레이아웃

## 🔍 Technical Details
- Presentation 레이어에서 ChallengeUseCase를 직접 소비하도록 바꿔 persisted challenge state를 UI에 반영합니다.
- 완료 카드는 achievedAt 기반으로 최근 획득 순 정렬되며, 진행 중 카드는 progress 우선으로 정렬됩니다.

## 📸 Screenshots / Videos
### Before
- 진행 중/완료 상태가 하나의 카드 구조에 섞여 있었습니다.

### After
- 진행 중 챌린지와 획득한 챌린지가 별도 섹션으로 분리되고, 완료 카드는 획득일과 시각적 강조를 표시합니다.

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [x] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS 18.0 Simulator
- Device: iPhone 17
- Xcode Version: 17C529

### Test Results
- `tuist generate`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,name=iPhone 17'`
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- 획득 이력의 별도 저장 모델은 후속 이슈 `#139`에서 다룹니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?