### PR TITLE
feat: add body profile HealthKit integration flow

### DIFF
--- a/Project/App/Sources/ContentView.swift
+++ b/Project/App/Sources/ContentView.swift
@@ -44,6 +44,7 @@ struct ContentView: View {
 
             ProfileView(
                 settingsViewModel: DIContainer.shared.resolve(SettingsViewModel.self),
+                bodyProfileViewModel: DIContainer.shared.resolve(BodyProfileViewModel.self),
                 routineViewModel: DIContainer.shared.resolve(ProfileRoutineViewModel.self)
             )
             .tabItem {

--- a/Project/Data/Sources/DataSource/HealthKitDataSource.swift
+++ b/Project/Data/Sources/DataSource/HealthKitDataSource.swift
@@ -16,6 +16,7 @@ public protocol HealthKitDataSource: Sendable {
     func requestAuthorization() async throws
     func readWaterIntake(from startDate: Date, to endDate: Date) async throws -> [(date: Date, amount: Double)]
     func readWaterSamples(from startDate: Date, to endDate: Date) async throws -> [HydrationEvent]
+    func readBodyProfile() async throws -> BodyProfile
     func setAGlassOfWater() async throws
     func resetWaterInTakeInToday() async throws
 }
@@ -50,12 +51,17 @@ public final class HealthKitDataSourceImpl: HealthKitDataSource, @unchecked Send
     }
     
     public func requestAuthorization() async throws {
-        guard let waterType = HKObjectType.quantityType(forIdentifier: .dietaryWater) else {
+        guard let waterType = HKObjectType.quantityType(forIdentifier: .dietaryWater),
+              let heightType = HKObjectType.quantityType(forIdentifier: .height),
+              let bodyMassType = HKObjectType.quantityType(forIdentifier: .bodyMass) else {
             throw HealthKitError.invalidObjectType
         }
         
         do {
-            try await healthStore.requestAuthorization(toShare: [waterType], read: [waterType])
+            try await healthStore.requestAuthorization(
+                toShare: [waterType],
+                read: [waterType, heightType, bodyMassType]
+            )
         } catch {
             throw HealthKitError.permissionDenied
         }
@@ -148,6 +154,29 @@ public final class HealthKitDataSourceImpl: HealthKitDataSource, @unchecked Send
             healthStore.execute(query)
         }
     }
+
+    public func readBodyProfile() async throws -> BodyProfile {
+        guard HKHealthStore.isHealthDataAvailable(), authorizationStatus == .sharingAuthorized else {
+            throw HealthKitError.permissionDenied
+        }
+
+        async let heightCM = latestQuantityValue(
+            for: .height,
+            unit: .meterUnit(with: .centi)
+        )
+        async let weightKG = latestQuantityValue(
+            for: .bodyMass,
+            unit: .gramUnit(with: .kilo)
+        )
+
+        let latestHeightCM = try await heightCM
+        let latestWeightKG = try await weightKG
+
+        return BodyProfile(
+            heightCM: latestHeightCM.map { BodyProfileValue(value: $0, source: .healthKit) },
+            weightKG: latestWeightKG.map { BodyProfileValue(value: $0, source: .healthKit) }
+        )
+    }
     
     public func setAGlassOfWater() async throws {
         guard HKHealthStore.isHealthDataAvailable(), authorizationStatus == .sharingAuthorized else {
@@ -215,6 +244,39 @@ public final class HealthKitDataSourceImpl: HealthKitDataSource, @unchecked Send
             }
             
             healthStore.execute(sampleQuery)
+        }
+    }
+
+    private func latestQuantityValue(
+        for identifier: HKQuantityTypeIdentifier,
+        unit: HKUnit
+    ) async throws -> Double? {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Double?, Error>) in
+            guard let quantityType = HKObjectType.quantityType(forIdentifier: identifier) else {
+                continuation.resume(throwing: HealthKitError.invalidObjectType)
+                return
+            }
+
+            let query = HKSampleQuery(
+                sampleType: quantityType,
+                predicate: nil,
+                limit: 1,
+                sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)]
+            ) { _, samples, error in
+                if error != nil {
+                    continuation.resume(throwing: HealthKitError.healthKitInternalError)
+                    return
+                }
+
+                guard let sample = (samples as? [HKQuantitySample])?.first else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                continuation.resume(returning: sample.quantity.doubleValue(for: unit))
+            }
+
+            healthStore.execute(query)
         }
     }
 }

--- a/Project/Data/Sources/DataSource/UserPreferencesDataSource.swift
+++ b/Project/Data/Sources/DataSource/UserPreferencesDataSource.swift
@@ -15,6 +15,8 @@ public protocol UserPreferencesDataSource: Sendable {
     func setMainIcon(_ icon: MainIcon)
     func getDailyWaterLimit() -> Double
     func setDailyWaterLimit(_ limit: Double)
+    func getManualBodyProfile() -> BodyProfile
+    func setManualBodyProfile(_ profile: BodyProfile)
 }
 
 public final class UserPreferencesDataSourceImpl: UserPreferencesDataSource, @unchecked Sendable {
@@ -92,6 +94,27 @@ public final class UserPreferencesDataSourceImpl: UserPreferencesDataSource, @un
         ubiquitousStore.synchronize()
     }
 
+    // MARK: - Manual Body Profile
+    public func getManualBodyProfile() -> BodyProfile {
+        let heightValue = userDefaults.object(forKey: .manualBodyHeightCM) as? Double
+        let weightValue = userDefaults.object(forKey: .manualBodyWeightKG) as? Double
+
+        return BodyProfile(
+            heightCM: sanitizedValue(heightValue).map {
+                BodyProfileValue(value: $0, source: .manual)
+            },
+            weightKG: sanitizedValue(weightValue).map {
+                BodyProfileValue(value: $0, source: .manual)
+            }
+        )
+    }
+
+    public func setManualBodyProfile(_ profile: BodyProfile) {
+        store(profile.heightCM?.value, forKey: .manualBodyHeightCM)
+        store(profile.weightKG?.value, forKey: .manualBodyWeightKG)
+        userDefaults.synchronize()
+    }
+
     private func migrateLegacyMainIconIfNeeded(currentValue: String) {
         guard userDefaults.object(forKey: .mainIcon) == nil,
               userDefaults.object(forKey: .legacyMainAppearance) != nil else {
@@ -101,5 +124,22 @@ public final class UserPreferencesDataSourceImpl: UserPreferencesDataSource, @un
         userDefaults.mainIcon = currentValue
         userDefaults.removeObject(forKey: .legacyMainAppearance)
         userDefaults.synchronize()
+    }
+
+    private func store(_ value: Double?, forKey key: String) {
+        guard let value = sanitizedValue(value) else {
+            userDefaults.removeObject(forKey: key)
+            return
+        }
+
+        userDefaults.set(value, forKey: key)
+    }
+
+    private func sanitizedValue(_ value: Double?) -> Double? {
+        guard let value, value > 0 else {
+            return nil
+        }
+
+        return value
     }
 }

--- a/Project/Data/Sources/Repository/HealthKitRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/HealthKitRepositoryImpl.swift
@@ -39,4 +39,8 @@ public struct HealthKitRepositoryImpl: HealthKitRepository {
         }
         
     }
+
+    public func fetchBodyProfile() async throws -> BodyProfile {
+        try await dataSource.readBodyProfile()
+    }
 }

--- a/Project/Data/Sources/Repository/UserPreferencesRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/UserPreferencesRepositoryImpl.swift
@@ -31,4 +31,12 @@ public struct UserPreferencesRepositoryImpl: UserPreferencesRepository {
     public func setDailyWaterLimit(_ limit: Double) {
         dataSource.setDailyWaterLimit(limit)
     }
+
+    public func getManualBodyProfile() -> BodyProfile {
+        dataSource.getManualBodyProfile()
+    }
+
+    public func setManualBodyProfile(_ profile: BodyProfile) {
+        dataSource.setManualBodyProfile(profile)
+    }
 }

