### PR TITLE
feat: store challenge badge history

### DIFF
--- a/Project/Data/Sources/DataSource/ChallengeStorageDataSource.swift
+++ b/Project/Data/Sources/DataSource/ChallengeStorageDataSource.swift
@@ -5,6 +5,8 @@ import Utils
 public protocol ChallengeStorageDataSource: Sendable {
     func fetchChallengeStates() -> [HydrationChallengeState]
     func saveChallengeStates(_ states: [HydrationChallengeState])
+    func fetchBadgeHistories() -> [HydrationChallengeBadgeHistory]
+    func saveBadgeHistories(_ histories: [HydrationChallengeBadgeHistory])
 }
 
 public final class ChallengeStorageDataSourceImpl: ChallengeStorageDataSource, @unchecked Sendable {
@@ -48,6 +50,23 @@ public final class ChallengeStorageDataSourceImpl: ChallengeStorageDataSource, @
         }
 
         userDefaults.set(data, forKey: .hydrationChallengeStates)
+        userDefaults.synchronize()
+    }
+
+    public func fetchBadgeHistories() -> [HydrationChallengeBadgeHistory] {
+        guard let data = userDefaults.data(forKey: .hydrationChallengeBadgeHistories) else {
+            return []
+        }
+
+        return (try? decoder.decode([HydrationChallengeBadgeHistory].self, from: data)) ?? []
+    }
+
+    public func saveBadgeHistories(_ histories: [HydrationChallengeBadgeHistory]) {
+        guard let data = try? encoder.encode(histories) else {
+            return
+        }
+
+        userDefaults.set(data, forKey: .hydrationChallengeBadgeHistories)
         userDefaults.synchronize()
     }
 

--- a/Project/Data/Sources/Repository/ChallengeRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/ChallengeRepositoryImpl.swift
@@ -15,4 +15,12 @@ public struct ChallengeRepositoryImpl: ChallengeRepository {
     public func saveChallengeStates(_ states: [HydrationChallengeState]) {
         storageDataSource.saveChallengeStates(states)
     }
+
+    public func fetchBadgeHistories() -> [HydrationChallengeBadgeHistory] {
+        storageDataSource.fetchBadgeHistories()
+    }
+
+    public func saveBadgeHistories(_ histories: [HydrationChallengeBadgeHistory]) {
+        storageDataSource.saveBadgeHistories(histories)
+    }
 }

--- a/Project/Data/Tests/ChallengeStorageDataSourceTests.swift
+++ b/Project/Data/Tests/ChallengeStorageDataSourceTests.swift
@@ -49,6 +49,31 @@ struct ChallengeStorageDataSourceTests {
         #expect(dataSource.fetchChallengeStates() == states)
     }
 
