### PR TITLE
feat: add lock screen water widget

### DIFF
--- a/Project/Widget/Sources/AppIntent.swift
+++ b/Project/Widget/Sources/AppIntent.swift
@@ -5,19 +5,25 @@
 //  Created by Kyeongmo Yang on 9/6/24.
 //
 
-import WidgetKit
 import AppIntents
 import DependencyInjection
 import DomainLayerInterface
+import WidgetKit
 
 struct ConfigurationAppIntent: WidgetConfigurationIntent {
-    static let title: LocalizedStringResource = "Configuration"
-    static let description = IntentDescription("This is an example widget.")
-    
-    // An example configurable parameter.
-    @Parameter(title: "Favorite Emoji", default: "😃")
-    var favoriteEmoji: String
-    
+    static let title: LocalizedStringResource = "물 마시기"
+    static let description = IntentDescription("오늘 마신 물의 양을 홈 화면과 잠금화면에서 확인합니다.")
+
+    public func perform() async throws -> some IntentResult {
+        .result()
+    }
+}
+
+struct LogWaterAppIntent: AppIntent {
+    static let title: LocalizedStringResource = "물 마시기"
+    static let description = IntentDescription("250ml 물 마시기를 기록합니다.")
+    static let openAppWhenRun = false
+
     public func perform() async throws -> some IntentResult {
         let waterUseCase = DIContainer.shared.resolve(DrinkWaterUseCase.self)
         let userPreferencesUseCase = DIContainer.shared.resolve(UserPreferencesUseCase.self)

--- a/Project/Widget/Sources/DrinkWaterLockScreenWidget.swift
+++ b/Project/Widget/Sources/DrinkWaterLockScreenWidget.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import WidgetKit
+
+struct DrinkWaterLockScreenWidgetEntryView: View {
+    @Environment(\.widgetFamily) private var widgetFamily
+    
+    let entry: DrinkWaterEntry
+    
+    private var accentColor: Color {
+        entry.isLimitReached ? .green : .accentColor
+    }
+    
+    var body: some View {
+        switch widgetFamily {
+        case .accessoryInline:
+            inlineView
+        case .accessoryCircular:
+            circularView
+        case .accessoryRectangular:
+            rectangularView
+        default:
+            rectangularView
+        }
+    }
+    
+    private var inlineView: some View {
+        Label("\(entry.mililiters.formatted())ml", systemImage: entry.mainAppearanceIcon)
+    }
+    
+    private var circularView: some View {
+        Gauge(value: entry.progressFraction) {
+            EmptyView()
+        } currentValueLabel: {
+            VStack(spacing: 0) {
+                Text("\(entry.mililiters)")
+                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .minimumScaleFactor(0.6)
+                
+                Text("ml")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .gaugeStyle(.accessoryCircularCapacity)
+        .tint(accentColor)
+    }
+    
+    private var rectangularView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: entry.mainAppearanceIcon)
+                    .foregroundStyle(accentColor)
+                
+                Text("오늘 수분")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                
+                Spacer(minLength: 4)
+                
+                Text("\(entry.percentage)%")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(accentColor)
+            }
+            
+            Text("\(entry.mililiters.formatted())ml")
+                .font(.system(size: 22, weight: .bold, design: .rounded))
+                .minimumScaleFactor(0.7)
+            
+            Text("\(entry.numberOfGlasses)잔 · 목표 \(entry.dailyLimitText)ml")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+struct DrinkWaterLockScreenWidget: Widget {
+    private let kind = "MulimeeLockScreenWidget"
+    
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+            intent: ConfigurationAppIntent.self,
+            provider: DrinkWaterWidgetProvider()
+        ) { entry in
+            DrinkWaterLockScreenWidgetEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("잠금화면 물 마시기")
+        .description("잠금화면에서 오늘 마신 물의 양을 빠르게 확인하세요")
+        .supportedFamilies([.accessoryInline, .accessoryCircular, .accessoryRectangular])
+    }
+}
+
+#Preview(as: .accessoryRectangular) {
+    DrinkWaterLockScreenWidget()
+} timeline: {
+    DrinkWaterEntry(
+        date: .now,
+        numberOfGlasses: 5,
+        dailyLimit: 2000,
+        mainAppearanceIcon: "drop.fill"
+    )
+}
+
+#Preview(as: .accessoryCircular) {
+    DrinkWaterLockScreenWidget()
+} timeline: {
+    DrinkWaterEntry(
+        date: .now,
+        numberOfGlasses: 6,
+        dailyLimit: 2000,
+        mainAppearanceIcon: "heart.fill"
+    )
+}
+
+#Preview(as: .accessoryInline) {
+    DrinkWaterLockScreenWidget()
+} timeline: {
+    DrinkWaterEntry(
+        date: .now,
+        numberOfGlasses: 3,
+        dailyLimit: 2000,
+        mainAppearanceIcon: "cloud.fill"
+    )
+}