--- a/Project/Domain/Interfaces/Entity/BodyProfile.swift
+++ b/Project/Domain/Interfaces/Entity/BodyProfile.swift
@@ -1,0 +1,53 @@
+//
+//  BodyProfile.swift
+//  DomainLayerInterface
+//
+//  Created by Codex on 3/29/26.
+//
+
+import Foundation
+
+public enum BodyProfileSource: String, Hashable, Sendable {
+    case healthKit
+    case manual
+}
+
+public struct BodyProfileValue: Hashable, Sendable {
+    public let value: Double
+    public let source: BodyProfileSource
+
+    public init(value: Double, source: BodyProfileSource) {
+        self.value = value
+        self.source = source
+    }
+}
+
+public struct BodyProfile: Hashable, Sendable {
+    public let heightCM: BodyProfileValue?
+    public let weightKG: BodyProfileValue?
+
+    public init(
+        heightCM: BodyProfileValue?,
+        weightKG: BodyProfileValue?
+    ) {
+        self.heightCM = heightCM
+        self.weightKG = weightKG
+    }
+
+    public static let empty = BodyProfile(heightCM: nil, weightKG: nil)
+
+    public var isEmpty: Bool {
+        heightCM == nil && weightKG == nil
+    }
+
+    public var isComplete: Bool {
+        heightCM != nil && weightKG != nil
+    }
+
+    public func merging(preferred other: BodyProfile) -> BodyProfile {
+        BodyProfile(
+            heightCM: other.heightCM ?? heightCM,
+            weightKG: other.weightKG ?? weightKG
+        )
+    }
+}