+    @Test("badge history를 저장하고 다시 읽어온다")
+    func saveAndFetchBadgeHistories() {
+        let suiteName = "ChallengeStorageDataSourceTests.\(UUID().uuidString)"
+        let userDefaults = makeIsolatedUserDefaults(suiteName: suiteName)
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let dataSource = ChallengeStorageDataSourceImpl(userDefaults: userDefaults)
+        let achievedAt = Date(timeIntervalSince1970: 1_710_000_000)
+        let histories = [
+            HydrationChallengeBadgeHistory(
+                kind: .weeklyAchievement80,
+                achievedAt: achievedAt,
+                cycleID: "week:1710000000"
+            ),
+            HydrationChallengeBadgeHistory(
+                kind: .goalAchievement30,
+                achievedAt: achievedAt.addingTimeInterval(3_600)
+            )
+        ]
+
+        dataSource.saveBadgeHistories(histories)
+
+        #expect(dataSource.fetchBadgeHistories() == histories)
+    }
+
     @Test("legacy challenge state를 새 모델로 마이그레이션한다")
     func migrateLegacyStates() throws {
         let suiteName = "ChallengeStorageDataSourceTests.\(UUID().uuidString)"
@@ -96,6 +121,40 @@ struct ChallengeStorageDataSourceTests {
         let dataSource = ChallengeStorageDataSourceImpl(userDefaults: userDefaults)
 
         #expect(dataSource.fetchChallengeStates().isEmpty)
+        #expect(dataSource.fetchBadgeHistories().isEmpty)
+    }
+
+    @Test("challenge state와 badge history는 분리 저장된다")
+    func stateAndHistoryAreStoredIndependently() {
+        let suiteName = "ChallengeStorageDataSourceTests.\(UUID().uuidString)"
+        let userDefaults = makeIsolatedUserDefaults(suiteName: suiteName)
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+
+        let dataSource = ChallengeStorageDataSourceImpl(userDefaults: userDefaults)
+        let timestamp = Date(timeIntervalSince1970: 1_710_000_000)
+        let states = [
+            HydrationChallengeState.cumulative(
+                HydrationCumulativeChallengeState(
+                    kind: .goalAchievement30,
+                    progress: 1,
+                    isCompleted: true,
+                    achievedAt: timestamp,
+                    updatedAt: timestamp
+                )
+            )
+        ]
+        let histories = [
+            HydrationChallengeBadgeHistory(
+                kind: .goalAchievement30,
+                achievedAt: timestamp
+            )
+        ]
+
+        dataSource.saveChallengeStates(states)
+        dataSource.saveBadgeHistories(histories)
+
+        #expect(dataSource.fetchChallengeStates() == states)
+        #expect(dataSource.fetchBadgeHistories() == histories)
     }
 
     private func makeIsolatedUserDefaults(suiteName: String) -> UserDefaults {

--- a/Project/Domain/Interfaces/Entity/HydrationChallengeBadgeHistory.swift
+++ b/Project/Domain/Interfaces/Entity/HydrationChallengeBadgeHistory.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct HydrationChallengeBadgeHistory: Identifiable, Codable, Equatable, Sendable {
+    public let id: String
+    public let kind: HydrationChallengeKind
+    public let achievedAt: Date
+    public let cycleID: String?
+
+    public init(
+        kind: HydrationChallengeKind,
+        achievedAt: Date,
+        cycleID: String? = nil
+    ) {
+        self.kind = kind
+        self.achievedAt = achievedAt
+        self.cycleID = cycleID
+        self.id = Self.makeID(kind: kind, cycleID: cycleID)
+    }
+
+    public static func makeID(kind: HydrationChallengeKind, cycleID: String?) -> String {
+        guard kind.stateType == .recurring, let cycleID else {
+            return kind.rawValue
+        }
+
+        return "\(kind.rawValue):\(cycleID)"
+    }
+}

--- a/Project/Domain/Interfaces/Repository/ChallengeRepository.swift
+++ b/Project/Domain/Interfaces/Repository/ChallengeRepository.swift
@@ -3,4 +3,6 @@ import Foundation
 public protocol ChallengeRepository: Sendable {
     func fetchChallengeStates() -> [HydrationChallengeState]
     func saveChallengeStates(_ states: [HydrationChallengeState])
+    func fetchBadgeHistories() -> [HydrationChallengeBadgeHistory]
+    func saveBadgeHistories(_ histories: [HydrationChallengeBadgeHistory])
 }

--- a/Project/Domain/Interfaces/UseCase/ChallengeUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/ChallengeUseCase.swift
@@ -2,4 +2,5 @@ import Foundation
 
 public protocol ChallengeUseCase: Sendable {
     func fetchChallenges(referenceDate: Date, calendar: Calendar) async -> [HydrationChallenge]
+    func fetchBadgeHistories() async -> [HydrationChallengeBadgeHistory]
 }

--- a/Project/Domain/Sources/UseCase/ChallengeUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/ChallengeUseCaseImpl.swift
@@ -53,8 +53,21 @@ public struct ChallengeUseCaseImpl: ChallengeUseCase {
         }
 
         challengeRepository.saveChallengeStates(results.map(\.state))
+        let persistedHistories = challengeRepository.fetchBadgeHistories()
+        let mergedHistories = mergeBadgeHistories(
+            persistedHistories: persistedHistories,
+            results: results
+        )
+
+        if mergedHistories != persistedHistories {
+            challengeRepository.saveBadgeHistories(mergedHistories)
+        }
 
         return results.map(\.challenge)
+    }
+
+    public func fetchBadgeHistories() async -> [HydrationChallengeBadgeHistory] {
+        challengeRepository.fetchBadgeHistories()
     }
 
     private func mergeChallenge(
@@ -249,5 +262,46 @@ public struct ChallengeUseCaseImpl: ChallengeUseCase {
         }
 
         return totals.values.filter { $0 >= dailyGoalML }.count
+    }
+
+    private func mergeBadgeHistories(
+        persistedHistories: [HydrationChallengeBadgeHistory],
+        results: [ChallengeMergeResult]
+    ) -> [HydrationChallengeBadgeHistory] {
+        var mergedHistories = persistedHistories
+        var knownIDs = Set(persistedHistories.map(\.id))
+
+        for history in results.compactMap(makeBadgeHistory(from:)) {
+            guard knownIDs.insert(history.id).inserted else {
+                continue
+            }
+
+            mergedHistories.append(history)
+        }
+
+        return mergedHistories.sorted(by: badgeHistorySort)
+    }
+
+    private func makeBadgeHistory(from result: ChallengeMergeResult) -> HydrationChallengeBadgeHistory? {
+        guard result.challenge.isCompleted, let achievedAt = result.challenge.achievedAt else {
+            return nil
+        }
+
+        return HydrationChallengeBadgeHistory(
+            kind: result.challenge.kind,
+            achievedAt: achievedAt,
+            cycleID: result.state.recurringState?.cycleID
+        )
+    }
+
+    private func badgeHistorySort(
+        lhs: HydrationChallengeBadgeHistory,
+        rhs: HydrationChallengeBadgeHistory
+    ) -> Bool {
+        if lhs.achievedAt != rhs.achievedAt {
+            return lhs.achievedAt > rhs.achievedAt
+        }
+
+        return lhs.id < rhs.id
     }
 }

