### PR TITLE
feat: add personalized challenge suggestions

### DIFF
--- a/Docs/personalized-challenge-strategy.md
+++ b/Docs/personalized-challenge-strategy.md
@@ -1,0 +1,51 @@
+# Personalized Challenge Strategy
+
+## Goal
+- Keep the fixed challenge set as the long-lived achievement layer.
+- Add lightweight personalized recommendations that reflect the user's current routine and recent hydration pattern.
+
+## Information Architecture
+- `추천 챌린지`
+  - non-persistent, recommendation-oriented cards
+  - show source, tier, recommendation reason, and next action
+- `진행 중 챌린지`
+  - fixed achievement challenges with progress tracking
+- `획득한 챌린지`
+  - completed fixed challenges
+
+## Implemented Recommendation Candidates
+1. `routineAnchor`
+- Source: enabled routine
+- Rule: pick the most frequent enabled routine, then the earliest one
+- Purpose: attach hydration to an existing cue
+
+2. `morningKickstart`
+- Source: recent records
+- Rule: if morning first-drink count in the last 14 days is below 5, recommend improving morning hydration
+- Purpose: move the first hydration earlier in the day
+
+3. `dailyGoalBooster`
+- Source: recent records
+- Rule: if monthly average intake is below the daily goal and morning habit is not the main gap, recommend raising the average by one 250ml step
+- Purpose: make daily goal progress feel reachable
+
+4. `consistencyDefender`
+- Source: recent records
+- Rule: if the user is already close to or above the goal, recommend preserving the current weekly pace
+- Purpose: keep momentum instead of only chasing deficit recovery
+
+## Tier Rules
+- `beginner`
+  - obvious habit gap exists
+  - recommendation should be low-friction and easy to start
+- `steady`
+  - baseline habit exists
+  - recommendation should strengthen consistency
+- `stretch`
+  - current pace is already healthy
+  - recommendation should preserve or slightly extend the pace
+
+## Next Expansion
+- Add more personalized candidates around time-of-day gaps, weekday gaps, and routine completion history
+- Connect personalized recommendations to badge history once `#139` is introduced
+- If recommendation quality grows, split the recommendation engine into its own policy/service layer

--- a/Project/Domain/Interfaces/Entity/PersonalizedHydrationChallenge.swift
+++ b/Project/Domain/Interfaces/Entity/PersonalizedHydrationChallenge.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public enum PersonalizedHydrationChallengeKind: String, CaseIterable, Codable, Identifiable, Sendable {
+    case routineAnchor
+    case morningKickstart
+    case dailyGoalBooster
+    case consistencyDefender
+
+    public var id: String { rawValue }
+}
+
+public enum HydrationChallengeRecommendationSource: String, Codable, Sendable {
+    case routine
+    case recentRecords
+}
+
+public enum HydrationChallengeTier: String, Codable, Sendable {
+    case beginner
+    case steady
+    case stretch
+}
+
+public struct PersonalizedHydrationChallenge: Identifiable, Equatable, Sendable {
+    public let kind: PersonalizedHydrationChallengeKind
+    public let tier: HydrationChallengeTier
+    public let source: HydrationChallengeRecommendationSource
+    public let primaryCurrentValue: Int
+    public let primaryTargetValue: Int
+    public let secondaryCurrentValue: Int?
+    public let secondaryTargetValue: Int?
+    public let anchorRoutine: HydrationRoutine?
+    public let currentAverageML: Int?
+    public let recommendedTargetML: Int?
+    public let dailyGoalML: Int?
+
+    public init(
+        kind: PersonalizedHydrationChallengeKind,
+        tier: HydrationChallengeTier,
+        source: HydrationChallengeRecommendationSource,
+        primaryCurrentValue: Int,
+        primaryTargetValue: Int,
+        secondaryCurrentValue: Int? = nil,
+        secondaryTargetValue: Int? = nil,
+        anchorRoutine: HydrationRoutine? = nil,
+        currentAverageML: Int? = nil,
+        recommendedTargetML: Int? = nil,
+        dailyGoalML: Int? = nil
+    ) {
+        self.kind = kind
+        self.tier = tier
+        self.source = source
+        self.primaryCurrentValue = primaryCurrentValue
+        self.primaryTargetValue = primaryTargetValue
+        self.secondaryCurrentValue = secondaryCurrentValue
+        self.secondaryTargetValue = secondaryTargetValue
+        self.anchorRoutine = anchorRoutine
+        self.currentAverageML = currentAverageML
+        self.recommendedTargetML = recommendedTargetML
+        self.dailyGoalML = dailyGoalML
+    }
+
+    public var id: PersonalizedHydrationChallengeKind { kind }
+}