--- a/Project/Domain/Interfaces/Entity/SettingMenu.swift
+++ b/Project/Domain/Interfaces/Entity/SettingMenu.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import Localization
 
 public enum SettingMenu: CaseIterable, Identifiable {
+    case bodyProfile
     case dailyLimit
     case mainIcon
     case withdrawal
@@ -18,6 +19,7 @@ public enum SettingMenu: CaseIterable, Identifiable {
 
     public var title: String {
         switch self {
+        case .bodyProfile: L10n.tr("settingBodyProfileTitle")
         case .dailyLimit: L10n.tr("settingDailyLimitTitle")
         case .mainIcon: L10n.tr("settingMainShapeTitle")
         case .withdrawal: L10n.tr("settingWithdrawalTitle")
@@ -26,6 +28,8 @@ public enum SettingMenu: CaseIterable, Identifiable {
 
     public var systemImage: String {
         switch self {
+        case .bodyProfile:
+            return "figure"
         case .dailyLimit:
             return "target"
         case .mainIcon:
@@ -37,6 +41,8 @@ public enum SettingMenu: CaseIterable, Identifiable {
 
     public var description: String {
         switch self {
+        case .bodyProfile:
+            return L10n.tr("settingBodyProfileDescription")
         case .dailyLimit:
             return L10n.tr("settingDailyLimitDescription")
         case .mainIcon:
@@ -48,6 +54,8 @@ public enum SettingMenu: CaseIterable, Identifiable {
 
     public var settingKey: String {
         switch self {
+        case .bodyProfile:
+            return "bodyProfile"
         case .dailyLimit:
             return "dailyWaterLimit"
         case .mainIcon:

--- a/Project/Domain/Interfaces/Repository/HealthKitRepository.swift
+++ b/Project/Domain/Interfaces/Repository/HealthKitRepository.swift
@@ -15,4 +15,5 @@ public protocol HealthKitRepository: Sendable {
     func drinkWater() async throws
     func reset() async throws
     func fetchHistory(from startDate: Date, to endDate: Date) async throws -> [HydrationRecord]
+    func fetchBodyProfile() async throws -> BodyProfile
 }

--- a/Project/Domain/Interfaces/Repository/UserPreferencesRepository.swift
+++ b/Project/Domain/Interfaces/Repository/UserPreferencesRepository.swift
@@ -13,4 +13,6 @@ public protocol UserPreferencesRepository: Sendable {
     func setMainIcon(_ icon: MainIcon)
     func getDailyWaterLimit() -> Double
     func setDailyWaterLimit(_ limit: Double)
+    func getManualBodyProfile() -> BodyProfile
+    func setManualBodyProfile(_ profile: BodyProfile)
 }

--- a/Project/Domain/Interfaces/UseCase/HealthKitUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/HealthKitUseCase.swift
@@ -15,4 +15,5 @@ public protocol HealthKitUseCase: Sendable {
     func drinkWater() async throws
     func reset() async throws
     func fetchHistory(from startDate: Date, to endDate: Date) async throws -> [HydrationRecord]
+    func fetchBodyProfile() async throws -> BodyProfile
 }

--- a/Project/Domain/Interfaces/UseCase/UserPreferencesUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/UserPreferencesUseCase.swift
@@ -13,4 +13,6 @@ public protocol UserPreferencesUseCase: Sendable {
     func setMainIcon(_ icon: MainIcon)
     func getDailyWaterLimit() -> Double
     func setDailyWaterLimit(_ limit: Double)
+    func getManualBodyProfile() -> BodyProfile
+    func setManualBodyProfile(_ profile: BodyProfile)
 }

--- a/Project/Domain/Sources/UseCase/HealthKitUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/HealthKitUseCaseImpl.swift
@@ -35,4 +35,8 @@ public struct HealthKitUseCaseImpl: HealthKitUseCase {
     public func fetchHistory(from startDate: Date, to endDate: Date) async throws -> [HydrationRecord] {
         try await repository.fetchHistory(from: startDate, to: endDate)
     }
+
+    public func fetchBodyProfile() async throws -> BodyProfile {
+        try await repository.fetchBodyProfile()
+    }
 }

--- a/Project/Domain/Sources/UseCase/UserPreferencesUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/UserPreferencesUseCaseImpl.swift
@@ -30,4 +30,12 @@ public struct UserPreferencesUseCaseImpl: UserPreferencesUseCase {
     public func setDailyWaterLimit(_ limit: Double) {
         repository.setDailyWaterLimit(limit)
     }
+
+    public func getManualBodyProfile() -> BodyProfile {
+        repository.getManualBodyProfile()
+    }
+
+    public func setManualBodyProfile(_ profile: BodyProfile) {
+        repository.setManualBodyProfile(profile)
+    }
 }

--- a/Project/Domain/Tests/HealthKitUseCaseTests.swift
+++ b/Project/Domain/Tests/HealthKitUseCaseTests.swift
@@ -243,6 +243,38 @@ struct HealthKitUseCaseTests {
             #expect(mockRepository.resetCallCount == 1)
         }
     }
+
+    @Test("신체 정보 조회 성공 테스트")
+    func fetchBodyProfileSuccess() async throws {
+        let mockRepository = MockHealthKitRepository()
+        mockRepository.simulateAuthorizationSuccess()
+        let profile = BodyProfile(
+            heightCM: BodyProfileValue(value: 173, source: .healthKit),
+            weightKG: BodyProfileValue(value: 66, source: .healthKit)
+        )
+        mockRepository.setBodyProfile(profile)
+        let useCase = HealthKitUseCaseImpl(repository: mockRepository)
+
+        let fetchedProfile = try await useCase.fetchBodyProfile()
+
+        #expect(mockRepository.fetchBodyProfileCallCount == 1)
+        #expect(fetchedProfile == profile)
+    }
+
+    @Test("권한 없이 신체 정보 조회 시도 테스트")
+    func fetchBodyProfileWithoutPermission() async {
+        let mockRepository = MockHealthKitRepository()
+        mockRepository.setAuthorizationStatus(.sharingDenied)
+        let useCase = HealthKitUseCaseImpl(repository: mockRepository)
+
+        do {
+            try await useCase.fetchBodyProfile()
+            #expect(Bool(false), "Expected error to be thrown")
+        } catch {
+            #expect(error as? HealthKitError == .permissionDenied)
+            #expect(mockRepository.fetchBodyProfileCallCount == 1)
+        }
+    }
     
     // MARK: - Integration Tests
     

--- a/Project/Domain/Tests/Mock/MockHealthKitRepository.swift
+++ b/Project/Domain/Tests/Mock/MockHealthKitRepository.swift
@@ -12,22 +12,26 @@ import Foundation
 final class MockHealthKitRepository: HealthKitRepository, @unchecked Sendable {
     private var _authorizationStatus: HealthKitAuthorizationStatus = .notDetermined
     private var _hydrationRecords: [HydrationRecord] = []
+    private var _bodyProfile: BodyProfile = .empty
 
     // Call tracking properties
     private(set) var requestAuthorizationCallCount = 0
     private(set) var drinkWaterCallCount = 0
     private(set) var resetCallCount = 0
     private(set) var fetchHistoryCallCount = 0
+    private(set) var fetchBodyProfileCallCount = 0
 
     // Error simulation properties
     var shouldThrowAuthorizationError = false
     var shouldThrowDrinkWaterError = false
     var shouldThrowResetError = false
     var shouldThrowFetchHistoryError = false
+    var shouldThrowFetchBodyProfileError = false
     var authorizationErrorToThrow: HealthKitError = .permissionDenied
     var drinkWaterErrorToThrow: HealthKitError = .healthKitInternalError
     var resetErrorToThrow: HealthKitError = .healthKitInternalError
     var fetchHistoryErrorToThrow: HealthKitError = .healthKitInternalError
+    var fetchBodyProfileErrorToThrow: HealthKitError = .healthKitInternalError
 
     // Captured parameters for verification
     private(set) var capturedStartDate: Date?
@@ -94,6 +98,20 @@ final class MockHealthKitRepository: HealthKitRepository, @unchecked Sendable {
         }.sorted { $0.date < $1.date }
     }
 
+    func fetchBodyProfile() async throws -> BodyProfile {
+        fetchBodyProfileCallCount += 1
+
+        if shouldThrowFetchBodyProfileError {
+            throw fetchBodyProfileErrorToThrow
+        }
+
+        if _authorizationStatus != .sharingAuthorized {
+            throw HealthKitError.permissionDenied
+        }
+
+        return _bodyProfile
+    }
+
     // MARK: - Test Helper Methods
     
     func setAuthorizationStatus(_ status: HealthKitAuthorizationStatus) {
@@ -105,6 +123,7 @@ final class MockHealthKitRepository: HealthKitRepository, @unchecked Sendable {
         drinkWaterCallCount = 0
         resetCallCount = 0
         fetchHistoryCallCount = 0
+        fetchBodyProfileCallCount = 0
     }
 
     func resetErrorFlags() {
@@ -112,6 +131,7 @@ final class MockHealthKitRepository: HealthKitRepository, @unchecked Sendable {
         shouldThrowDrinkWaterError = false
         shouldThrowResetError = false
         shouldThrowFetchHistoryError = false
+        shouldThrowFetchBodyProfileError = false
     }
 
     func resetCapturedValues() {
@@ -129,6 +149,10 @@ final class MockHealthKitRepository: HealthKitRepository, @unchecked Sendable {
 
     func setHydrationRecords(_ records: [HydrationRecord]) {
         _hydrationRecords = records
+    }
+
+    func setBodyProfile(_ profile: BodyProfile) {
+        _bodyProfile = profile
     }
 
     func addHydrationRecord(_ record: HydrationRecord) {

--- a/Project/Domain/Tests/Mock/MockUserPreferencesRepository.swift
+++ b/Project/Domain/Tests/Mock/MockUserPreferencesRepository.swift
@@ -11,16 +11,20 @@ import DomainLayerInterface
 final class MockUserPreferencesRepository: UserPreferencesRepository, @unchecked Sendable {
     private var _mainIcon: MainIcon = .default
     private var _dailyWaterLimit: Double = 2000.0
+    private var _manualBodyProfile: BodyProfile = .empty
 
     // Call tracking properties
     private(set) var getMainIconCallCount = 0
     private(set) var setMainIconCallCount = 0
     private(set) var getDailyWaterLimitCallCount = 0
     private(set) var setDailyWaterLimitCallCount = 0
+    private(set) var getManualBodyProfileCallCount = 0
+    private(set) var setManualBodyProfileCallCount = 0
 
     // Captured values for verification
     private(set) var capturedMainIcon: MainIcon?
     private(set) var capturedDailyWaterLimit: Double?
+    private(set) var capturedManualBodyProfile: BodyProfile?
 
     func getMainIcon() -> MainIcon {
         getMainIconCallCount += 1
@@ -44,6 +48,17 @@ final class MockUserPreferencesRepository: UserPreferencesRepository, @unchecked
         _dailyWaterLimit = limit
     }
 
+    func getManualBodyProfile() -> BodyProfile {
+        getManualBodyProfileCallCount += 1
+        return _manualBodyProfile
+    }
+
+    func setManualBodyProfile(_ profile: BodyProfile) {
+        setManualBodyProfileCallCount += 1
+        capturedManualBodyProfile = profile
+        _manualBodyProfile = profile
+    }
+
     // MARK: - Test Helper Methods
 
     func resetCallCounts() {
@@ -51,16 +66,20 @@ final class MockUserPreferencesRepository: UserPreferencesRepository, @unchecked
         setMainIconCallCount = 0
         getDailyWaterLimitCallCount = 0
         setDailyWaterLimitCallCount = 0
+        getManualBodyProfileCallCount = 0
+        setManualBodyProfileCallCount = 0
     }
 
     func resetCapturedValues() {
         capturedMainIcon = nil
         capturedDailyWaterLimit = nil
+        capturedManualBodyProfile = nil
     }
 
     func resetToDefaults() {
         _mainIcon = .default
         _dailyWaterLimit = 2000.0
+        _manualBodyProfile = .empty
         resetCallCounts()
         resetCapturedValues()
     }

--- a/Project/Domain/Tests/UserPreferencesUseCaseTests.swift
+++ b/Project/Domain/Tests/UserPreferencesUseCaseTests.swift
@@ -222,6 +222,33 @@ struct UserPreferencesUseCaseTests {
         #expect(mockRepository.setDailyWaterLimitCallCount == 1)
     }
 
+    @Test("직접 입력 신체 정보 저장 테스트")
+    func setManualBodyProfile() {
+        let mockRepository = MockUserPreferencesRepository()
+        let useCase = UserPreferencesUseCaseImpl(repository: mockRepository)
+        let profile = BodyProfile(
+            heightCM: BodyProfileValue(value: 171, source: .manual),
+            weightKG: BodyProfileValue(value: 61, source: .manual)
+        )
+
+        useCase.setManualBodyProfile(profile)
+
+        #expect(mockRepository.setManualBodyProfileCallCount == 1)
+        #expect(mockRepository.capturedManualBodyProfile == profile)
+        #expect(useCase.getManualBodyProfile() == profile)
+    }
+
+    @Test("초기 직접 입력 신체 정보 조회 테스트")
+    func getManualBodyProfileInitial() {
+        let mockRepository = MockUserPreferencesRepository()
+        let useCase = UserPreferencesUseCaseImpl(repository: mockRepository)
+
+        let profile = useCase.getManualBodyProfile()
+
+        #expect(profile == .empty)
+        #expect(mockRepository.getManualBodyProfileCallCount == 1)
+    }
+
     @Test("UseCase는 Repository에만 의존해야 한다")
     func useCaseDependencyTest() {
         // Given: Mock Repository가 있을 때

--- a/Project/Presentation/Sources/View/Authentication/HealthKitPermissionGateView.swift
+++ b/Project/Presentation/Sources/View/Authentication/HealthKitPermissionGateView.swift
@@ -153,11 +153,11 @@ public struct HealthKitPermissionGateView<Content: View>: View {
     private var descriptionText: String {
         switch viewModel.authorizationStatus {
         case .notDetermined:
-            return "물리미는 물 섭취 기록을 저장하고 불러오기 위해 건강 앱 권한이 필요합니다."
+            return "물리미는 물 섭취 기록과 신체 정보를 불러오기 위해 건강 앱 권한이 필요합니다."
         case .sharingDenied:
             return "한 번 거부한 권한은 앱에서 다시 요청할 수 없어요. 설정에서 건강 권한을 허용한 뒤 다시 돌아와 주세요."
         case .sharingAuthorized:
-            return "물리미는 물 섭취 기록을 저장하고 불러오기 위해 건강 앱 권한이 필요합니다."
+            return "물리미는 물 섭취 기록과 신체 정보를 불러오기 위해 건강 앱 권한이 필요합니다."
         }
     }
 

--- a/Project/Presentation/Sources/View/Profile/ProfileView.swift
+++ b/Project/Presentation/Sources/View/Profile/ProfileView.swift
@@ -4,13 +4,16 @@ import SwiftUI
 
 public struct ProfileView: View {
     @Bindable private var settingsViewModel: SettingsViewModel
+    @Bindable private var bodyProfileViewModel: BodyProfileViewModel
     @Bindable private var routineViewModel: ProfileRoutineViewModel
 
     public init(
         settingsViewModel: SettingsViewModel,
+        bodyProfileViewModel: BodyProfileViewModel,
         routineViewModel: ProfileRoutineViewModel
     ) {
         self.settingsViewModel = settingsViewModel
+        self.bodyProfileViewModel = bodyProfileViewModel
         self.routineViewModel = routineViewModel
     }
 
@@ -26,6 +29,20 @@ public struct ProfileView: View {
                 }
 
                 Section {
+                    NavigationLink {
+                        SettingDetailView(
+                            menu: .bodyProfile,
+                            viewModel: settingsViewModel,
+                            bodyProfileViewModel: bodyProfileViewModel
+                        )
+                    } label: {
+                        settingsRow(
+                            title: L10n.tr("settingBodyProfileTitle"),
+                            value: bodyProfileViewModel.summaryText,
+                            systemImage: "figure"
+                        )
+                    }
+
                     NavigationLink {
                         SettingDetailView(menu: .dailyLimit, viewModel: settingsViewModel)
                     } label: {
@@ -84,6 +101,7 @@ public struct ProfileView: View {
             .navigationTitle(L10n.tr("profileTitle"))
             .task {
                 await routineViewModel.load()
+                await bodyProfileViewModel.load()
             }
         }
     }

--- a/Project/Presentation/Sources/View/Settings/SettingDetailView.swift
+++ b/Project/Presentation/Sources/View/Settings/SettingDetailView.swift
@@ -9,19 +9,32 @@
 import DomainLayerInterface
 import Localization
 import SwiftUI
+import UIKit
 
 public struct SettingDetailView: View {
     let menu: SettingMenu
     private let viewModel: SettingsViewModel
+    private let bodyProfileViewModel: BodyProfileViewModel?
     
-    public init(menu: SettingMenu, viewModel: SettingsViewModel) {
+    public init(
+        menu: SettingMenu,
+        viewModel: SettingsViewModel,
+        bodyProfileViewModel: BodyProfileViewModel? = nil
+    ) {
         self.menu = menu
         self.viewModel = viewModel
+        self.bodyProfileViewModel = bodyProfileViewModel
     }
     
     public var body: some View {
         Group {
             switch menu {
+            case .bodyProfile:
+                if let bodyProfileViewModel {
+                    BodyProfileSettingView(viewModel: bodyProfileViewModel)
+                } else {
+                    EmptyView()
+                }
             case .dailyLimit:
                 DailyLimitSettingView(viewModel: viewModel)
             case .mainIcon:
@@ -35,6 +48,253 @@ public struct SettingDetailView: View {
 }
 
 // MARK: - Setting Detail Views
+private struct BodyProfileSettingView: View {
+    @Bindable private var viewModel: BodyProfileViewModel
+    @Environment(\.openURL) private var openURL
+
+    init(viewModel: BodyProfileViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                summaryCard
+                healthSyncCard
+                manualInputCard
+            }
+            .padding()
+        }
+        .navigationTitle(L10n.tr("settingBodyProfileTitle"))
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.load()
+        }
+    }
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(L10n.tr("bodyProfileSummaryCardTitle"))
+                .font(.headline)
+
+            profileMetricRow(
+                title: L10n.tr("bodyProfileHeightTitle"),
+                value: viewModel.resolvedHeightText ?? L10n.tr("bodyProfileMissingValue"),
+                source: viewModel.heightSourceText
+            )
+
+            profileMetricRow(
+                title: L10n.tr("bodyProfileWeightTitle"),
+                value: viewModel.resolvedWeightText ?? L10n.tr("bodyProfileMissingValue"),
+                source: viewModel.weightSourceText
+            )
+
+            Text(L10n.tr("bodyProfileSourcePriorityDescription"))
+                .font(.footnote)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(uiColor: .systemGray6))
+        )
+    }
+
+    private var healthSyncCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(L10n.tr("bodyProfileHealthKitSectionTitle"))
+                .font(.headline)
+
+            Text(viewModel.helperText)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundColor(.red)
+            }
+
+            switch viewModel.availabilityState {
+            case .needsPermission:
+                primaryButton(
+                    title: L10n.tr("bodyProfileConnectHealthKitTitle"),
+                    isLoading: viewModel.isLoading
+                ) {
+                    await viewModel.requestHealthKitBodyProfile()
+                }
+            case .permissionDenied:
+                VStack(spacing: 10) {
+                    primaryButton(
+                        title: L10n.tr("bodyProfileOpenSettingsTitle"),
+                        isLoading: false
+                    ) {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            openURL(url)
+                        }
+                    }
+
+                    secondaryAsyncButton(title: L10n.tr("bodyProfileRetryHealthSyncTitle")) {
+                        await viewModel.requestHealthKitBodyProfile()
+                    }
+                }
+            case .noData, .incomplete, .ready:
+                primaryButton(
+                    title: L10n.tr("bodyProfileRetryHealthSyncTitle"),
+                    isLoading: viewModel.isLoading
+                ) {
+                    await viewModel.requestHealthKitBodyProfile()
+                }
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(uiColor: .systemGray6))
+        )
+    }
+
+    private var manualInputCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(L10n.tr("bodyProfileManualSectionTitle"))
+                .font(.headline)
+
+            Text(L10n.tr("bodyProfileManualSectionDescription"))
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 12) {
+                TextField(
+                    L10n.tr("bodyProfileHeightPlaceholder"),
+                    text: $viewModel.heightInput
+                )
+                .keyboardType(.decimalPad)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color(uiColor: .secondarySystemBackground))
+                )
+
+                TextField(
+                    L10n.tr("bodyProfileWeightPlaceholder"),
+                    text: $viewModel.weightInput
+                )
+                .keyboardType(.decimalPad)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color(uiColor: .secondarySystemBackground))
+                )
+            }
+
+            secondaryButton(title: viewModel.manualSaveButtonTitle) {
+                viewModel.saveManualBodyProfile()
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(uiColor: .systemGray6))
+        )
+    }
+
+    private func profileMetricRow(title: String, value: String, source: String?) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                Text(value)
+                    .font(.title3)
+                    .fontWeight(.semibold)
+            }
+
+            Spacer()
+
+            if let source {
+                Text(source)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.accentColor)
+            }
+        }
+    }
+
+    private func primaryButton(
+        title: String,
+        isLoading: Bool,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button {
+            Task {
+                await action()
+            }
+        } label: {
+            HStack {
+                Spacer()
+
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(.white)
+                } else {
+                    Text(title)
+                        .fontWeight(.semibold)
+                }
+
+                Spacer()
+            }
+            .padding()
+            .background(Color.accentColor)
+            .foregroundColor(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func secondaryButton(title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.accentColor.opacity(0.3), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func secondaryAsyncButton(
+        title: String,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button {
+            Task {
+                await action()
+            }
+        } label: {
+            Text(title)
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.accentColor.opacity(0.3), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
 private struct DailyLimitSettingView: View {
     private let viewModel: SettingsViewModel
     

--- a/Project/Presentation/Sources/ViewModel/BodyProfileViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/BodyProfileViewModel.swift
@@ -1,0 +1,250 @@
+//
+//  BodyProfileViewModel.swift
+//  PresentationLayer
+//
+//  Created by Codex on 3/29/26.
+//
+
+import DomainLayerInterface
+import Foundation
+import Localization
+import Observation
+
+@Observable
+@MainActor
+public final class BodyProfileViewModel {
+    public enum AvailabilityState: Equatable {
+        case ready
+        case needsPermission
+        case permissionDenied
+        case noData
+        case incomplete
+    }
+
+    public private(set) var authorizationStatus: HealthKitAuthorizationStatus
+    public private(set) var resolvedBodyProfile: BodyProfile = .empty
+    public private(set) var healthKitBodyProfile: BodyProfile = .empty
+    public private(set) var manualBodyProfile: BodyProfile = .empty
+    public private(set) var isLoading = false
+    public private(set) var hasLoaded = false
+    public var heightInput = ""
+    public var weightInput = ""
+    public var errorMessage: String?
+
+    private let healthKitUseCase: HealthKitUseCase
+    private let userPreferencesUseCase: UserPreferencesUseCase
+
+    public init(
+        healthKitUseCase: HealthKitUseCase,
+        userPreferencesUseCase: UserPreferencesUseCase
+    ) {
+        self.healthKitUseCase = healthKitUseCase
+        self.userPreferencesUseCase = userPreferencesUseCase
+        self.authorizationStatus = healthKitUseCase.authorisationStatus
+    }
+
+    public var availabilityState: AvailabilityState {
+        if resolvedBodyProfile.isComplete {
+            return .ready
+        }
+
+        switch authorizationStatus {
+        case .notDetermined:
+            return .needsPermission
+        case .sharingDenied:
+            return .permissionDenied
+        case .sharingAuthorized:
+            if healthKitBodyProfile.isEmpty && manualBodyProfile.isEmpty {
+                return .noData
+            }
+            return .incomplete
+        }
+    }
+
+    public var summaryText: String {
+        let heightText = resolvedHeightText
+        let weightText = resolvedWeightText
+
+        switch (heightText, weightText) {
+        case let (height?, weight?):
+            return "\(height) · \(weight)"
+        case let (height?, nil):
+            return "\(height) · \(L10n.tr("bodyProfileWeightMissingValue"))"
+        case let (nil, weight?):
+            return "\(L10n.tr("bodyProfileHeightMissingValue")) · \(weight)"
+        case (nil, nil):
+            return L10n.tr("bodyProfileSummaryNeedsInput")
+        }
+    }
+
+    public var helperText: String {
+        switch availabilityState {
+        case .ready:
+            return L10n.tr("bodyProfileSourcePriorityDescription")
+        case .needsPermission:
+            return L10n.tr("bodyProfilePermissionNeededDescription")
+        case .permissionDenied:
+            return L10n.tr("bodyProfilePermissionDeniedDescription")
+        case .noData:
+            return L10n.tr("bodyProfileNoDataDescription")
+        case .incomplete:
+            return L10n.tr("bodyProfileIncompleteDescription")
+        }
+    }
+
+    public var resolvedHeightText: String? {
+        resolvedBodyProfile.heightCM.map {
+            L10n.tr("bodyProfileHeightValueFormat", Int($0.value.rounded()))
+        }
+    }
+
+    public var resolvedWeightText: String? {
+        resolvedBodyProfile.weightKG.map {
+            L10n.tr("bodyProfileWeightValueFormat", Int($0.value.rounded()))
+        }
+    }
+
+    public var heightSourceText: String? {
+        sourceText(for: resolvedBodyProfile.heightCM?.source)
+    }
+
+    public var weightSourceText: String? {
+        sourceText(for: resolvedBodyProfile.weightKG?.source)
+    }
+
+    public var manualSaveButtonTitle: String {
+        manualBodyProfile.isEmpty
+            ? L10n.tr("bodyProfileSaveManualTitle")
+            : L10n.tr("bodyProfileSaveManualChangesTitle")
+    }
+
+    public func load() async {
+        guard !hasLoaded else {
+            await refresh()
+            return
+        }
+
+        hasLoaded = true
+        await refresh()
+    }
+
+    public func refresh() async {
+        isLoading = true
+        authorizationStatus = healthKitUseCase.authorisationStatus
+        manualBodyProfile = userPreferencesUseCase.getManualBodyProfile()
+        syncInputsFromManualProfile()
+        errorMessage = nil
+
+        if authorizationStatus == .sharingAuthorized {
+            await refreshHealthKitBodyProfile()
+        } else {
+            healthKitBodyProfile = .empty
+            updateResolvedProfile()
+        }
+
+        isLoading = false
+    }
+
+    public func requestHealthKitBodyProfile() async {
+        isLoading = true
+        errorMessage = nil
+
+        if authorizationStatus == .notDetermined {
+            do {
+                try await healthKitUseCase.requestAuthorization()
+            } catch {
+                authorizationStatus = healthKitUseCase.authorisationStatus
+                errorMessage = L10n.tr("bodyProfilePermissionRequestFailureDescription")
+                updateResolvedProfile()
+                isLoading = false
+                return
+            }
+        }
+
+        authorizationStatus = healthKitUseCase.authorisationStatus
+
+        guard authorizationStatus == .sharingAuthorized else {
+            errorMessage = L10n.tr("bodyProfilePermissionDeniedDescription")
+            updateResolvedProfile()
+            isLoading = false
+            return
+        }
+
+        await refreshHealthKitBodyProfile()
+        isLoading = false
+    }
+
+    public func saveManualBodyProfile() {
+        let height = parseInput(heightInput)
+        let weight = parseInput(weightInput)
+
+        guard height.isValid, weight.isValid else {
+            errorMessage = L10n.tr("bodyProfileManualInputValidationDescription")
+            return
+        }
+
+        let profile = BodyProfile(
+            heightCM: height.value.map { BodyProfileValue(value: $0, source: .manual) },
+            weightKG: weight.value.map { BodyProfileValue(value: $0, source: .manual) }
+        )
+
+        userPreferencesUseCase.setManualBodyProfile(profile)
+        manualBodyProfile = userPreferencesUseCase.getManualBodyProfile()
+        syncInputsFromManualProfile()
+        updateResolvedProfile()
+        errorMessage = nil
+    }
+
+    private func refreshHealthKitBodyProfile() async {
+        do {
+            healthKitBodyProfile = try await healthKitUseCase.fetchBodyProfile()
+        } catch {
+            healthKitBodyProfile = .empty
+            errorMessage = L10n.tr("bodyProfileHealthSyncFailureDescription")
+        }
+
+        updateResolvedProfile()
+    }
+
+    private func updateResolvedProfile() {
+        resolvedBodyProfile = manualBodyProfile.merging(preferred: healthKitBodyProfile)
+    }
+
+    private func syncInputsFromManualProfile() {
+        heightInput = manualBodyProfile.heightCM.map { Self.inputText(for: $0.value) } ?? ""
+        weightInput = manualBodyProfile.weightKG.map { Self.inputText(for: $0.value) } ?? ""
+    }
+
+    private func sourceText(for source: BodyProfileSource?) -> String? {
+        switch source {
+        case .healthKit:
+            return L10n.tr("bodyProfileSourceHealthKit")
+        case .manual:
+            return L10n.tr("bodyProfileSourceManual")
+        case nil:
+            return nil
+        }
+    }
+
+    private func parseInput(_ value: String) -> (value: Double?, isValid: Bool) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmed.isEmpty else {
+            return (nil, true)
+        }
+
+        guard let number = Double(trimmed), number > 0 else {
+            return (nil, false)
+        }
+
+        return (number, true)
+    }
+
+    private static func inputText(for value: Double) -> String {
+        if value.rounded(.towardZero) == value {
+            return String(Int(value))
+        }
+
+        return String(value)
+    }
+}

--- a/Project/Presentation/Tests/BodyProfileViewModelTests.swift
+++ b/Project/Presentation/Tests/BodyProfileViewModelTests.swift
@@ -1,0 +1,120 @@
+import DomainLayerInterface
+import Foundation
+import Localization
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("BodyProfileViewModel Tests")
+struct BodyProfileViewModelTests {
+    @MainActor
+    @Test("HealthKit 값이 있으면 직접 입력값보다 우선한다")
+    func healthKitPreferredOverManualInput() async {
+        let healthKitUseCase = MockHealthKitUseCase()
+        healthKitUseCase.authorizationStatusValue = .sharingAuthorized
+        healthKitUseCase.bodyProfileToReturn = BodyProfile(
+            heightCM: BodyProfileValue(value: 172, source: .healthKit),
+            weightKG: BodyProfileValue(value: 64, source: .healthKit)
+        )
+
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.manualBodyProfileValue = BodyProfile(
+            heightCM: BodyProfileValue(value: 168, source: .manual),
+            weightKG: BodyProfileValue(value: 60, source: .manual)
+        )
+
+        let viewModel = BodyProfileViewModel(
+            healthKitUseCase: healthKitUseCase,
+            userPreferencesUseCase: userPreferencesUseCase
+        )
+
+        await viewModel.load()
+
+        #expect(viewModel.availabilityState == .ready)
+        #expect(viewModel.resolvedHeightText == L10n.tr("bodyProfileHeightValueFormat", 172))
+        #expect(viewModel.resolvedWeightText == L10n.tr("bodyProfileWeightValueFormat", 64))
+        #expect(viewModel.heightSourceText == L10n.tr("bodyProfileSourceHealthKit"))
+        #expect(viewModel.weightSourceText == L10n.tr("bodyProfileSourceHealthKit"))
+    }
+
+    @MainActor
+    @Test("HealthKit 값이 없으면 직접 입력값으로 fallback 한다")
+    func manualFallbackWhenHealthKitMissing() async {
+        let healthKitUseCase = MockHealthKitUseCase()
+        healthKitUseCase.authorizationStatusValue = .sharingAuthorized
+        healthKitUseCase.bodyProfileToReturn = .empty
+
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.manualBodyProfileValue = BodyProfile(
+            heightCM: BodyProfileValue(value: 165, source: .manual),
+            weightKG: BodyProfileValue(value: 55, source: .manual)
+        )
+
+        let viewModel = BodyProfileViewModel(
+            healthKitUseCase: healthKitUseCase,
+            userPreferencesUseCase: userPreferencesUseCase
+        )
+
+        await viewModel.load()
+
+        #expect(viewModel.availabilityState == .ready)
+        #expect(viewModel.heightSourceText == L10n.tr("bodyProfileSourceManual"))
+        #expect(viewModel.weightSourceText == L10n.tr("bodyProfileSourceManual"))
+        #expect(viewModel.summaryText == "\(L10n.tr("bodyProfileHeightValueFormat", 165)) · \(L10n.tr("bodyProfileWeightValueFormat", 55))")
+    }
+
+    @MainActor
+    @Test("권한이 없고 값도 비어 있으면 permission 상태를 노출한다")
+    func permissionStateWhenNoProfileExists() async {
+        let healthKitUseCase = MockHealthKitUseCase()
+        healthKitUseCase.authorizationStatusValue = .sharingDenied
+
+        let viewModel = BodyProfileViewModel(
+            healthKitUseCase: healthKitUseCase,
+            userPreferencesUseCase: MockUserPreferencesUseCase()
+        )
+
+        await viewModel.load()
+
+        #expect(viewModel.availabilityState == .permissionDenied)
+        #expect(viewModel.summaryText == L10n.tr("bodyProfileSummaryNeedsInput"))
+    }
+
+    @MainActor
+    @Test("권한은 있지만 건강 앱과 직접 입력 값이 모두 없으면 noData 상태를 노출한다")
+    func noDataStateWhenAuthorizedButEmpty() async {
+        let healthKitUseCase = MockHealthKitUseCase()
+        healthKitUseCase.authorizationStatusValue = .sharingAuthorized
+        healthKitUseCase.bodyProfileToReturn = .empty
+
+        let viewModel = BodyProfileViewModel(
+            healthKitUseCase: healthKitUseCase,
+            userPreferencesUseCase: MockUserPreferencesUseCase()
+        )
+
+        await viewModel.load()
+
+        #expect(viewModel.availabilityState == .noData)
+        #expect(viewModel.helperText == L10n.tr("bodyProfileNoDataDescription"))
+    }
+
+    @MainActor
+    @Test("직접 입력 저장 시 UseCase와 상태를 함께 갱신한다")
+    func saveManualBodyProfile() {
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        let viewModel = BodyProfileViewModel(
+            healthKitUseCase: MockHealthKitUseCase(),
+            userPreferencesUseCase: userPreferencesUseCase
+        )
+
+        viewModel.heightInput = "171"
+        viewModel.weightInput = "59"
+        viewModel.saveManualBodyProfile()
+
+        #expect(userPreferencesUseCase.setManualBodyProfileCallCount == 1)
+        #expect(userPreferencesUseCase.capturedManualBodyProfile?.heightCM?.value == 171)
+        #expect(userPreferencesUseCase.capturedManualBodyProfile?.weightKG?.value == 59)
+        #expect(viewModel.heightSourceText == L10n.tr("bodyProfileSourceManual"))
+        #expect(viewModel.weightSourceText == L10n.tr("bodyProfileSourceManual"))
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockHealthKitUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockHealthKitUseCase.swift
@@ -3,16 +3,19 @@ import Foundation
 
 final class MockHealthKitUseCase: HealthKitUseCase, @unchecked Sendable {
     var authorizationStatusValue: HealthKitAuthorizationStatus = .notDetermined
+    var bodyProfileToReturn: BodyProfile = .empty
 
     private(set) var requestAuthorizationCallCount = 0
     private(set) var drinkWaterCallCount = 0
     private(set) var resetCallCount = 0
     private(set) var fetchHistoryCallCount = 0
+    private(set) var fetchBodyProfileCallCount = 0
 
     var requestAuthorizationError: Error?
     var drinkWaterError: Error?
     var resetError: Error?
     var fetchHistoryError: Error?
+    var fetchBodyProfileError: Error?
     var authorizationStatusAfterRequest: HealthKitAuthorizationStatus = .sharingAuthorized
 
     var historyToReturn: [HydrationRecord] = []
@@ -54,5 +57,13 @@ final class MockHealthKitUseCase: HealthKitUseCase, @unchecked Sendable {
             throw fetchHistoryError
         }
         return historyToReturn
+    }
+
+    func fetchBodyProfile() async throws -> BodyProfile {
+        fetchBodyProfileCallCount += 1
+        if let fetchBodyProfileError {
+            throw fetchBodyProfileError
+        }
+        return bodyProfileToReturn
     }
 }

--- a/Project/Presentation/Tests/Mock/MockUserPreferencesUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockUserPreferencesUseCase.swift
@@ -3,14 +3,18 @@ import DomainLayerInterface
 final class MockUserPreferencesUseCase: UserPreferencesUseCase, @unchecked Sendable {
     var mainIconValue: MainIcon = .default
     var dailyWaterLimitValue: Double = 2000
+    var manualBodyProfileValue: BodyProfile = .empty
 
     private(set) var getMainIconCallCount = 0
     private(set) var setMainIconCallCount = 0
     private(set) var getDailyWaterLimitCallCount = 0
     private(set) var setDailyWaterLimitCallCount = 0
+    private(set) var getManualBodyProfileCallCount = 0
+    private(set) var setManualBodyProfileCallCount = 0
 
     private(set) var capturedMainIcon: MainIcon?
     private(set) var capturedDailyWaterLimit: Double?
+    private(set) var capturedManualBodyProfile: BodyProfile?
 
     func getMainIcon() -> MainIcon {
         getMainIconCallCount += 1
@@ -32,5 +36,16 @@ final class MockUserPreferencesUseCase: UserPreferencesUseCase, @unchecked Senda
         setDailyWaterLimitCallCount += 1
         capturedDailyWaterLimit = limit
         dailyWaterLimitValue = limit
+    }
+
+    func getManualBodyProfile() -> BodyProfile {
+        getManualBodyProfileCallCount += 1
+        return manualBodyProfileValue
+    }
+
+    func setManualBodyProfile(_ profile: BodyProfile) {
+        setManualBodyProfileCallCount += 1
+        capturedManualBodyProfile = profile
+        manualBodyProfileValue = profile
     }
 }

--- a/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
+++ b/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
@@ -89,6 +89,12 @@ struct ProfileRoutineViewModelTests {
         func setDailyWaterLimit(_ limit: Double) {
             dailyWaterLimit = limit
         }
+
+        func getManualBodyProfile() -> BodyProfile {
+            .empty
+        }
+
+        func setManualBodyProfile(_ profile: BodyProfile) {}
     }
 
     @MainActor

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockHealthKitUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockHealthKitUseCase.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public final class MockHealthKitUseCase: HealthKitUseCase, @unchecked Sendable {
     public var authorisationStatus: HealthKitAuthorizationStatus = .sharingAuthorized
+    public var bodyProfile: BodyProfile = .empty
 
     public init() {}
     
@@ -47,5 +48,9 @@ public final class MockHealthKitUseCase: HealthKitUseCase, @unchecked Sendable {
                 date: calendar.date(byAdding: .hour, value: -5, to: today) ?? today
             )
         ]
+    }
+
+    public func fetchBodyProfile() async throws -> BodyProfile {
+        bodyProfile
     }
 }

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockUserPreferencesUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockUserPreferencesUseCase.swift
@@ -11,6 +11,7 @@ import DomainLayerInterface
 public final class MockUserPreferencesUseCase: UserPreferencesUseCase, @unchecked Sendable {
     private var mainIcon: MainIcon = .drop
     private var dailyWaterLimit: Double = 2000
+    private var manualBodyProfile: BodyProfile = .empty
     private var accentColor: String = "blue"
 
     public init() {}
@@ -29,6 +30,14 @@ public final class MockUserPreferencesUseCase: UserPreferencesUseCase, @unchecke
 
     public func setDailyWaterLimit(_ limit: Double) {
         dailyWaterLimit = limit
+    }
+
+    public func getManualBodyProfile() -> BodyProfile {
+        manualBodyProfile
+    }
+
+    public func setManualBodyProfile(_ profile: BodyProfile) {
+        manualBodyProfile = profile
     }
 
     public func getAccentColor() -> String {

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -118,6 +118,14 @@ public final class PreviewAssembly: Assembly {
         }
         .inObjectScope(.container)
 
+        container.register(BodyProfileViewModel.self) { resolver in
+            BodyProfileViewModel(
+                healthKitUseCase: resolver.resolve(HealthKitUseCase.self)!,
+                userPreferencesUseCase: resolver.resolve(UserPreferencesUseCase.self)!
+            )
+        }
+        .inObjectScope(.container)
+
         // MARK: - Settings (Preview)
         container.register(SettingsViewModel.self) { resolver in
             SettingsViewModel(

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewViewModelFactory.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewViewModelFactory.swift
@@ -34,9 +34,11 @@ public struct PreviewViews {
     /// ProfileView Preview 생성
     public static var profile: some View {
         let settingsViewModel = DIContainer.preview.resolve(SettingsViewModel.self)
+        let bodyProfileViewModel = DIContainer.preview.resolve(BodyProfileViewModel.self)
         let routineViewModel = DIContainer.preview.resolve(ProfileRoutineViewModel.self)
         return ProfileView(
             settingsViewModel: settingsViewModel,
+            bodyProfileViewModel: bodyProfileViewModel,
             routineViewModel: routineViewModel
         )
     }

--- a/Project/Shared/DependencyInjection/Sources/Preview/ViewPreviews.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/ViewPreviews.swift
@@ -37,8 +37,13 @@ import SwiftUI
 // MARK: - ProfileView Preview
 #Preview("ProfileView") {
     let settingsViewModel = DIContainer.preview.resolve(SettingsViewModel.self)
+    let bodyProfileViewModel = DIContainer.preview.resolve(BodyProfileViewModel.self)
     let routineViewModel = DIContainer.preview.resolve(ProfileRoutineViewModel.self)
-    ProfileView(settingsViewModel: settingsViewModel, routineViewModel: routineViewModel)
+    ProfileView(
+        settingsViewModel: settingsViewModel,
+        bodyProfileViewModel: bodyProfileViewModel,
+        routineViewModel: routineViewModel
+    )
 }
 
 #Preview("ProfileRoutineView") {
@@ -72,6 +77,16 @@ import SwiftUI
 #Preview("DailyLimit Setting") {
     let viewModel = DIContainer.preview.resolve(SettingsViewModel.self)
     SettingDetailView(menu: .dailyLimit, viewModel: viewModel)
+}
+
+#Preview("BodyProfile Setting") {
+    let settingsViewModel = DIContainer.preview.resolve(SettingsViewModel.self)
+    let bodyProfileViewModel = DIContainer.preview.resolve(BodyProfileViewModel.self)
+    SettingDetailView(
+        menu: .bodyProfile,
+        viewModel: settingsViewModel,
+        bodyProfileViewModel: bodyProfileViewModel
+    )
 }
 
 #Preview("MainShape Setting") {

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -106,6 +106,19 @@ public final class PresentationAssembly: Assembly {
         }
         .inObjectScope(.container)
 
+        container.register(BodyProfileViewModel.self) { resolver in
+            let healthKitUseCase = resolver.resolve(HealthKitUseCase.self)!
+            let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
+
+            return MainActor.assumeIsolated {
+                BodyProfileViewModel(
+                    healthKitUseCase: healthKitUseCase,
+                    userPreferencesUseCase: userPreferencesUseCase
+                )
+            }
+        }
+        .inObjectScope(.container)
+
         // MARK: - Settings
         container.register(SettingsViewModel.self) { resolver in
             SettingsViewModel(

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockHealthKitUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockHealthKitUseCaseForTesting.swift
@@ -12,11 +12,13 @@ public final class MockHealthKitUseCaseForTesting: HealthKitUseCase, @unchecked 
     public var authorisationStatus: HealthKitAuthorizationStatus = .sharingAuthorized
     public var shouldThrowError = false
     public var fetchHistoryResult: [HydrationRecord] = []
+    public var bodyProfileResult: BodyProfile = .empty
 
     public var drinkWaterCallCount = 0
     public var resetCallCount = 0
     public var requestAuthorizationCallCount = 0
     public var fetchHistoryCallCount = 0
+    public var fetchBodyProfileCallCount = 0
 
     public init() {}
 
@@ -45,6 +47,16 @@ public final class MockHealthKitUseCaseForTesting: HealthKitUseCase, @unchecked 
         }
 
         return fetchHistoryResult
+    }
+
+    public func fetchBodyProfile() async throws -> BodyProfile {
+        fetchBodyProfileCallCount += 1
+
+        if shouldThrowError {
+            throw HealthKitError.healthKitInternalError
+        }
+
+        return bodyProfileResult
     }
 
     // Testing helpers

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockUserPreferencesUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockUserPreferencesUseCaseForTesting.swift
@@ -11,6 +11,7 @@ import DomainLayerInterface
 public final class MockUserPreferencesUseCaseForTesting: UserPreferencesUseCase, @unchecked Sendable {
     public var mainIcon: MainIcon = .drop
     public var dailyWaterLimit: Double = 2000
+    public var manualBodyProfile: BodyProfile = .empty
     public var accentColor: String = "blue"
 
     public init() {}
@@ -29,6 +30,14 @@ public final class MockUserPreferencesUseCaseForTesting: UserPreferencesUseCase,
 
     public func setDailyWaterLimit(_ limit: Double) {
         dailyWaterLimit = limit
+    }
+
+    public func getManualBodyProfile() -> BodyProfile {
+        manualBodyProfile
+    }
+
+    public func setManualBodyProfile(_ profile: BodyProfile) {
+        manualBodyProfile = profile
     }
 
     public func getAccentColor() -> String {

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -1519,6 +1519,347 @@
         }
       }
     },
+    "bodyProfileConnectHealthKitTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱에서 가져오기"
+          }
+        }
+      }
+    },
+    "bodyProfileHealthKitSectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱 연동"
+          }
+        }
+      }
+    },
+    "bodyProfileHealthSyncFailureDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱에서 신체 정보를 불러오지 못했어요. 잠시 후 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "bodyProfileHeightMissingValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키 입력 필요"
+          }
+        }
+      }
+    },
+    "bodyProfileHeightPlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키를 입력해 주세요 (cm)"
+          }
+        }
+      }
+    },
+    "bodyProfileHeightTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키"
+          }
+        }
+      }
+    },
+    "bodyProfileHeightValueFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld cm"
+          }
+        }
+      }
+    },
+    "bodyProfileIncompleteDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱에서 값을 가져오거나 직접 입력해 주세요. 키와 몸무게가 모두 있어야 추천에 사용할 수 있어요."
+          }
+        }
+      }
+    },
+    "bodyProfileManualInputValidationDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키와 몸무게는 0보다 큰 숫자로 입력해 주세요."
+          }
+        }
+      }
+    },
+    "bodyProfileManualSectionDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱에 값이 없을 때 사용할 fallback 정보를 직접 입력할 수 있어요."
+          }
+        }
+      }
+    },
+    "bodyProfileManualSectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "직접 입력"
+          }
+        }
+      }
+    },
+    "bodyProfileMissingValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "입력 필요"
+          }
+        }
+      }
+    },
+    "bodyProfileNoDataDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱에 키와 몸무게가 없어요. 직접 입력하거나 건강 앱에 값을 추가한 뒤 다시 가져와 주세요."
+          }
+        }
+      }
+    },
+    "bodyProfileOpenSettingsTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정 열기"
+          }
+        }
+      }
+    },
+    "bodyProfilePermissionDeniedDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 권한이 꺼져 있어요. 설정에서 권한을 다시 허용하거나 직접 입력해 주세요."
+          }
+        }
+      }
+    },
+    "bodyProfilePermissionNeededDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천에 쓸 키와 몸무게를 불러오려면 건강 앱 접근이 필요해요."
+          }
+        }
+      }
+    },
+    "bodyProfilePermissionRequestFailureDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 권한을 확인하지 못했어요. 잠시 후 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "bodyProfileRetryHealthSyncTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱에서 다시 가져오기"
+          }
+        }
+      }
+    },
+    "bodyProfileSaveManualChangesTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "직접 입력 수정하기"
+          }
+        }
+      }
+    },
+    "bodyProfileSaveManualTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "직접 입력 저장하기"
+          }
+        }
+      }
+    },
+    "bodyProfileSourceHealthKit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱"
+          }
+        }
+      }
+    },
+    "bodyProfileSourceManual" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "직접 입력"
+          }
+        }
+      }
+    },
+    "bodyProfileSourcePriorityDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천에는 건강 앱 값이 우선 사용되고, 값이 없으면 직접 입력한 값이 사용돼요."
+          }
+        }
+      }
+    },
+    "bodyProfileSummaryCardTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 신체 정보"
+          }
+        }
+      }
+    },
+    "bodyProfileSummaryNeedsInput" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키와 몸무게를 입력해 주세요"
+          }
+        }
+      }
+    },
+    "bodyProfileWeightMissingValue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "몸무게 입력 필요"
+          }
+        }
+      }
+    },
+    "bodyProfileWeightPlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "몸무게를 입력해 주세요 (kg)"
+          }
+        }
+      }
+    },
+    "bodyProfileWeightTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "몸무게"
+          }
+        }
+      }
+    },
+    "bodyProfileWeightValueFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld kg"
+          }
+        }
+      }
+    },
+    "settingBodyProfileDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키와 몸무게를 관리합니다"
+          }
+        }
+      }
+    },
+    "settingBodyProfileTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "신체 정보"
+          }
+        }
+      }
+    },
     "settingDailyLimitDescription" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Project/Shared/Utils/Sources/String+Extensions.swift
