### PR TITLE
fix: add HealthKit pre-prompt gate

### DIFF
--- a/Project/App/Supports/Mulimi.entitlements
+++ b/Project/App/Supports/Mulimi.entitlements
@@ -17,7 +17,7 @@
 		<string>CloudKit</string>
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)gaeng2y.DrinkWater</string>
+	<string>8UV3Y69NB7.gaeng2y.DrinkWater</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Project/App/Watch/Supports/MulimiWatch.entitlements
+++ b/Project/App/Watch/Supports/MulimiWatch.entitlements
@@ -13,7 +13,7 @@
 		<string>CloudKit</string>
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)gaeng2y.DrinkWater</string>
+	<string>8UV3Y69NB7.gaeng2y.DrinkWater</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.gaeng2y.drinkwater</string>

--- a/Project/Presentation/Sources/View/Authentication/HealthKitPermissionGateView.swift
+++ b/Project/Presentation/Sources/View/Authentication/HealthKitPermissionGateView.swift
@@ -46,12 +46,12 @@ public struct HealthKitPermissionGateView<Content: View>: View {
                     .font(.system(size: 72))
                     .foregroundStyle(.teal)
 
-                Text("건강 접근 권한이 필요해요")
+                Text(titleText)
                     .font(.largeTitle)
                     .fontWeight(.bold)
                     .multilineTextAlignment(.center)
 
-                Text("멀리미는 물 섭취 기록을 저장하고 불러오기 위해 건강 앱 권한이 필요합니다.")
+                Text(descriptionText)
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -71,8 +71,12 @@ public struct HealthKitPermissionGateView<Content: View>: View {
 
             VStack(spacing: 12) {
                 Button {
-                    Task {
-                        await viewModel.requestAuthorization()
+                    if viewModel.authorizationStatus == .sharingDenied {
+                        openSettings()
+                    } else {
+                        Task {
+                            await viewModel.requestAuthorization()
+                        }
                     }
                 } label: {
                     Group {
@@ -96,9 +100,9 @@ public struct HealthKitPermissionGateView<Content: View>: View {
 
                 if viewModel.authorizationStatus == .sharingDenied {
                     Button {
-                        openSettings()
+                        viewModel.refreshStatus()
                     } label: {
-                        Text("설정 열기")
+                        Text("다시 확인하기")
                             .font(.headline)
                             .fontWeight(.semibold)
                             .frame(maxWidth: .infinity)
@@ -111,6 +115,14 @@ public struct HealthKitPermissionGateView<Content: View>: View {
             }
             .padding(.horizontal, 24)
 
+            if viewModel.authorizationStatus == .sharingDenied {
+                Text("설정 앱에서 건강 > 데이터 접근 및 기기 > 물리미 경로로 들어가 권한을 다시 켤 수 있어요.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+
             Spacer()
         }
         .padding()
@@ -121,9 +133,31 @@ public struct HealthKitPermissionGateView<Content: View>: View {
         case .notDetermined:
             return "건강 권한 허용하기"
         case .sharingDenied:
-            return "다시 확인하기"
+            return "설정 열기"
         case .sharingAuthorized:
             return "계속하기"
+        }
+    }
+
+    private var titleText: String {
+        switch viewModel.authorizationStatus {
+        case .notDetermined:
+            return "건강 접근 권한이 필요해요"
+        case .sharingDenied:
+            return "건강 권한이 꺼져 있어요"
+        case .sharingAuthorized:
+            return "건강 접근 권한이 필요해요"
+        }
+    }
+
+    private var descriptionText: String {
+        switch viewModel.authorizationStatus {
+        case .notDetermined:
+            return "물리미는 물 섭취 기록을 저장하고 불러오기 위해 건강 앱 권한이 필요합니다."
+        case .sharingDenied:
+            return "한 번 거부한 권한은 앱에서 다시 요청할 수 없어요. 설정에서 건강 권한을 허용한 뒤 다시 돌아와 주세요."
+        case .sharingAuthorized:
+            return "물리미는 물 섭취 기록을 저장하고 불러오기 위해 건강 앱 권한이 필요합니다."
         }
     }
 

--- a/Project/Presentation/Sources/ViewModel/HealthKitPermissionViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HealthKitPermissionViewModel.swift
@@ -18,7 +18,6 @@ public final class HealthKitPermissionViewModel {
     public var errorMessage: String?
 
     private let healthKitUseCase: HealthKitUseCase
-    private var hasRequestedOnLaunch = false
 
     public init(healthKitUseCase: HealthKitUseCase) {
         self.healthKitUseCase = healthKitUseCase
@@ -34,13 +33,6 @@ public final class HealthKitPermissionViewModel {
             errorMessage = nil
             return
         }
-
-        guard authorizationStatus == .notDetermined, !hasRequestedOnLaunch else {
-            return
-        }
-
-        hasRequestedOnLaunch = true
-        await requestAuthorization()
     }
 
     public func refreshStatus() {
@@ -59,16 +51,32 @@ public final class HealthKitPermissionViewModel {
         do {
             try await healthKitUseCase.requestAuthorization()
         } catch {
-            errorMessage = error.localizedDescription
+            errorMessage = defaultErrorMessage
         }
 
         refreshStatus()
+
+        if authorizationStatus == .sharingDenied {
+            errorMessage = deniedMessage
+        } else if isAuthorized {
+            errorMessage = nil
+        } else if errorMessage == nil {
+            errorMessage = defaultErrorMessage
+        }
+
         isLoading = false
     }
 
     public func markSignedOut() {
-        hasRequestedOnLaunch = false
         errorMessage = nil
         refreshStatus()
+    }
+
+    private var deniedMessage: String {
+        "한 번 거부한 건강 권한은 앱에서 다시 요청할 수 없어요. 설정에서 다시 허용해 주세요."
+    }
+
+    private var defaultErrorMessage: String {
+        "건강 권한을 확인하는 중 문제가 발생했어요. 잠시 후 다시 시도해 주세요."
     }
 }

--- a/Project/Presentation/Tests/HealthKitPermissionViewModelTests.swift
+++ b/Project/Presentation/Tests/HealthKitPermissionViewModelTests.swift
@@ -30,8 +30,8 @@ struct HealthKitPermissionViewModelTests {
     }
 
     @MainActor
-    @Test("prepareIfNeeded는 최초 notDetermined 상태에서 권한을 요청한다")
-    func prepareIfNeededRequestsAuthorization() async {
+    @Test("prepareIfNeeded는 최초 notDetermined 상태에서도 자동 권한 요청을 하지 않는다")
+    func prepareIfNeededDoesNotRequestAuthorizationAutomatically() async {
         let healthKitUseCase = MockHealthKitUseCase()
         healthKitUseCase.authorizationStatusValue = .notDetermined
 
@@ -39,13 +39,28 @@ struct HealthKitPermissionViewModelTests {
 
         await viewModel.prepareIfNeeded()
 
+        #expect(healthKitUseCase.requestAuthorizationCallCount == 0)
+        #expect(viewModel.authorizationStatus == .notDetermined)
+        #expect(viewModel.isAuthorized == false)
+    }
+
+    @Test("requestAuthorization 성공 시 권한 상태를 갱신한다")
+    func requestAuthorizationSuccess() async {
+        let healthKitUseCase = MockHealthKitUseCase()
+        healthKitUseCase.authorizationStatusValue = .notDetermined
+
+        let viewModel = HealthKitPermissionViewModel(healthKitUseCase: healthKitUseCase)
+
+        await viewModel.requestAuthorization()
+
         #expect(healthKitUseCase.requestAuthorizationCallCount == 1)
         #expect(viewModel.authorizationStatus == .sharingAuthorized)
         #expect(viewModel.isAuthorized == true)
+        #expect(viewModel.errorMessage == nil)
     }
 
     @MainActor
-    @Test("requestAuthorization 실패 시 에러 메시지를 유지한다")
+    @Test("requestAuthorization 실패 시 사용자용 에러 메시지를 유지한다")
     func requestAuthorizationFailure() async {
         let healthKitUseCase = MockHealthKitUseCase()
         healthKitUseCase.authorizationStatusValue = .notDetermined
@@ -57,22 +72,37 @@ struct HealthKitPermissionViewModelTests {
 
         #expect(healthKitUseCase.requestAuthorizationCallCount == 1)
         #expect(viewModel.isAuthorized == false)
-        #expect(viewModel.errorMessage == MockError.failed.localizedDescription)
+        #expect(viewModel.errorMessage == "건강 권한을 확인하는 중 문제가 발생했어요. 잠시 후 다시 시도해 주세요.")
     }
 
     @MainActor
-    @Test("markSignedOut는 자동 요청 상태를 초기화한다")
-    func markSignedOutResetsLaunchState() async {
+    @Test("requestAuthorization 이후 거부 상태면 설정 안내 메시지를 노출한다")
+    func requestAuthorizationShowsDeniedMessage() async {
         let healthKitUseCase = MockHealthKitUseCase()
         healthKitUseCase.authorizationStatusValue = .notDetermined
+        healthKitUseCase.authorizationStatusAfterRequest = .sharingDenied
 
         let viewModel = HealthKitPermissionViewModel(healthKitUseCase: healthKitUseCase)
 
-        await viewModel.prepareIfNeeded()
-        healthKitUseCase.authorizationStatusValue = .notDetermined
-        viewModel.markSignedOut()
-        await viewModel.prepareIfNeeded()
+        await viewModel.requestAuthorization()
 
-        #expect(healthKitUseCase.requestAuthorizationCallCount == 2)
+        #expect(viewModel.isAuthorized == false)
+        #expect(viewModel.errorMessage == "한 번 거부한 건강 권한은 앱에서 다시 요청할 수 없어요. 설정에서 다시 허용해 주세요.")
+    }
+
+    @MainActor
+    @Test("markSignedOut는 에러 메시지를 초기화한다")
+    func markSignedOutClearsErrorMessage() async {
+        let healthKitUseCase = MockHealthKitUseCase()
+        healthKitUseCase.authorizationStatusValue = .notDetermined
+        healthKitUseCase.authorizationStatusAfterRequest = .sharingDenied
+
+        let viewModel = HealthKitPermissionViewModel(healthKitUseCase: healthKitUseCase)
+
+        await viewModel.requestAuthorization()
+        viewModel.markSignedOut()
+
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.authorizationStatus == .sharingDenied)
     }
 }

--- a/Project/Presentation/Tests/HealthKitPermissionViewModelTests.swift
+++ b/Project/Presentation/Tests/HealthKitPermissionViewModelTests.swift
@@ -44,6 +44,7 @@ struct HealthKitPermissionViewModelTests {
         #expect(viewModel.isAuthorized == false)
     }
 
+    @MainActor
     @Test("requestAuthorization 성공 시 권한 상태를 갱신한다")
     func requestAuthorizationSuccess() async {
         let healthKitUseCase = MockHealthKitUseCase()

--- a/Project/Presentation/Tests/Mock/MockHealthKitUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockHealthKitUseCase.swift
@@ -13,6 +13,7 @@ final class MockHealthKitUseCase: HealthKitUseCase, @unchecked Sendable {
     var drinkWaterError: Error?
     var resetError: Error?
     var fetchHistoryError: Error?
+    var authorizationStatusAfterRequest: HealthKitAuthorizationStatus = .sharingAuthorized
 
     var historyToReturn: [HydrationRecord] = []
 
@@ -28,7 +29,7 @@ final class MockHealthKitUseCase: HealthKitUseCase, @unchecked Sendable {
         if let requestAuthorizationError {
             throw requestAuthorizationError
         }
-        authorizationStatusValue = .sharingAuthorized
+        authorizationStatusValue = authorizationStatusAfterRequest
     }
 
     func drinkWater() async throws {


### PR DESCRIPTION
## 📝 Summary
앱 시작 시 HealthKit 권한을 바로 재요청하려 하지 않고, 먼저 프리 프롬프트를 보여준 뒤 사용자가 직접 요청하도록 권한 게이트를 정리했습니다.
추가로 워치 빌드 중 entitlements 파일 수정 오류가 나던 문제와 권한 안내 문구의 앱 이름 표기를 함께 정리했습니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [x] 🐛 Bug fix (버그 수정)
- [x] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #152
- Related to #150

## 📋 Changes Made
### Added
- HealthKit 권한 거부 상태를 테스트할 수 있도록 mock 상태 전환 경로를 추가했습니다.

### Changed
- 로그인 후 HealthKit 권한 화면이 자동 시스템 시트 대신 프리 프롬프트 중심으로 동작하도록 변경했습니다.
- 권한 거부 상태에서는 재요청 대신 `설정 열기`를 메인 CTA로 노출하도록 정리했습니다.
- 사용자 노출 문구에서 앱 이름을 `물리미`로 맞췄습니다.
- iCloud KVS 식별자를 실제 팀 식별자로 고정해 entitlements가 빌드 중 수정되지 않도록 정리했습니다.

### Fixed
- 한 번 거부된 HealthKit 권한을 앱이 다시 요청할 수 있는 것처럼 보이던 UX를 수정했습니다.
- `MulimiWatch.entitlements was modified during the build` 오류를 수정했습니다.

### Removed
- HealthKit 권한 자동 요청 흐름을 제거했습니다.

## 🔍 Technical Details
- `HealthKitPermissionViewModel`은 더 이상 `prepareIfNeeded()`에서 자동 요청하지 않고 상태만 동기화합니다.
- `sharingDenied` 상태에서는 안내 메시지를 고정하고, 권한 변경은 설정 앱 복귀 후 `refreshStatus()`로 반영합니다.
- `com.apple.developer.ubiquity-kvstore-identifier`는 `8UV3Y69NB7.gaeng2y.DrinkWater`로 고정했습니다.

## 📸 Screenshots / Videos
### Before
- 로그인 직후 HealthKit 시스템 시트를 바로 띄우려 했고, 거부 후에는 다시 요청 가능한 것처럼 보였습니다.

### After
- 프리 프롬프트를 먼저 보여주고, 거부 후에는 설정 이동과 상태 재확인 흐름으로 전환됩니다.

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [ ] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS Simulator SDK 26.2 / watchOS SDK 26.2
- Device: generic iOS Simulator, generic watchOS
- Xcode Version: Xcode 26.3

### Test Results
- `tuist generate`
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'generic/platform=iOS Simulator' -sdk iphonesimulator`
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme MulimiWatch -destination 'generic/platform=watchOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `PresentationLayer` 테스트 실행은 현재 로컬 `CoreSimulatorService` 불안정으로 생략했습니다.

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- HealthKit은 한 번 거부된 뒤 앱이 시스템 권한 시트를 다시 강제로 띄울 수 없다는 플랫폼 제약을 기준으로 UX를 정리했습니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [x] 환경 설정 변경이 필요한가요?