--- a/Project/Domain/Interfaces/UseCase/PersonalizedChallengeUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/PersonalizedChallengeUseCase.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol PersonalizedChallengeUseCase: Sendable {
+    func fetchPersonalizedChallenges(
+        snapshot: HydrationProgressSnapshot,
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> [PersonalizedHydrationChallenge]
+}

--- a/Project/Domain/Sources/UseCase/PersonalizedChallengeUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/PersonalizedChallengeUseCaseImpl.swift
@@ -1,0 +1,235 @@
+import DomainLayerInterface
+import Foundation
+
+public struct PersonalizedChallengeUseCaseImpl: PersonalizedChallengeUseCase {
+    private enum Constants {
+        static let morningWindowDays = 14
+        static let morningCutoffHour = 12
+        static let morningTargetDays = 5
+        static let weeklyConsistencyTargetDays = 5
+        static let intakeStepML = 250
+    }
+
+    private let routineUseCase: RoutineUseCase
+    private let drinkWaterRepository: DrinkWaterRepository
+
+    public init(
+        routineUseCase: RoutineUseCase,
+        drinkWaterRepository: DrinkWaterRepository
+    ) {
+        self.routineUseCase = routineUseCase
+        self.drinkWaterRepository = drinkWaterRepository
+    }
+
+    public func fetchPersonalizedChallenges(
+        snapshot: HydrationProgressSnapshot,
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> [PersonalizedHydrationChallenge] {
+        guard snapshot.isEmpty == false else {
+            return []
+        }
+
+        var challenges: [PersonalizedHydrationChallenge] = []
+
+        if let anchorRoutine = selectAnchorRoutine(from: routineUseCase.fetchRoutines()) {
+            challenges.append(
+                makeRoutineAnchorChallenge(
+                    routine: anchorRoutine,
+                    snapshot: snapshot
+                )
+            )
+        }
+
+        if let recordBasedChallenge = await makeRecordBasedChallenge(
+            snapshot: snapshot,
+            referenceDate: referenceDate,
+            calendar: calendar
+        ) {
+            challenges.append(recordBasedChallenge)
+        }
+
+        return challenges
+    }
+
+    private func selectAnchorRoutine(from routines: [HydrationRoutine]) -> HydrationRoutine? {
+        routines
+            .filter(\.isEnabled)
+            .sorted { lhs, rhs in
+                if lhs.weekdays.count != rhs.weekdays.count {
+                    return lhs.weekdays.count > rhs.weekdays.count
+                }
+                if lhs.hour != rhs.hour {
+                    return lhs.hour < rhs.hour
+                }
+                return lhs.minute < rhs.minute
+            }
+            .first
+    }
+
+    private func makeRoutineAnchorChallenge(
+        routine: HydrationRoutine,
+        snapshot: HydrationProgressSnapshot
+    ) -> PersonalizedHydrationChallenge {
+        PersonalizedHydrationChallenge(
+            kind: .routineAnchor,
+            tier: tierForRoutine(snapshot: snapshot),
+            source: .routine,
+            primaryCurrentValue: routine.weekdays.count,
+            primaryTargetValue: max(routine.weekdays.count, 3),
+            anchorRoutine: routine
+        )
+    }
+
+    private func makeRecordBasedChallenge(
+        snapshot: HydrationProgressSnapshot,
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> PersonalizedHydrationChallenge? {
+        let morningHydrationDays = await recentMorningHydrationDays(
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        if morningHydrationDays < Constants.morningTargetDays {
+            return PersonalizedHydrationChallenge(
+                kind: .morningKickstart,
+                tier: tierForMorningKickstart(
+                    matchedDays: morningHydrationDays,
+                    totalDays: Constants.morningWindowDays
+                ),
+                source: .recentRecords,
+                primaryCurrentValue: morningHydrationDays,
+                primaryTargetValue: Constants.morningTargetDays,
+                secondaryCurrentValue: Constants.morningWindowDays
+            )
+        }
+
+        let dailyGoalML = Int(snapshot.dailyGoalML.rounded())
+        let monthlyAverageML = Int(snapshot.monthlyAverageML.rounded())
+
+        if dailyGoalML > 0, monthlyAverageML < dailyGoalML {
+            let stepAlignedTarget = nextStepTarget(
+                currentValue: monthlyAverageML,
+                step: Constants.intakeStepML
+            )
+            let recommendedTargetML = min(
+                dailyGoalML,
+                stepAlignedTarget
+            )
+
+            return PersonalizedHydrationChallenge(
+                kind: .dailyGoalBooster,
+                tier: tierForDailyGoalBooster(
+                    averageML: monthlyAverageML,
+                    dailyGoalML: dailyGoalML
+                ),
+                source: .recentRecords,
+                primaryCurrentValue: monthlyAverageML,
+                primaryTargetValue: recommendedTargetML,
+                currentAverageML: monthlyAverageML,
+                recommendedTargetML: recommendedTargetML,
+                dailyGoalML: dailyGoalML
+            )
+        }
+
+        return PersonalizedHydrationChallenge(
+            kind: .consistencyDefender,
+            tier: .stretch,
+            source: .recentRecords,
+            primaryCurrentValue: snapshot.weeklyAchievedDays,
+            primaryTargetValue: min(
+                max(Constants.weeklyConsistencyTargetDays, snapshot.weeklyAchievedDays + 1),
+                7
+            ),
+            secondaryCurrentValue: snapshot.weeklyElapsedDays,
+            secondaryTargetValue: 7
+        )
+    }
+
+    private func recentMorningHydrationDays(
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> Int {
+        let startOfReferenceDay = calendar.startOfDay(for: referenceDate)
+        let intervalStart = calendar.date(
+            byAdding: .day,
+            value: -(Constants.morningWindowDays - 1),
+            to: startOfReferenceDay
+        ) ?? startOfReferenceDay
+        let intervalEnd = calendar.date(byAdding: .day, value: 1, to: startOfReferenceDay) ?? referenceDate
+        let events = await drinkWaterRepository.hydrationEvents(
+            in: DateInterval(start: intervalStart, end: intervalEnd)
+        )
+
+        let firstEventsByDay = events.reduce(into: [Date: Date]()) { partialResult, event in
+            let day = calendar.startOfDay(for: event.consumedAt)
+            let current = partialResult[day]
+            if current == nil || event.consumedAt < current! {
+                partialResult[day] = event.consumedAt
+            }
+        }
+
+        return firstEventsByDay.values.reduce(into: 0) { result, firstEvent in
+            let hour = calendar.component(.hour, from: firstEvent)
+            if hour < Constants.morningCutoffHour {
+                result += 1
+            }
+        }
+    }
+
+    private func tierForRoutine(snapshot: HydrationProgressSnapshot) -> HydrationChallengeTier {
+        switch snapshot.weeklyAchievementRate {
+        case ..<0.4:
+            return .beginner
+        case ..<0.8:
+            return .steady
+        default:
+            return .stretch
+        }
+    }
+
+    private func tierForMorningKickstart(matchedDays: Int, totalDays: Int) -> HydrationChallengeTier {
+        let rate = totalDays > 0 ? Double(matchedDays) / Double(totalDays) : 0
+        switch rate {
+        case ..<0.3:
+            return .beginner
+        case ..<0.6:
+            return .steady
+        default:
+            return .stretch
+        }
+    }
+
+    private func tierForDailyGoalBooster(averageML: Int, dailyGoalML: Int) -> HydrationChallengeTier {
+        guard dailyGoalML > 0 else {
+            return .beginner
+        }
+
+        let rate = Double(averageML) / Double(dailyGoalML)
+        switch rate {
+        case ..<0.55:
+            return .beginner
+        case ..<0.85:
+            return .steady
+        default:
+            return .stretch
+        }
+    }
+
+    private func roundedUp(_ value: Int, step: Int) -> Int {
+        guard step > 0 else {
+            return value
+        }
+
+        return ((value + step - 1) / step) * step
+    }
+
+    private func nextStepTarget(currentValue: Int, step: Int) -> Int {
+        let roundedValue = roundedUp(currentValue, step: step)
+        if roundedValue == currentValue {
+            return roundedValue + step
+        }
+        return roundedValue
+    }
+}

--- a/Project/Domain/Tests/PersonalizedChallengeUseCaseTests.swift
+++ b/Project/Domain/Tests/PersonalizedChallengeUseCaseTests.swift
@@ -1,0 +1,195 @@
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import DomainLayer
+
+@Suite("PersonalizedChallengeUseCase Tests")
+struct PersonalizedChallengeUseCaseTests {
+    @Test("활성 루틴이 있으면 루틴 기반 추천을 우선 노출한다")
+    func routineAnchorRecommendation() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 19, hour: 9))!
+        let routineRepository = MockRoutineRepository()
+        routineRepository.routines = [
+            HydrationRoutine(
+                title: "출근 준비",
+                hour: 8,
+                minute: 30,
+                weekdays: [.monday, .tuesday, .wednesday, .thursday, .friday],
+                isEnabled: true
+            )
+        ]
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        drinkWaterRepository.setHydrationEvents(
+            makeMorningEvents(
+                calendar: calendar,
+                referenceDate: referenceDate,
+                hydratedDayOffsets: [0, 2]
+            )
+        )
+        let useCase = PersonalizedChallengeUseCaseImpl(
+            routineUseCase: RoutineUseCaseImpl(repository: routineRepository),
+            drinkWaterRepository: drinkWaterRepository
+        )
+
+        let challenges = await useCase.fetchPersonalizedChallenges(
+            snapshot: makeSnapshot(monthlyAverageML: 1500, dailyGoalML: 2000, weeklyAchievementRate: 0.65),
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        #expect(challenges.first?.kind == .routineAnchor)
+        #expect(challenges.first?.anchorRoutine?.title == "출근 준비")
+        #expect(challenges.first?.tier == .steady)
+    }
+
+    @Test("오전 섭취 습관이 부족하면 기록 기반 추천은 오전 시작 챌린지를 반환한다")
+    func morningKickstartRecommendation() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 19, hour: 9))!
+        let routineRepository = MockRoutineRepository()
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        drinkWaterRepository.setHydrationEvents(
+            makeMorningEvents(
+                calendar: calendar,
+                referenceDate: referenceDate,
+                hydratedDayOffsets: [0, 5, 10]
+            )
+        )
+        let useCase = PersonalizedChallengeUseCaseImpl(
+            routineUseCase: RoutineUseCaseImpl(repository: routineRepository),
+            drinkWaterRepository: drinkWaterRepository
+        )
+
+        let challenges = await useCase.fetchPersonalizedChallenges(
+            snapshot: makeSnapshot(monthlyAverageML: 1800, dailyGoalML: 2000, weeklyAchievementRate: 0.35),
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        #expect(challenges.count == 1)
+        #expect(challenges.first?.kind == .morningKickstart)
+        #expect(challenges.first?.primaryCurrentValue == 3)
+        #expect(challenges.first?.primaryTargetValue == 5)
+    }
+
+    @Test("최근 평균이 목표보다 낮지만 오전 습관이 안정적이면 평균 증량 추천을 반환한다")
+    func dailyGoalBoosterRecommendation() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 19, hour: 9))!
+        let routineRepository = MockRoutineRepository()
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        drinkWaterRepository.setHydrationEvents(
+            makeMorningEvents(
+                calendar: calendar,
+                referenceDate: referenceDate,
+                hydratedDayOffsets: Array(0..<6)
+            )
+        )
+        let useCase = PersonalizedChallengeUseCaseImpl(
+            routineUseCase: RoutineUseCaseImpl(repository: routineRepository),
+            drinkWaterRepository: drinkWaterRepository
+        )
+
+        let challenges = await useCase.fetchPersonalizedChallenges(
+            snapshot: makeSnapshot(monthlyAverageML: 1620, dailyGoalML: 2000, weeklyAchievementRate: 0.5),
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        #expect(challenges.first?.kind == .dailyGoalBooster)
+        #expect(challenges.first?.recommendedTargetML == 1750)
+        #expect(challenges.first?.tier == .steady)
+    }
+
+    @Test("목표를 안정적으로 달성 중이면 유지형 추천을 반환한다")
+    func consistencyDefenderRecommendation() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 19, hour: 9))!
+        let routineRepository = MockRoutineRepository()
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        drinkWaterRepository.setHydrationEvents(
+            makeMorningEvents(
+                calendar: calendar,
+                referenceDate: referenceDate,
+                hydratedDayOffsets: Array(0..<7)
+            )
+        )
+        let useCase = PersonalizedChallengeUseCaseImpl(
+            routineUseCase: RoutineUseCaseImpl(repository: routineRepository),
+            drinkWaterRepository: drinkWaterRepository
+        )
+
+        let challenges = await useCase.fetchPersonalizedChallenges(
+            snapshot: makeSnapshot(
+                monthlyAverageML: 2150,
+                dailyGoalML: 2000,
+                weeklyAchievementRate: 0.9,
+                weeklyAchievedDays: 4,
+                weeklyElapsedDays: 4
+            ),
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        #expect(challenges.first?.kind == .consistencyDefender)
+        #expect(challenges.first?.primaryCurrentValue == 4)
+        #expect(challenges.first?.primaryTargetValue == 5)
+    }
+
+    private func makeSnapshot(
+        monthlyAverageML: Double,
+        dailyGoalML: Double,
+        weeklyAchievementRate: Double,
+        weeklyAchievedDays: Int = 2,
+        weeklyElapsedDays: Int = 4
+    ) -> HydrationProgressSnapshot {
+        HydrationProgressSnapshot(
+            dailyGoalML: dailyGoalML,
+            todayIntakeML: 1200,
+            hasAchievedTodayGoal: false,
+            weeklyAverageML: monthlyAverageML,
+            monthlyAverageML: monthlyAverageML,
+            weeklyAchievementRate: weeklyAchievementRate,
+            monthlyAchievementRate: weeklyAchievementRate,
+            weeklyAchievedDays: weeklyAchievedDays,
+            monthlyAchievedDays: 10,
+            weeklyElapsedDays: weeklyElapsedDays,
+            monthlyElapsedDays: 19,
+            currentStreak: 2,
+            isEmpty: false
+        )
+    }
+
+    private func makeMorningEvents(
+        calendar: Calendar,
+        referenceDate: Date,
+        hydratedDayOffsets: [Int]
+    ) -> [HydrationEvent] {
+        hydratedDayOffsets.map { offset in
+            let day = calendar.date(byAdding: .day, value: -offset, to: referenceDate) ?? referenceDate
+            let consumedAt = calendar.date(
+                bySettingHour: 9,
+                minute: 0,
+                second: 0,
+                of: day
+            ) ?? day
+
+            return HydrationEvent(
+                id: UUID(),
+                consumedAt: consumedAt,
+                volumeML: 250
+            )
+        }
+    }
+
+    private func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        calendar.firstWeekday = 2
+        calendar.minimumDaysInFirstWeek = 4
+        return calendar
+    }
+}