--- a/Project/Domain/Tests/ChallengeUseCaseTests.swift
+++ b/Project/Domain/Tests/ChallengeUseCaseTests.swift
@@ -65,6 +65,10 @@ struct ChallengeUseCaseTests {
         #expect(challengeRepository.lastSavedStates[1].recurringState != nil)
         #expect(challengeRepository.lastSavedStates[2].kind == .goalAchievement30)
         #expect(challengeRepository.lastSavedStates[2].cumulativeState != nil)
+        #expect(challengeRepository.saveBadgeHistoriesCallCount == 1)
+        #expect(challengeRepository.lastSavedBadgeHistories.count == 1)
+        #expect(challengeRepository.lastSavedBadgeHistories.first?.kind == .streak7)
+        #expect(challengeRepository.lastSavedBadgeHistories.first?.achievedAt == referenceDate)
     }
 
     @Test("같은 주기의 반복형 챌린지는 완료 상태와 달성 시점을 유지한다")
@@ -106,6 +110,15 @@ struct ChallengeUseCaseTests {
                 )
             ]
         )
+        challengeRepository.setBadgeHistories(
+            [
+                HydrationChallengeBadgeHistory(
+                    kind: .weeklyAchievement80,
+                    achievedAt: achievedAt,
+                    cycleID: weeklyCycleID
+                )
+            ]
+        )
 
         let useCase = ChallengeUseCaseImpl(
             progressUseCase: progressUseCase,
@@ -119,6 +132,7 @@ struct ChallengeUseCaseTests {
         #expect(weekly?.isCompleted == true)
         #expect(weekly?.progress == 1)
         #expect(weekly?.achievedAt == achievedAt)
+        #expect(challengeRepository.saveBadgeHistoriesCallCount == 0)
     }
 
     @Test("새 주기로 넘어가면 반복형 챌린지는 완료 상태를 초기화한다")
@@ -161,6 +175,15 @@ struct ChallengeUseCaseTests {
                 )
             ]
         )