+++ b/Project/Shared/Utils/Sources/String+Extensions.swift
@@ -24,6 +24,8 @@ public extension String {
     static let mainIcon: String = "mainIcon"
     static let legacyMainAppearance: String = "mainAppearance"
     static let dailyWaterLimit: String = "dailyWaterLimit"
+    static let manualBodyHeightCM: String = "manualBodyHeightCM"
+    static let manualBodyWeightKG: String = "manualBodyWeightKG"
     static let hydrationRoutines: String = "hydrationRoutines"
     static let hydrationChallengeStates: String = "hydrationChallengeStates"
     static let hydrationChallengeBadgeHistories: String = "hydrationChallengeBadgeHistories"

--- a/Project/Shared/Utils/Sources/UserDefaults+Extensions.swift
+++ b/Project/Shared/Utils/Sources/UserDefaults+Extensions.swift
@@ -33,4 +33,14 @@ public extension UserDefaults {
         get { self.double(forKey: .dailyWaterLimit) }
         set { self.set(newValue, forKey: .dailyWaterLimit) }
     }
+
+    @objc dynamic var manualBodyHeightCM: Double {
+        get { self.double(forKey: .manualBodyHeightCM) }
+        set { self.set(newValue, forKey: .manualBodyHeightCM) }
+    }
+
+    @objc dynamic var manualBodyWeightKG: Double {
+        get { self.double(forKey: .manualBodyWeightKG) }
+        set { self.set(newValue, forKey: .manualBodyWeightKG) }
+    }
 }