--- a/Project/Presentation/Sources/View/Challenge/ChallengeView.swift
+++ b/Project/Presentation/Sources/View/Challenge/ChallengeView.swift
@@ -47,6 +47,19 @@ public struct ChallengeView: View {
     private var challengeContent: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
+                if viewModel.recommendedChallenges.isEmpty == false {
+                    ChallengeSectionHeader(
+                        title: L10n.tr("challengeRecommendedSectionTitle"),
+                        subtitle: L10n.tr("challengeRecommendedSectionDescription")
+                    )
+
+                    VStack(spacing: 14) {
+                        ForEach(viewModel.recommendedChallenges) { challenge in
+                            PersonalizedChallengeCard(challenge: challenge)
+                        }
+                    }
+                }
+
                 if viewModel.inProgressChallenges.isEmpty == false {
                     ChallengeSectionHeader(
                         title: L10n.tr("challengeInProgressSectionTitle"),
@@ -98,6 +111,103 @@ public struct ChallengeView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity)
+    }
+}
+
+private struct PersonalizedChallengeCard: View {
+    let challenge: PersonalizedChallengeCardModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 8) {
+                        ChallengeBadge(
+                            title: L10n.tr("challengeRecommendedBadge"),
+                            color: accentColor
+                        )
+
+                        ChallengeBadge(
+                            title: challenge.sourceText,
+                            color: .secondary
+                        )
+
+                        ChallengeBadge(
+                            title: challenge.tierText,
+                            color: accentColor.opacity(0.85)
+                        )
+                    }
+
+                    Text(challenge.title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+
+                    Text(challenge.description)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 12)
+
+                Image(systemName: challenge.symbolName)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(accentColor)
+                    .frame(width: 42, height: 42)
+                    .background(
+                        Circle()
+                            .fill(accentColor.opacity(0.12))
+                    )
+            }
+
+            VStack(spacing: 10) {
+                ChallengeInfoRow(
+                    title: L10n.tr("challengeRecommendationReasonTitle"),
+                    message: challenge.reasonText,
+                    systemImage: "lightbulb.fill",
+                    tintColor: accentColor
+                )
+
+                ChallengeInfoRow(
+                    title: L10n.tr("challengeRecommendationActionTitle"),
+                    message: challenge.actionText,
+                    systemImage: "figure.walk",
+                    tintColor: accentColor
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(uiColor: .secondarySystemBackground).opacity(0.98),
+                            accentColor.opacity(0.08)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .stroke(accentColor.opacity(0.1), lineWidth: 1)
+                )
+        )
+    }
+
+    private var accentColor: Color {
+        switch challenge.kind {
+        case .routineAnchor:
+            return .mint
+        case .morningKickstart:
+            return .orange
+        case .dailyGoalBooster:
+            return .blue
+        case .consistencyDefender:
+            return .green
+        }
     }
 }
 