+        challengeRepository.setBadgeHistories(
+            [
+                HydrationChallengeBadgeHistory(
+                    kind: .weeklyAchievement80,
+                    achievedAt: achievedAt,
+                    cycleID: previousCycleID
+                )
+            ]
+        )
 
         let useCase = ChallengeUseCaseImpl(
             progressUseCase: progressUseCase,
@@ -174,6 +197,7 @@ struct ChallengeUseCaseTests {
         #expect(weekly?.isCompleted == false)
         #expect(weekly?.achievedAt == nil)
         #expect(weekly?.progress == 0.3125)
+        #expect(challengeRepository.saveBadgeHistoriesCallCount == 0)
     }
 
     @Test("누적형 챌린지는 진행도가 바뀌어도 완료 상태를 유지한다")
@@ -225,6 +249,63 @@ struct ChallengeUseCaseTests {
         #expect(count?.isCompleted == true)
         #expect(count?.progress == 1)
         #expect(count?.achievedAt == achievedAt)
+        #expect(challengeRepository.saveBadgeHistoriesCallCount == 1)
+        #expect(challengeRepository.lastSavedBadgeHistories.count == 1)
+        #expect(challengeRepository.lastSavedBadgeHistories.first?.kind == .goalAchievement30)
+        #expect(challengeRepository.lastSavedBadgeHistories.first?.achievedAt == achievedAt)
+    }
+
+    @Test("반복형 챌린지는 새 주기 완료 시 배지 이력을 누적 저장한다")
+    func appendsRecurringBadgeHistoryForNewCycleCompletion() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 17, hour: 9))!
+        let previousWeekDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 9))!
+        let previousAchievedAt = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 8))!
+        let progressUseCase = MockHydrationProgressUseCase()
+        progressUseCase.snapshot = HydrationProgressSnapshot(
+            dailyGoalML: 2000,
+            weeklyAverageML: 2200,
+            monthlyAverageML: 2000,
+            weeklyAchievementRate: 1,
+            monthlyAchievementRate: 0.5,
+            weeklyAchievedDays: 2,
+            monthlyAchievedDays: 8,
+            weeklyElapsedDays: 2,
+            monthlyElapsedDays: 17,
+            currentStreak: 2,
+            isEmpty: false
+        )
+
+        let challengeRepository = MockChallengeRepository()
+        let previousCycleID = HydrationChallengeKind.weeklyAchievement80.recurringCycleID(
+            referenceDate: previousWeekDate,
+            calendar: calendar
+        )
+        challengeRepository.setBadgeHistories(
+            [
+                HydrationChallengeBadgeHistory(
+                    kind: .weeklyAchievement80,
+                    achievedAt: previousAchievedAt,
+                    cycleID: previousCycleID
+                )
+            ]
+        )
+
+        let useCase = ChallengeUseCaseImpl(
+            progressUseCase: progressUseCase,
+            challengeRepository: challengeRepository,
+            drinkWaterRepository: MockDrinkWaterRepository()
+        )
+
+        let challenges = await useCase.fetchChallenges(referenceDate: referenceDate, calendar: calendar)
+        let weekly = challenges.first { $0.kind == .weeklyAchievement80 }
+
+        #expect(weekly?.isCompleted == true)
+        #expect(weekly?.achievedAt == referenceDate)
+        #expect(challengeRepository.saveBadgeHistoriesCallCount == 1)
+        #expect(challengeRepository.lastSavedBadgeHistories.count == 2)
+        #expect(challengeRepository.lastSavedBadgeHistories.first?.cycleID != previousCycleID)
+        #expect(challengeRepository.lastSavedBadgeHistories.first?.achievedAt == referenceDate)
     }
 
     private func makeGoalAchievementEvents(calendar: Calendar, achievedDays: [Int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]) -> [HydrationEvent] {

--- a/Project/Domain/Tests/Mock/MockChallengeRepository.swift
+++ b/Project/Domain/Tests/Mock/MockChallengeRepository.swift
@@ -3,10 +3,14 @@ import Foundation
 
 final class MockChallengeRepository: ChallengeRepository, @unchecked Sendable {
     private var states: [HydrationChallengeState] = []
+    private var badgeHistories: [HydrationChallengeBadgeHistory] = []
 
     private(set) var fetchChallengeStatesCallCount = 0
     private(set) var saveChallengeStatesCallCount = 0
     private(set) var lastSavedStates: [HydrationChallengeState] = []
+    private(set) var fetchBadgeHistoriesCallCount = 0
+    private(set) var saveBadgeHistoriesCallCount = 0
+    private(set) var lastSavedBadgeHistories: [HydrationChallengeBadgeHistory] = []
 
     func fetchChallengeStates() -> [HydrationChallengeState] {
         fetchChallengeStatesCallCount += 1
@@ -19,7 +23,22 @@ final class MockChallengeRepository: ChallengeRepository, @unchecked Sendable {
         lastSavedStates = states
     }
 
+    func fetchBadgeHistories() -> [HydrationChallengeBadgeHistory] {
+        fetchBadgeHistoriesCallCount += 1
+        return badgeHistories
+    }
+
+    func saveBadgeHistories(_ histories: [HydrationChallengeBadgeHistory]) {
+        saveBadgeHistoriesCallCount += 1
+        badgeHistories = histories
+        lastSavedBadgeHistories = histories
+    }
+
     func setChallengeStates(_ states: [HydrationChallengeState]) {
         self.states = states
+    }
+
+    func setBadgeHistories(_ histories: [HydrationChallengeBadgeHistory]) {
+        badgeHistories = histories
     }
 }

--- a/Project/Presentation/Sources/View/Challenge/ChallengeView.swift
+++ b/Project/Presentation/Sources/View/Challenge/ChallengeView.swift
@@ -81,7 +81,7 @@ public struct ChallengeView: View {
 
                     VStack(spacing: 14) {
                         ForEach(viewModel.completedChallenges) { challenge in
-                            ChallengeCard(challenge: challenge)
+                            ChallengeHistoryCard(challenge: challenge)
                         }
                     }
                 }
@@ -346,6 +346,85 @@ private struct ChallengeCard: View {
             .overlay(
                 RoundedRectangle(cornerRadius: 24, style: .continuous)
                     .stroke(accentColor.opacity(challenge.isCompleted ? 0.22 : 0.08), lineWidth: 1)
+            )
+    }
+}
+
+private struct ChallengeHistoryCard: View {
+    let challenge: ChallengeHistoryCardModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 10) {
+                    ChallengeBadge(
+                        title: challenge.badgeText,
+                        color: accentColor
+                    )
+
+                    Text(challenge.title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+
+                    Text(challenge.description)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 12)
+
+                Image(systemName: challenge.symbolName)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(accentColor)
+                    .frame(width: 42, height: 42)
+                    .background(
+                        Circle()
+                            .fill(accentColor.opacity(0.18))
+                    )
+            }
+
+            Label(challenge.achievedAtText, systemImage: "checkmark.seal.fill")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(accentColor)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(cardBackground)
+        .overlay(alignment: .topTrailing) {
+            Image(systemName: "sparkles")
+                .font(.headline.weight(.bold))
+                .foregroundStyle(accentColor.opacity(0.9))
+                .padding(16)
+        }
+    }
+
+    private var accentColor: Color {
+        switch challenge.kind {
+        case .streak7:
+            return .orange
+        case .weeklyAchievement80:
+            return .mint
+        case .goalAchievement30:
+            return .blue
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 24, style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: [
+                        accentColor.opacity(0.22),
+                        Color(uiColor: .secondarySystemBackground).opacity(0.96)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .stroke(accentColor.opacity(0.22), lineWidth: 1)
             )
     }
 }