### PR DESCRIPTION
## 📝 Summary
- HealthKit에서 키와 몸무게를 읽어와 신체 정보 source로 사용할 수 있게 했습니다.
- 프로필 탭에 신체 정보 설정 진입점을 추가하고, 권한 없음, 데이터 없음, 직접 입력 fallback UX를 구현했습니다.
- `#89`에서 사용할 수 있도록 신체 정보 우선순위를 `HealthKit > 직접 입력`으로 정리했습니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #149
- Related to #89

## 📋 Changes Made
### Added
- `BodyProfile`, `BodyProfileValue`, `BodyProfileSource` 도메인 타입 추가
- `BodyProfileViewModel` 및 프로필 내 신체 정보 설정 화면 추가
- 직접 입력한 키와 몸무게용 `UserDefaults` 저장 키 추가
- HealthKit, UserPreferences, Presentation 테스트 케이스 추가

### Changed
- HealthKit 권한 요청 범위를 `dietaryWater`뿐 아니라 `height`, `bodyMass` 읽기까지 포함하도록 확장
- `HealthKitUseCase`와 `UserPreferencesUseCase`가 신체 정보 조회와 저장 계약을 다루도록 확장
- 프로필 탭 빠른 설정에 `신체 정보` 항목 추가
- 신체 정보 source priority를 `HealthKit 우선, 직접 입력 fallback`으로 반영
- HealthKit 권한 게이트 설명 문구를 수분 기록 + 신체 정보 기준으로 수정