--- a/Project/Presentation/Sources/ViewModel/ChallengeViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/ChallengeViewModel.swift
@@ -21,26 +21,42 @@ struct ChallengeCardModel: Identifiable, Equatable {
     let isCompleted: Bool
 }
 
+struct PersonalizedChallengeCardModel: Identifiable, Equatable {
+    let id: PersonalizedHydrationChallengeKind
+    let kind: PersonalizedHydrationChallengeKind
+    let sourceText: String
+    let tierText: String
+    let title: String
+    let description: String
+    let reasonText: String
+    let actionText: String
+    let symbolName: String
+}
+
 @MainActor
 @Observable
 public final class ChallengeViewModel {
     private(set) var isLoading = false
     private(set) var isEmpty = false
+    private(set) var recommendedChallenges: [PersonalizedChallengeCardModel] = []
     private(set) var inProgressChallenges: [ChallengeCardModel] = []
     private(set) var completedChallenges: [ChallengeCardModel] = []
 
     private let challengeUseCase: ChallengeUseCase
+    private let personalizedChallengeUseCase: PersonalizedChallengeUseCase
     private let progressUseCase: HydrationProgressUseCase
     private let calendar: Calendar
     private let currentDateProvider: @Sendable () -> Date
 
     public init(
         challengeUseCase: ChallengeUseCase,
+        personalizedChallengeUseCase: PersonalizedChallengeUseCase,
         progressUseCase: HydrationProgressUseCase,
         calendar: Calendar = .autoupdatingCurrent,
         currentDateProvider: @escaping @Sendable () -> Date = { .now }
     ) {
         self.challengeUseCase = challengeUseCase
+        self.personalizedChallengeUseCase = personalizedChallengeUseCase
         self.progressUseCase = progressUseCase
         self.calendar = calendar
         self.currentDateProvider = currentDateProvider
@@ -58,17 +74,28 @@ public final class ChallengeViewModel {
 
         isEmpty = snapshot.isEmpty
         guard snapshot.isEmpty == false else {
+            recommendedChallenges = []
             inProgressChallenges = []
             completedChallenges = []
             return
         }
 
-        let challenges = await challengeUseCase.fetchChallenges(
+        async let recommended = personalizedChallengeUseCase.fetchPersonalizedChallenges(
+            snapshot: snapshot,
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+        async let challenges = challengeUseCase.fetchChallenges(
             referenceDate: referenceDate,
             calendar: calendar
         )
 
-        let cards = challenges.map { makeCardModel(from: $0, snapshot: snapshot) }
+        let recommendedCards = await recommended
+        let fixedCards = await challenges
+
+        recommendedChallenges = recommendedCards.map(makePersonalizedCardModel(from:))
+
+        let cards = fixedCards.map { makeCardModel(from: $0, snapshot: snapshot) }
 
         inProgressChallenges = cards
             .filter { $0.isCompleted == false }
@@ -76,6 +103,22 @@ public final class ChallengeViewModel {
         completedChallenges = cards
             .filter(\.isCompleted)
             .sorted(by: completedSort)
+    }
+
+    private func makePersonalizedCardModel(
+        from challenge: PersonalizedHydrationChallenge
+    ) -> PersonalizedChallengeCardModel {
+        PersonalizedChallengeCardModel(
+            id: challenge.kind,
+            kind: challenge.kind,
+            sourceText: sourceText(for: challenge.source),
+            tierText: tierText(for: challenge.tier),
+            title: personalizedTitle(for: challenge),
+            description: personalizedDescription(for: challenge),
+            reasonText: personalizedReasonText(for: challenge),
+            actionText: personalizedActionText(for: challenge),
+            symbolName: personalizedSymbolName(for: challenge.kind)
+        )
     }
 
     private func makeCardModel(
@@ -293,6 +336,119 @@ public final class ChallengeViewModel {
                 .day()
         )
         return L10n.tr("challengeAchievedAtFormat", formattedDate)
+    }
+
+    private func sourceText(for source: HydrationChallengeRecommendationSource) -> String {
+        switch source {
+        case .routine:
+            return L10n.tr("challengeRecommendationSourceRoutine")
+        case .recentRecords:
+            return L10n.tr("challengeRecommendationSourceRecentRecords")
+        }
+    }
+
+    private func tierText(for tier: HydrationChallengeTier) -> String {
+        switch tier {
+        case .beginner:
+            return L10n.tr("challengeRecommendationTierBeginner")
+        case .steady:
+            return L10n.tr("challengeRecommendationTierSteady")
+        case .stretch:
+            return L10n.tr("challengeRecommendationTierStretch")
+        }
+    }
+
+    private func personalizedTitle(for challenge: PersonalizedHydrationChallenge) -> String {
+        switch challenge.kind {
+        case .routineAnchor:
+            return L10n.tr(
+                "challengePersonalizedRoutineTitleFormat",
+                challenge.anchorRoutine?.title ?? L10n.tr("challengeRecommendationSourceRoutine")
+            )
+        case .morningKickstart:
+            return L10n.tr("challengePersonalizedMorningTitle")
+        case .dailyGoalBooster:
+            return L10n.tr("challengePersonalizedBoosterTitle")
+        case .consistencyDefender:
+            return L10n.tr("challengePersonalizedConsistencyTitle")
+        }
+    }
+
+    private func personalizedDescription(for challenge: PersonalizedHydrationChallenge) -> String {
+        switch challenge.kind {
+        case .routineAnchor:
+            return L10n.tr(
+                "challengePersonalizedRoutineDescriptionFormat",
+                challenge.anchorRoutine?.weekdayText ?? "",
+                challenge.anchorRoutine?.timeText ?? ""
+            )
+        case .morningKickstart:
+            return L10n.tr("challengePersonalizedMorningDescription")
+        case .dailyGoalBooster:
+            return L10n.tr("challengePersonalizedBoosterDescription")
+        case .consistencyDefender:
+            return L10n.tr("challengePersonalizedConsistencyDescription")
+        }
+    }
+
+    private func personalizedReasonText(for challenge: PersonalizedHydrationChallenge) -> String {
+        switch challenge.kind {
+        case .routineAnchor:
+            return L10n.tr("challengePersonalizedRoutineReason")
+        case .morningKickstart:
+            return L10n.tr(
+                "challengePersonalizedMorningReasonFormat",
+                challenge.primaryCurrentValue,
+                challenge.secondaryCurrentValue ?? 14
+            )
+        case .dailyGoalBooster:
+            return L10n.tr(
+                "challengePersonalizedBoosterReasonFormat",
+                challenge.currentAverageML ?? challenge.primaryCurrentValue,
+                challenge.dailyGoalML ?? 0
+            )
+        case .consistencyDefender:
+            return L10n.tr(
+                "challengePersonalizedConsistencyReasonFormat",
+                challenge.primaryCurrentValue,
+                challenge.secondaryCurrentValue ?? 7
+            )
+        }
+    }
+
+    private func personalizedActionText(for challenge: PersonalizedHydrationChallenge) -> String {
+        switch challenge.kind {
+        case .routineAnchor:
+            return L10n.tr(
+                "challengePersonalizedRoutineActionFormat",
+                challenge.primaryTargetValue
+            )
+        case .morningKickstart:
+            return L10n.tr("challengePersonalizedMorningAction")
+        case .dailyGoalBooster:
+            return L10n.tr(
+                "challengePersonalizedBoosterActionFormat",
+                challenge.recommendedTargetML ?? challenge.primaryTargetValue
+            )
+        case .consistencyDefender:
+            return L10n.tr(
+                "challengePersonalizedConsistencyActionFormat",
+                challenge.primaryTargetValue
+            )
+        }
+    }
+
+    private func personalizedSymbolName(for kind: PersonalizedHydrationChallengeKind) -> String {
+        switch kind {
+        case .routineAnchor:
+            return "calendar.badge.clock"
+        case .morningKickstart:
+            return "sun.max.fill"
+        case .dailyGoalBooster:
+            return "drop.circle.fill"
+        case .consistencyDefender:
+            return "shield.checkered"
+        }
     }
 
     private func requiredWeeklyAchievedDays(for elapsedDays: Int) -> Int {

--- a/Project/Presentation/Tests/ChallengeViewModelTests.swift
+++ b/Project/Presentation/Tests/ChallengeViewModelTests.swift
@@ -29,6 +29,7 @@ struct ChallengeViewModelTests {
             isEmpty: false
         )
         let challengeUseCase = MockChallengeUseCase()
+        let personalizedChallengeUseCase = MockPersonalizedChallengeUseCase()
         challengeUseCase.challenges = [
             HydrationChallenge(
                 kind: .streak7,
@@ -63,9 +64,26 @@ struct ChallengeViewModelTests {
                 achievedAt: nil
             )
         ]
+        personalizedChallengeUseCase.challenges = [
+            PersonalizedHydrationChallenge(
+                kind: .routineAnchor,
+                tier: .steady,
+                source: .routine,
+                primaryCurrentValue: 5,
+                primaryTargetValue: 5,
+                anchorRoutine: HydrationRoutine(
+                    title: "출근 전 물",
+                    hour: 8,
+                    minute: 30,
+                    weekdays: [.monday, .tuesday, .wednesday, .thursday, .friday],
+                    isEnabled: true
+                )
+            )
+        ]
 
         let viewModel = ChallengeViewModel(
             challengeUseCase: challengeUseCase,
+            personalizedChallengeUseCase: personalizedChallengeUseCase,
             progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
@@ -74,8 +92,11 @@ struct ChallengeViewModelTests {
         await viewModel.loadChallenges()
 
         #expect(viewModel.isEmpty == false)
+        #expect(viewModel.recommendedChallenges.count == 1)
         #expect(viewModel.inProgressChallenges.count == 2)
         #expect(viewModel.completedChallenges.count == 1)
+        #expect(viewModel.recommendedChallenges.first?.kind == .routineAnchor)
+        #expect(viewModel.recommendedChallenges.first?.sourceText == L10n.tr("challengeRecommendationSourceRoutine"))
         #expect(viewModel.inProgressChallenges.first?.kind == .streak7)
         #expect(viewModel.completedChallenges.first?.kind == .weeklyAchievement80)
         #expect(viewModel.completedChallenges.first?.badgeText == L10n.tr("challengeEarnedBadge"))
@@ -86,6 +107,7 @@ struct ChallengeViewModelTests {
         #expect(viewModel.inProgressChallenges.last?.title == L10n.tr("challengeGoalCardTitle"))
         #expect(viewModel.inProgressChallenges.last?.todayActionText == L10n.tr("challengeTodayActionGoalFormat", 13, 30))
         #expect(challengeUseCase.requestedReferenceDate == referenceDate)
+        #expect(personalizedChallengeUseCase.requestedReferenceDate == referenceDate)
     }
 
     @MainActor
@@ -96,9 +118,11 @@ struct ChallengeViewModelTests {
         let progressUseCase = MockHydrationProgressUseCase()
         progressUseCase.snapshot = .empty(dailyGoalML: 2000)
         let challengeUseCase = MockChallengeUseCase()
+        let personalizedChallengeUseCase = MockPersonalizedChallengeUseCase()
 
         let viewModel = ChallengeViewModel(
             challengeUseCase: challengeUseCase,
+            personalizedChallengeUseCase: personalizedChallengeUseCase,
             progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
@@ -107,9 +131,11 @@ struct ChallengeViewModelTests {
         await viewModel.loadChallenges()
 
         #expect(viewModel.isEmpty == true)
+        #expect(viewModel.recommendedChallenges.isEmpty)
         #expect(viewModel.inProgressChallenges.isEmpty)
         #expect(viewModel.completedChallenges.isEmpty)
         #expect(challengeUseCase.requestedReferenceDate == nil)
+        #expect(personalizedChallengeUseCase.requestedReferenceDate == nil)
     }
 
     @MainActor
@@ -134,6 +160,7 @@ struct ChallengeViewModelTests {
             isEmpty: false
         )
         let challengeUseCase = MockChallengeUseCase()
+        let personalizedChallengeUseCase = MockPersonalizedChallengeUseCase()
         challengeUseCase.challenges = [
             HydrationChallenge(
                 kind: .goalAchievement30,
@@ -159,6 +186,7 @@ struct ChallengeViewModelTests {
 
         let viewModel = ChallengeViewModel(
             challengeUseCase: challengeUseCase,
+            personalizedChallengeUseCase: personalizedChallengeUseCase,
             progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }
@@ -197,6 +225,7 @@ struct ChallengeViewModelTests {
             isEmpty: false
         )
         let challengeUseCase = MockChallengeUseCase()
+        let personalizedChallengeUseCase = MockPersonalizedChallengeUseCase()
         challengeUseCase.challenges = [
             HydrationChallenge(
                 kind: .goalAchievement30,
@@ -224,6 +253,7 @@ struct ChallengeViewModelTests {
 
         let viewModel = ChallengeViewModel(
             challengeUseCase: challengeUseCase,
+            personalizedChallengeUseCase: personalizedChallengeUseCase,
             progressUseCase: progressUseCase,
             calendar: calendar,
             currentDateProvider: { referenceDate }

--- a/Project/Presentation/Tests/Mock/MockPersonalizedChallengeUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockPersonalizedChallengeUseCase.swift
@@ -1,0 +1,16 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockPersonalizedChallengeUseCase: PersonalizedChallengeUseCase, @unchecked Sendable {
+    var challenges: [PersonalizedHydrationChallenge] = []
+    private(set) var requestedReferenceDate: Date?
+
+    func fetchPersonalizedChallenges(
+        snapshot: HydrationProgressSnapshot,
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> [PersonalizedHydrationChallenge] {
+        requestedReferenceDate = referenceDate
+        return challenges
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockPersonalizedChallengeUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockPersonalizedChallengeUseCase.swift
@@ -1,0 +1,45 @@
+import DomainLayerInterface
+import Foundation
+
+public final class MockPersonalizedChallengeUseCase: PersonalizedChallengeUseCase, @unchecked Sendable {
+    public var challenges: [PersonalizedHydrationChallenge]
+
+    public init(
+        challenges: [PersonalizedHydrationChallenge] = [
+            PersonalizedHydrationChallenge(
+                kind: .routineAnchor,
+                tier: .steady,
+                source: .routine,
+                primaryCurrentValue: 5,
+                primaryTargetValue: 5,
+                anchorRoutine: HydrationRoutine(
+                    title: "출근 전 물",
+                    hour: 8,
+                    minute: 30,
+                    weekdays: [.monday, .tuesday, .wednesday, .thursday, .friday],
+                    isEnabled: true
+                )
+            ),
+            PersonalizedHydrationChallenge(
+                kind: .dailyGoalBooster,
+                tier: .beginner,
+                source: .recentRecords,
+                primaryCurrentValue: 1450,
+                primaryTargetValue: 1750,
+                currentAverageML: 1450,
+                recommendedTargetML: 1750,
+                dailyGoalML: 2000
+            )
+        ]
+    ) {
+        self.challenges = challenges
+    }
+
+    public func fetchPersonalizedChallenges(
+        snapshot: HydrationProgressSnapshot,
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> [PersonalizedHydrationChallenge] {
+        challenges
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -31,6 +31,9 @@ public final class PreviewAssembly: Assembly {
         container.register(ChallengeUseCase.self) { _ in
             MockChallengeUseCase()
         }
+        container.register(PersonalizedChallengeUseCase.self) { _ in
+            MockPersonalizedChallengeUseCase()
+        }
 
         container.register(SignInUseCase.self) { _ in
             MockSignInUseCase()
@@ -68,6 +71,7 @@ public final class PreviewAssembly: Assembly {
         container.register(ChallengeViewModel.self) { resolver in
             ChallengeViewModel(
                 challengeUseCase: resolver.resolve(ChallengeUseCase.self)!,
+                personalizedChallengeUseCase: resolver.resolve(PersonalizedChallengeUseCase.self)!,
                 progressUseCase: resolver.resolve(HydrationProgressUseCase.self)!
             )
         }

--- a/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
@@ -30,6 +30,12 @@ public final class DomainAssembly: Assembly {
                 drinkWaterRepository: resolver.resolve(DrinkWaterRepository.self)!
             )
         }
+        container.register(PersonalizedChallengeUseCase.self) { resolver in
+            PersonalizedChallengeUseCaseImpl(
+                routineUseCase: resolver.resolve(RoutineUseCase.self)!,
+                drinkWaterRepository: resolver.resolve(DrinkWaterRepository.self)!
+            )
+        }
         
         // MARK: - HealthKit
         container.register(HealthKitUseCase.self) { resolver in

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -59,11 +59,13 @@ public final class PresentationAssembly: Assembly {
 
         container.register(ChallengeViewModel.self) { resolver in
             let challengeUseCase = resolver.resolve(ChallengeUseCase.self)!
+            let personalizedChallengeUseCase = resolver.resolve(PersonalizedChallengeUseCase.self)!
             let progressUseCase = resolver.resolve(HydrationProgressUseCase.self)!
 
             return MainActor.assumeIsolated {
                 ChallengeViewModel(
                     challengeUseCase: challengeUseCase,
+                    personalizedChallengeUseCase: personalizedChallengeUseCase,
                     progressUseCase: progressUseCase
                 )
             }

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockPersonalizedChallengeUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockPersonalizedChallengeUseCaseForTesting.swift
@@ -1,0 +1,16 @@
+import DomainLayerInterface
+import Foundation
+
+public final class MockPersonalizedChallengeUseCaseForTesting: PersonalizedChallengeUseCase, @unchecked Sendable {
+    public var challenges: [PersonalizedHydrationChallenge] = []
+
+    public init() {}
+
+    public func fetchPersonalizedChallenges(
+        snapshot: HydrationProgressSnapshot,
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> [PersonalizedHydrationChallenge] {
+        challenges
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Testing/TestingAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/TestingAssembly.swift
@@ -30,6 +30,9 @@ public final class TestingAssembly: Assembly {
         container.register(ChallengeUseCase.self) { _ in
             MockChallengeUseCaseForTesting()
         }
+        container.register(PersonalizedChallengeUseCase.self) { _ in
+            MockPersonalizedChallengeUseCaseForTesting()
+        }
 
         container.register(RoutineUseCase.self) { _ in
             MockRoutineUseCaseForTesting()

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -254,6 +254,292 @@
         }
       }
     },
+    "challengePersonalizedBoosterActionFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주 평균을 %lldml까지 끌어올리는 흐름을 만들어보세요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedBoosterDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 평균에서 한 컵만 더해도 목표에 가까워질 수 있어요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedBoosterReasonFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 월 평균이 %lldml로 목표 %lldml보다 낮아요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedBoosterTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하루 평균 한 컵 더"
+          }
+        }
+      }
+    },
+    "challengePersonalizedConsistencyActionFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주 %lld일 달성으로 안정적인 페이스를 굳혀보세요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedConsistencyDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미 안정적인 흐름이 보이니 유지 난이도의 도전이 맞아요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedConsistencyReasonFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주 %lld/%lld일 목표를 달성했어요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedConsistencyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지금 흐름 유지하기"
+          }
+        }
+      }
+    },
+    "challengePersonalizedMorningAction" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음 7일 중 5일은 정오 전에 첫 물 250ml를 마셔보세요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedMorningDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하루 첫 섭취 시점을 앞당기면 전체 수분 흐름이 더 안정됩니다."
+          }
+        }
+      }
+    },
+    "challengePersonalizedMorningReasonFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 %2$lld일 중 %1$lld일만 오전에 첫 섭취가 있었어요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedMorningTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오전 첫 물 습관 만들기"
+          }
+        }
+      }
+    },
+    "challengePersonalizedRoutineActionFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주 %lld일은 루틴 직전에 250ml를 먼저 마셔보세요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedRoutineDescriptionFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ %@ 흐름에 물 섭취를 묶어보세요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedRoutineReason" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미 설정한 루틴이 있어 실행 장벽이 가장 낮아요."
+          }
+        }
+      }
+    },
+    "challengePersonalizedRoutineTitleFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 루틴에 물 한 잔 붙이기"
+          }
+        }
+      }
+    },
+    "challengeRecommendationActionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제안 액션"
+          }
+        }
+      }
+    },
+    "challengeRecommendationReasonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천 이유"
+          }
+        }
+      }
+    },
+    "challengeRecommendedBadge" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "맞춤 추천"
+          }
+        }
+      }
+    },
+    "challengeRecommendedSectionDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "루틴과 최근 기록을 기반으로 지금 가장 맞는 도전을 골랐어요."
+          }
+        }
+      }
+    },
+    "challengeRecommendedSectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천 챌린지"
+          }
+        }
+      }
+    },
+    "challengeRecommendationSourceRecentRecords" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기록 기반"
+          }
+        }
+      }
+    },
+    "challengeRecommendationSourceRoutine" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "루틴 기반"
+          }
+        }
+      }
+    },
+    "challengeRecommendationTierBeginner" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가볍게"
+          }
+        }
+      }
+    },
+    "challengeRecommendationTierSteady" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "습관화"
+          }
+        }
+      }
+    },
+    "challengeRecommendationTierStretch" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스트레치"
+          }
+        }
+      }
+    },
     "challengeMetricMonthlyTitle" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## 📝 Summary