--- a/Project/Widget/Sources/DrinkWaterWidget.swift
+++ b/Project/Widget/Sources/DrinkWaterWidget.swift
@@ -1,117 +1,16 @@
-//
-//  DrinkWaterWidget.swift
-//  DrinkWaterWidget
-//
-//  Created by Kyeongmo Yang on 2023/06/24.
-//
-
 import SwiftUI
 import Utils
 import WidgetKit
-import DependencyInjection
-import DomainLayerInterface
 
-struct Provider: AppIntentTimelineProvider {
-    private let waterUseCase: DrinkWaterUseCase
-    private let userPreferencesUseCase: UserPreferencesUseCase
+struct DrinkWaterWidgetEntryView: View {
+    let entry: DrinkWaterEntry
     
-    init() {
-        self.waterUseCase = DIContainer.shared.resolve(DrinkWaterUseCase.self)
-        self.userPreferencesUseCase = DIContainer.shared.resolve(UserPreferencesUseCase.self)
-    }
-    
-    func placeholder(in context: Context) -> DrinkWaterEntry {
-        .init(
-            date: .now,
-            numberOfGlasses: 0,
-            dailyLimit: 2000,
-            mainAppearanceIcon: "drop.fill",
-            configuration: ConfigurationAppIntent()
-        )
-    }
-    
-    func snapshot(
-        for configuration: ConfigurationAppIntent,
-        in context: Context
-    ) async -> DrinkWaterEntry {
-        await waterUseCase.migrateLegacyDataIfNeeded()
-        let dailyLimit = userPreferencesUseCase.getDailyWaterLimit()
-        let mainAppearance = userPreferencesUseCase.getMainAppearance()
-        let appearanceIcon = mainAppearance.systemImage
-        
-        return .init(
-            date: .now,
-            numberOfGlasses: await waterUseCase.currentWater,
-            dailyLimit: dailyLimit,
-            mainAppearanceIcon: appearanceIcon,
-            configuration: ConfigurationAppIntent()
-        )
-    }
-    
-    func timeline(
-        for configuration: ConfigurationAppIntent,
-        in context: Context
-    ) async -> Timeline<DrinkWaterEntry> {
-        await waterUseCase.migrateLegacyDataIfNeeded()
-        let dailyLimit = userPreferencesUseCase.getDailyWaterLimit()
-        let mainAppearance = userPreferencesUseCase.getMainAppearance()
-        let appearanceIcon = mainAppearance.systemImage
-        let currentCount = await waterUseCase.currentWater
-        
-        var entries: [DrinkWaterEntry] = []
-        
-        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
-        let currentDate = Date()
-        for hourOffset in 0 ..< 5 {
-            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
-            let entry = DrinkWaterEntry(
-                date: entryDate,
-                numberOfGlasses: currentCount,
-                dailyLimit: dailyLimit,
-                mainAppearanceIcon: appearanceIcon,
-                configuration: ConfigurationAppIntent()
-            )
-            entries.append(entry)
-        }
-        
-        return Timeline(entries: entries, policy: .atEnd)
-    }
-}
-
-struct DrinkWaterEntry: TimelineEntry {
-    let date: Date
-    let numberOfGlasses: Int
-    let dailyLimit: Double
-    let mainAppearanceIcon: String
-    let configuration: ConfigurationAppIntent
-}
-
-struct DrinkWaterWidgetEntryView : View {
-    var entry: Provider.Entry
-    
-    private var numberOfGlasses: Int {
-        entry.numberOfGlasses
-    }
-    
-    private var mililiters: Int {
-        250 * numberOfGlasses
-    }
-    
-    private var progress: CGFloat {
-        CGFloat(mililiters) / entry.dailyLimit
-    }
-    
-    private var percentage: Int {
-        Int(progress * 100.0)
-    }
-    
-    private var isLimitReached: Bool {
-        Double(mililiters) >= entry.dailyLimit
+    private var accentColor: Color {
+        entry.isLimitReached ? .green : .accentColor
     }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            // 상단: MainAppearance 아이콘 (좌) + 마시기 버튼 (우)
             HStack {
                 Image(systemName: entry.mainAppearanceIcon)
                     .font(.system(size: 20, weight: .semibold))
@@ -119,11 +18,11 @@ struct DrinkWaterWidgetEntryView : View {
                 
                 Spacer()
                 
-                Button(intent: ConfigurationAppIntent()) {
+                Button(intent: LogWaterAppIntent()) {
                     HStack(spacing: 4) {
-                        Image(systemName: isLimitReached ? "checkmark.circle.fill" : "plus.circle.fill")
+                        Image(systemName: entry.isLimitReached ? "checkmark.circle.fill" : "plus.circle.fill")
                             .font(.system(size: 12, weight: .medium))
-                        Text(isLimitReached ? "완료" : "마시기")
+                        Text(entry.isLimitReached ? "완료" : "마시기")
                             .font(.system(size: 11, weight: .semibold))
                     }
                     .foregroundColor(.white)
@@ -131,29 +30,26 @@ struct DrinkWaterWidgetEntryView : View {
                     .padding(.vertical, 4)
                     .background(
                         RoundedRectangle(cornerRadius: 6)
-                            .fill(isLimitReached ? Color.green : Color.accentColor)
+                            .fill(accentColor)
                     )
                 }
-                .buttonStyle(PlainButtonStyle())
-                .disabled(isLimitReached)
+                .buttonStyle(.plain)
+                .disabled(entry.isLimitReached)
             }
             
-            // 마신 ml (큰 글씨)
-            Text("\(mililiters.formatted())ml")
+            Text("\(entry.mililiters.formatted())ml")
                 .font(.system(size: 25, weight: .bold, design: .rounded))
                 .foregroundColor(.primary)
             
-            // 잔수 / 목표
-            Text("\(numberOfGlasses)잔 / 목표 \(Int(entry.dailyLimit.rounded()))ml")
+            Text("\(entry.numberOfGlasses)잔 / 목표 \(entry.dailyLimitText)ml")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(.secondary)
             
             Spacer()
             
-            // 하단: 프로그레스 바
-            ProgressView(value: progress)
-                .progressViewStyle(LinearProgressViewStyle())
-                .tint(isLimitReached ? .green : .accentColor)
+            ProgressView(value: entry.progressFraction)
+                .progressViewStyle(.linear)
+                .tint(accentColor)
                 .scaleEffect(y: 1.5)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -168,13 +64,13 @@ struct DrinkWaterWidget: Widget {
         AppIntentConfiguration(
             kind: kind,
             intent: ConfigurationAppIntent.self,
-            provider: Provider()
+            provider: DrinkWaterWidgetProvider()
         ) { entry in
             DrinkWaterWidgetEntryView(entry: entry)
                 .containerBackground(.fill.tertiary, for: .widget)
         }
         .configurationDisplayName("물 마시기")
-        .description("오늘 마신 물의 양을 확인하고 기록하세요")
+        .description("홈 화면에서 오늘 마신 물의 양을 확인하고 기록하세요")
         .supportedFamilies([.systemSmall])
     }
 }
@@ -186,21 +82,18 @@ struct DrinkWaterWidget: Widget {
         date: .now,
         numberOfGlasses: 0,
         dailyLimit: 2000,
-        mainAppearanceIcon: "drop.fill",
-        configuration: .init()
+        mainAppearanceIcon: "drop.fill"
     )
     DrinkWaterEntry(
         date: .now,
         numberOfGlasses: 4,
         dailyLimit: 2000,
-        mainAppearanceIcon: "heart.fill",
-        configuration: .init()
+        mainAppearanceIcon: "heart.fill"
     )
     DrinkWaterEntry(
         date: .now,
         numberOfGlasses: 8,
         dailyLimit: 2000,
-        mainAppearanceIcon: "cloud.fill",
-        configuration: .init()
+        mainAppearanceIcon: "cloud.fill"
     )
 }

--- a/Project/Widget/Sources/DrinkWaterWidgetBundle.swift
+++ b/Project/Widget/Sources/DrinkWaterWidgetBundle.swift
@@ -12,5 +12,6 @@ import SwiftUI
 struct DrinkWaterWidgetBundle: WidgetBundle {
     var body: some Widget {
         DrinkWaterWidget()
+        DrinkWaterLockScreenWidget()
     }
 }

--- a/Project/Widget/Sources/DrinkWaterWidgetShared.swift
+++ b/Project/Widget/Sources/DrinkWaterWidgetShared.swift
@@ -1,0 +1,94 @@
+import DependencyInjection
+import DomainLayerInterface
+import Foundation
+import WidgetKit
+
+struct DrinkWaterWidgetProvider: AppIntentTimelineProvider {
+    private let waterUseCase: DrinkWaterUseCase
+    private let userPreferencesUseCase: UserPreferencesUseCase
+
+    init() {
+        self.waterUseCase = DIContainer.shared.resolve(DrinkWaterUseCase.self)
+        self.userPreferencesUseCase = DIContainer.shared.resolve(UserPreferencesUseCase.self)
+    }
+
+    func placeholder(in context: Context) -> DrinkWaterEntry {
+        .init(
+            date: .now,
+            numberOfGlasses: 0,
+            dailyLimit: 2000,
+            mainAppearanceIcon: "drop.fill"
+        )
+    }
+
+    func snapshot(
+        for configuration: ConfigurationAppIntent,
+        in context: Context
+    ) async -> DrinkWaterEntry {
+        await makeEntry(date: .now)
+    }
+
+    func timeline(
+        for configuration: ConfigurationAppIntent,
+        in context: Context
+    ) async -> Timeline<DrinkWaterEntry> {
+        await waterUseCase.migrateLegacyDataIfNeeded()
+
+        let currentDate = Date()
+        var entries: [DrinkWaterEntry] = []
+
+        for hourOffset in 0..<5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate) ?? currentDate
+            let entry = await makeEntry(date: entryDate)
+            entries.append(entry)
+        }
+
+        return Timeline(entries: entries, policy: .atEnd)
+    }
+
+    private func makeEntry(date: Date) async -> DrinkWaterEntry {
+        await waterUseCase.migrateLegacyDataIfNeeded()
+        let dailyLimit = userPreferencesUseCase.getDailyWaterLimit()
+        let appearanceIcon = userPreferencesUseCase.getMainAppearance().fillSystemImage
+
+        return DrinkWaterEntry(
+            date: date,
+            numberOfGlasses: await waterUseCase.currentWater,
+            dailyLimit: dailyLimit,
+            mainAppearanceIcon: appearanceIcon
+        )
+    }
+}
+
+struct DrinkWaterEntry: TimelineEntry {
+    let date: Date
+    let numberOfGlasses: Int
+    let dailyLimit: Double
+    let mainAppearanceIcon: String
+}
+
+extension DrinkWaterEntry {
+    var mililiters: Int {
+        250 * numberOfGlasses
+    }
+
+    var progressFraction: Double {
+        guard dailyLimit > 0 else {
+            return 0
+        }
+
+        return min(max(Double(mililiters) / dailyLimit, 0), 1)
+    }
+
+    var percentage: Int {
+        Int(progressFraction * 100.0)
+    }
+
+    var isLimitReached: Bool {
+        Double(mililiters) >= dailyLimit
+    }
+
+    var dailyLimitText: String {
+        Int(dailyLimit.rounded()).formatted()
+    }
+}


### PR DESCRIPTION
## 📝 Summary
잠금화면 위젯에서 오늘 마신 물의 양을 바로 확인할 수 있도록 `accessoryInline`, `accessoryCircular`, `accessoryRectangular` 패밀리를 추가했습니다.
또한 홈 화면 위젯과 잠금화면 위젯을 별도 파일로 분리하고, 공통 타임라인/엔트리 로직은 공유 파일로 정리했습니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [x] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [ ] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #70
- Related to -

## 📋 Changes Made
### Added
- 잠금화면 위젯 전용 `DrinkWaterLockScreenWidget` 추가
- 위젯 공통 provider/entry 계산을 위한 `DrinkWaterWidgetShared.swift` 추가
- 잠금화면 미리보기(`accessoryInline`, `accessoryCircular`, `accessoryRectangular`) 추가

### Changed
- 홈 화면 위젯을 `DrinkWaterWidget.swift`에 집중시키고 `systemSmall` 전용으로 정리
- 홈 화면/잠금화면 위젯을 `DrinkWaterWidgetBundle`에 각각 등록
- `ConfigurationAppIntent`와 물 기록 액션용 `LogWaterAppIntent`를 분리

### Fixed
- 잠금화면에서 현재 섭취량을 보여줄 수 없던 상태를 개선

### Removed
- 홈 화면과 잠금화면 위젯 구현이 한 파일에 섞여 있던 구조

## 🔍 Technical Details
- 두 위젯 모두 `DrinkWaterWidgetProvider`를 공유하며, 동일한 `DrinkWaterUseCase`/`UserPreferencesUseCase` 기준으로 현재 잔 수, 목표 ml, 메인 아이콘을 계산합니다.
- 잠금화면 위젯은 패밀리별로 밀도를 다르게 적용했습니다.
  - `accessoryInline`: 현재 ml 텍스트 중심
  - `accessoryCircular`: 목표 대비 진행률 게이지
  - `accessoryRectangular`: 현재 ml, 목표, 진행률 퍼센트

## 📸 Screenshots / Videos
### Before
- 잠금화면 전용 위젯 없음

### After
- 스크린샷 미첨부
- 코드 기준으로 잠금화면 위젯 3종 패밀리 추가

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [ ] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS Simulator 26.2
- Device: iPhone 17
- Xcode Version: Xcode 26.3 (17C529)

### Test Results
- `tuist generate` 성공
- `WidgetExtension` iOS Simulator build 성공
- `Mulimi` iOS Simulator build 성공
- 수동 위젯 배치/동작 확인은 아직 수행하지 않음

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

기존 public API breaking change는 없습니다.

## 📌 Additional Notes
- 리뷰 시 잠금화면 위젯 패밀리별 정보 밀도와 홈 화면 위젯 분리 구조를 중점적으로 보면 됩니다.
- 실제 UI 확인이 필요하면 시뮬레이터에서 잠금화면 위젯을 수동 배치해 검증해야 합니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