--- a/Project/Presentation/Sources/ViewModel/ChallengeViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/ChallengeViewModel.swift
@@ -21,6 +21,17 @@ struct ChallengeCardModel: Identifiable, Equatable {
     let isCompleted: Bool
 }
 
+struct ChallengeHistoryCardModel: Identifiable, Equatable {
+    let id: String
+    let kind: HydrationChallengeKind
+    let badgeText: String
+    let title: String
+    let symbolName: String
+    let description: String
+    let achievedAt: Date
+    let achievedAtText: String
+}
+
 struct PersonalizedChallengeCardModel: Identifiable, Equatable {
     let id: PersonalizedHydrationChallengeKind
     let kind: PersonalizedHydrationChallengeKind
@@ -40,7 +51,7 @@ public final class ChallengeViewModel {
     private(set) var isEmpty = false
     private(set) var recommendedChallenges: [PersonalizedChallengeCardModel] = []
     private(set) var inProgressChallenges: [ChallengeCardModel] = []
-    private(set) var completedChallenges: [ChallengeCardModel] = []
+    private(set) var completedChallenges: [ChallengeHistoryCardModel] = []
 
     private let challengeUseCase: ChallengeUseCase
     private let personalizedChallengeUseCase: PersonalizedChallengeUseCase
@@ -92,16 +103,16 @@ public final class ChallengeViewModel {
 
         let recommendedCards = await recommended
         let fixedCards = await challenges
+        let badgeHistories = await challengeUseCase.fetchBadgeHistories()
 
         recommendedChallenges = recommendedCards.map(makePersonalizedCardModel(from:))
 
-        let cards = fixedCards.map { makeCardModel(from: $0, snapshot: snapshot) }
-
-        inProgressChallenges = cards
+        inProgressChallenges = fixedCards
             .filter { $0.isCompleted == false }
+            .map { makeCardModel(from: $0, snapshot: snapshot) }
             .sorted(by: inProgressSort)
-        completedChallenges = cards
-            .filter(\.isCompleted)
+        completedChallenges = badgeHistories
+            .map { makeHistoryCardModel(from: $0) }
             .sorted(by: completedSort)
     }
 
@@ -128,21 +139,34 @@ public final class ChallengeViewModel {
         ChallengeCardModel(
             id: challenge.kind,
             kind: challenge.kind,
-            badgeText: challenge.isCompleted
-                ? L10n.tr("challengeEarnedBadge")
-                : L10n.tr("challengeInProgressBadge"),
+            badgeText: L10n.tr("challengeInProgressBadge"),
             title: title(for: challenge.kind),
             symbolName: symbolName(for: challenge.kind),
             valueText: valueText(for: challenge),
             description: description(for: challenge),
             progress: challenge.progress,
             progressText: progressText(for: challenge),
-            remainingConditionText: challenge.isCompleted ? nil : remainingConditionText(for: challenge),
-            todayActionText: challenge.isCompleted ? nil : todayActionText(for: challenge, snapshot: snapshot),
-            todayActionCompleted: challenge.isCompleted ? false : todayActionCompleted(for: challenge, snapshot: snapshot),
-            achievedAt: challenge.achievedAt,
-            achievedAtText: challenge.achievedAt.map(achievedAtText),
-            isCompleted: challenge.isCompleted
+            remainingConditionText: remainingConditionText(for: challenge),
+            todayActionText: todayActionText(for: challenge, snapshot: snapshot),
+            todayActionCompleted: todayActionCompleted(for: challenge, snapshot: snapshot),
+            achievedAt: nil,
+            achievedAtText: nil,
+            isCompleted: false
+        )
+    }
+
+    private func makeHistoryCardModel(
+        from history: HydrationChallengeBadgeHistory
+    ) -> ChallengeHistoryCardModel {
+        ChallengeHistoryCardModel(
+            id: history.id,
+            kind: history.kind,
+            badgeText: L10n.tr("challengeEarnedBadge"),
+            title: title(for: history.kind),
+            symbolName: symbolName(for: history.kind),
+            description: completedDescription(for: history.kind),
+            achievedAt: history.achievedAt,
+            achievedAtText: achievedAtText(for: history.achievedAt)
         )
     }
 
@@ -185,9 +209,6 @@ public final class ChallengeViewModel {
         switch challenge.kind {
         case .streak7:
             let remainingDays = max(challenge.primaryTargetValue - challenge.primaryCurrentValue, 0)
-            if challenge.isCompleted {
-                return L10n.tr("challengeCompletedDescription")
-            }
             if challenge.primaryCurrentValue == 0 {
                 return L10n.tr("challengeStreakStartDescription")
             }
@@ -197,17 +218,11 @@ public final class ChallengeViewModel {
             let achievedDays = challenge.secondaryCurrentValue ?? 0
             let elapsedDays = max(challenge.secondaryTargetValue ?? 1, 1)
 
-            if challenge.isCompleted {
-                return L10n.tr("challengeWeeklyCompletedDescription")
-            }
             return L10n.tr("challengeWeeklyProgressDescriptionFormat", achievedDays, elapsedDays)
 
         case .goalAchievement30:
             let remainingCount = max(challenge.primaryTargetValue - challenge.primaryCurrentValue, 0)
 
-            if challenge.isCompleted {
-                return L10n.tr("challengeGoalCompletedDescription")
-            }
             if challenge.primaryCurrentValue == 0 {
                 return L10n.tr("challengeGoalStartDescription")
             }
@@ -338,6 +353,17 @@ public final class ChallengeViewModel {
         return L10n.tr("challengeAchievedAtFormat", formattedDate)
     }
 
+    private func completedDescription(for kind: HydrationChallengeKind) -> String {
+        switch kind {
+        case .streak7:
+            return L10n.tr("challengeCompletedDescription")
+        case .weeklyAchievement80:
+            return L10n.tr("challengeWeeklyCompletedDescription")
+        case .goalAchievement30:
+            return L10n.tr("challengeGoalCompletedDescription")
+        }
+    }
+
     private func sourceText(for source: HydrationChallengeRecommendationSource) -> String {
         switch source {
         case .routine:
@@ -463,12 +489,11 @@ public final class ChallengeViewModel {
         return lhs.kind.rawValue < rhs.kind.rawValue
     }
 
-    private func completedSort(lhs: ChallengeCardModel, rhs: ChallengeCardModel) -> Bool {
-        switch (lhs.achievedAt, rhs.achievedAt) {
-        case let (left?, right?) where left != right:
-            return left > right
-        default:
-            return lhs.kind.rawValue < rhs.kind.rawValue
+    private func completedSort(lhs: ChallengeHistoryCardModel, rhs: ChallengeHistoryCardModel) -> Bool {
+        if lhs.achievedAt != rhs.achievedAt {
+            return lhs.achievedAt > rhs.achievedAt
         }
+
+        return lhs.id < rhs.id
     }
 }

--- a/Project/Presentation/Tests/ChallengeViewModelTests.swift
+++ b/Project/Presentation/Tests/ChallengeViewModelTests.swift
@@ -64,6 +64,13 @@ struct ChallengeViewModelTests {
                 achievedAt: nil
             )
         ]
+        challengeUseCase.badgeHistories = [
+            HydrationChallengeBadgeHistory(
+                kind: .weeklyAchievement80,
+                achievedAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 11))!,
+                cycleID: "week:1710115200"
+            )
+        ]
         personalizedChallengeUseCase.challenges = [
             PersonalizedHydrationChallenge(
                 kind: .routineAnchor,
@@ -107,6 +114,7 @@ struct ChallengeViewModelTests {
         #expect(viewModel.inProgressChallenges.last?.title == L10n.tr("challengeGoalCardTitle"))
         #expect(viewModel.inProgressChallenges.last?.todayActionText == L10n.tr("challengeTodayActionGoalFormat", 13, 30))
         #expect(challengeUseCase.requestedReferenceDate == referenceDate)
+        #expect(challengeUseCase.fetchBadgeHistoriesCallCount == 1)
         #expect(personalizedChallengeUseCase.requestedReferenceDate == referenceDate)
     }
 
@@ -135,6 +143,7 @@ struct ChallengeViewModelTests {
         #expect(viewModel.inProgressChallenges.isEmpty)
         #expect(viewModel.completedChallenges.isEmpty)
         #expect(challengeUseCase.requestedReferenceDate == nil)
+        #expect(challengeUseCase.fetchBadgeHistoriesCallCount == 0)
         #expect(personalizedChallengeUseCase.requestedReferenceDate == nil)
     }
 
@@ -161,26 +170,20 @@ struct ChallengeViewModelTests {
         )
         let challengeUseCase = MockChallengeUseCase()
         let personalizedChallengeUseCase = MockPersonalizedChallengeUseCase()
-        challengeUseCase.challenges = [
-            HydrationChallenge(
+        challengeUseCase.badgeHistories = [
+            HydrationChallengeBadgeHistory(
                 kind: .goalAchievement30,
-                progress: 1,
-                currentValue: 30,
-                targetValue: 30,
-                primaryCurrentValue: 30,
-                primaryTargetValue: 30,
-                isCompleted: true,
-                achievedAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 10))
+                achievedAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 10))!
             ),
-            HydrationChallenge(
+            HydrationChallengeBadgeHistory(
                 kind: .streak7,
-                progress: 1,
-                currentValue: 7,
-                targetValue: 7,
-                primaryCurrentValue: 7,
-                primaryTargetValue: 7,
-                isCompleted: true,
-                achievedAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 12))
+                achievedAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 12))!,
+                cycleID: "streak:1710201600"
+            ),
+            HydrationChallengeBadgeHistory(
+                kind: .streak7,
+                achievedAt: calendar.date(from: DateComponents(year: 2026, month: 3, day: 9))!,
+                cycleID: "streak:1710028800"
             )
         ]
 
@@ -197,7 +200,8 @@ struct ChallengeViewModelTests {
         #expect(
             viewModel.completedChallenges.map { $0.kind } == [
                 HydrationChallengeKind.streak7,
-                HydrationChallengeKind.goalAchievement30
+                HydrationChallengeKind.goalAchievement30,
+                HydrationChallengeKind.streak7
             ]
         )
         #expect(viewModel.completedChallenges.first?.description == L10n.tr("challengeCompletedDescription"))

--- a/Project/Presentation/Tests/Mock/MockChallengeUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockChallengeUseCase.swift
@@ -3,10 +3,17 @@ import Foundation
 
 final class MockChallengeUseCase: ChallengeUseCase, @unchecked Sendable {
     var challenges: [HydrationChallenge] = []
+    var badgeHistories: [HydrationChallengeBadgeHistory] = []
     private(set) var requestedReferenceDate: Date?
+    private(set) var fetchBadgeHistoriesCallCount = 0
 
     func fetchChallenges(referenceDate: Date, calendar: Calendar) async -> [HydrationChallenge] {
         requestedReferenceDate = referenceDate
         return challenges
+    }
+
+    func fetchBadgeHistories() async -> [HydrationChallengeBadgeHistory] {
+        fetchBadgeHistoriesCallCount += 1
+        return badgeHistories
     }
 }

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockChallengeUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockChallengeUseCase.swift
@@ -3,6 +3,7 @@ import Foundation
 
 public final class MockChallengeUseCase: ChallengeUseCase, @unchecked Sendable {
     public var challenges: [HydrationChallenge]
+    public var badgeHistories: [HydrationChallengeBadgeHistory]
 
     public init(
         challenges: [HydrationChallenge] = [
@@ -38,12 +39,28 @@ public final class MockChallengeUseCase: ChallengeUseCase, @unchecked Sendable {
                 isCompleted: false,
                 achievedAt: nil
             )
+        ],
+        badgeHistories: [HydrationChallengeBadgeHistory] = [
+            HydrationChallengeBadgeHistory(
+                kind: .weeklyAchievement80,
+                achievedAt: Date()
+            ),
+            HydrationChallengeBadgeHistory(
+                kind: .streak7,
+                achievedAt: Date().addingTimeInterval(-86_400),
+                cycleID: "streak:preview"
+            )
         ]
     ) {
         self.challenges = challenges
+        self.badgeHistories = badgeHistories
     }
 
     public func fetchChallenges(referenceDate: Date, calendar: Calendar) async -> [HydrationChallenge] {
         challenges
+    }
+
+    public func fetchBadgeHistories() async -> [HydrationChallengeBadgeHistory] {
+        badgeHistories
     }
 }

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockChallengeUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockChallengeUseCaseForTesting.swift
@@ -7,4 +7,8 @@ public final class MockChallengeUseCaseForTesting: ChallengeUseCase, @unchecked 
     public func fetchChallenges(referenceDate: Date, calendar: Calendar) async -> [HydrationChallenge] {
         []
     }
+
+    public func fetchBadgeHistories() async -> [HydrationChallengeBadgeHistory] {
+        []
+    }
 }

--- a/Project/Shared/Utils/Sources/String+Extensions.swift
+++ b/Project/Shared/Utils/Sources/String+Extensions.swift
@@ -25,4 +25,5 @@ public extension String {
     static let dailyWaterLimit: String = "dailyWaterLimit"
     static let hydrationRoutines: String = "hydrationRoutines"
     static let hydrationChallengeStates: String = "hydrationChallengeStates"
+    static let hydrationChallengeBadgeHistories: String = "hydrationChallengeBadgeHistories"
 }


### PR DESCRIPTION
## Summary
- separate challenge badge history from progress state persistence
- append recurring and cumulative badge histories with dedupe rules
- render the earned challenge section as a badge history timeline

## Related Issues
- Closes #139

## Testing
- `DomainLayer` tests: 71 passed
- `DataLayer` tests: 14 passed
- `PresentationLayer` tests: 40 passed