챌린지 탭에 고정 업적과 별도로 루틴/최근 기록 기반의 맞춤 추천 챌린지를 추가했습니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [x] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #136
- Related to #95

## 📋 Changes Made
### Added
- `PersonalizedHydrationChallenge` 모델과 `PersonalizedChallengeUseCase`를 추가했습니다.
- 루틴 기반 `routineAnchor`, 기록 기반 `morningKickstart` / `dailyGoalBooster` / `consistencyDefender` 추천 규칙을 추가했습니다.
- 챌린지 탭에 `추천 챌린지` 섹션을 추가했습니다.
- 개인화 추천 전략 문서를 추가했습니다.

### Changed
- `ChallengeViewModel`이 고정 챌린지와 개인화 추천 챌린지를 함께 로드하도록 변경했습니다.
- DI/Preview/Testing assembly에 개인화 챌린지 use case와 mock을 연결했습니다.
- 로컬라이즈 문자열을 개인화 추천 카드 구조에 맞춰 확장했습니다.

### Fixed
- 기존 챌린지 탭이 고정 업적 정보만 보여주던 구조를 사용자 습관 기반 제안까지 읽을 수 있게 보강했습니다.

### Removed
- 없음

## 🔍 Technical Details
- `DomainLayer`에 개인화 챌린지 후보, 추천 source, tier 모델을 추가했습니다.
- `PersonalizedChallengeUseCaseImpl`은 활성 루틴과 최근 14일 기록을 바탕으로 추천 카드를 생성합니다.
- 추천 카드는 영속화 대상이 아니라 현재 사용자 습관을 반영하는 lightweight recommendation layer로 분리했습니다.
- `ChallengeView`는 `추천 챌린지 / 진행 중 챌린지 / 획득한 챌린지` 3개 섹션으로 구성됩니다.

## 📸 Screenshots / Videos
### Before
- 챌린지 탭에는 고정 업적 카드만 노출됐습니다.

### After
- 챌린지 탭 상단에 루틴/최근 기록 기반의 맞춤 추천 챌린지가 추가됩니다.

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [x] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS Simulator
- Device: iPhone 17
- Xcode Version: 26.3

### Test Results
- `tuist generate`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer -destination "platform=iOS Simulator,name=iPhone 17"`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination "platform=iOS Simulator,name=iPhone 17"`
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- 개인화 챌린지는 고정 업적과 별도 정보 구조로 두고, 현재는 추천 레이어만 추가했습니다.
- 규칙 문서는 `Docs/personalized-challenge-strategy.md`에 정리했습니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [x] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