### Fixed
- 권한은 있지만 건강 앱에 값이 없는 경우와 권한이 없는 경우를 UI에서 구분하도록 수정
- HealthKit 값이 없을 때 추천 입력용 신체 정보를 확보할 경로가 없던 문제를 직접 입력 fallback으로 보완

### Removed
- 없음

## 🔍 Technical Details
- `HealthKitDataSource`에 최신 `height`와 `bodyMass` 샘플 조회를 추가하고 `BodyProfile`로 매핑했습니다.
- 수동 입력값은 App Group `UserDefaults`에 저장하고, resolve 시 `manual.merging(preferred: healthKit)` 방식으로 합칩니다.
- `BodyProfileViewModel`은 `needsPermission`, `permissionDenied`, `noData`, `incomplete`, `ready` 상태를 분리해 CTA를 다르게 노출합니다.

## 📸 Screenshots / Videos
### Before
- 신체 정보 진입점 및 유도 UI 없음

### After
- 프로필 > 신체 정보에서 건강 앱 연동, 직접 입력, 설정 이동 CTA 제공

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS 26.4 Simulator / generic iOS
- Device: iPhone 17 Pro Simulator
- Xcode Version: Xcode 26.4 (17E192)

### Test Results
- `tuist generate` 성공
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer -destination 'platform=iOS Simulator,id=F1962A90-7912-44CB-A7F9-FFFAAB3D0CA3' -sdk iphonesimulator -derivedDataPath /tmp/MulimiDomainTest` 통과
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,id=F1962A90-7912-44CB-A7F9-FFFAAB3D0CA3' -sdk iphonesimulator -derivedDataPath /tmp/MulimiPresentationTest2` 통과
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'generic/platform=iOS Simulator' -sdk iphonesimulator -derivedDataPath /tmp/MulimiPresentationBuild` 통과
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS' -derivedDataPath /tmp/MulimiAppDeviceBuild` 통과

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- `#89`에서 추천 입력값을 사용할 때는 `BodyProfileViewModel`이 아니라 동일한 우선순위를 가진 resolved profile 로직을 도메인 쪽으로 끌어올리는 후속 정리가 필요할 수 있습니다.
- `Mulimi` 스킴은 watch 타깃이 포함돼 있어 `generic/platform=iOS Simulator`에서는 product type 제약으로 빌드할 수 없어서, 앱 빌드는 `generic/platform=iOS` 기준으로 검증했습니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [x] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
