### PR TITLE
feat: add AI hydration goal recommendation

### DIFF
--- a/Project/App/Sources/ContentView.swift
+++ b/Project/App/Sources/ContentView.swift
@@ -45,6 +45,7 @@ struct ContentView: View {
             ProfileView(
                 settingsViewModel: DIContainer.shared.resolve(SettingsViewModel.self),
                 bodyProfileViewModel: DIContainer.shared.resolve(BodyProfileViewModel.self),
+                recommendationViewModel: DIContainer.shared.resolve(HydrationGoalRecommendationViewModel.self),
                 routineViewModel: DIContainer.shared.resolve(ProfileRoutineViewModel.self)
             )
             .tabItem {

--- a/Project/Data/Sources/DataSource/FoundationModelsHydrationGoalRecommendationDataSource.swift
+++ b/Project/Data/Sources/DataSource/FoundationModelsHydrationGoalRecommendationDataSource.swift
@@ -1,0 +1,136 @@
+//
+//  FoundationModelsHydrationGoalRecommendationDataSource.swift
+//  DataLayer
+//
+//  Created by Codex on 3/30/26.
+//
+
+import DomainLayerInterface
+import Foundation
+import FoundationModels
+
+public protocol HydrationGoalRecommendationDataSource: Sendable {
+    func availability() -> HydrationGoalRecommendationUnavailableReason?
+    func generateRecommendation(
+        for input: HydrationGoalRecommendationInput
+    ) async throws -> HydrationGoalRecommendation
+}
+
+@Generable
+private struct GeneratedHydrationGoalRecommendation {
+    let recommendedLimitML: Int
+    let summary: String
+    let primaryReason: String
+    let secondaryReason: String
+    let caution: String
+}
+
+public final class FoundationModelsHydrationGoalRecommendationDataSource: HydrationGoalRecommendationDataSource, @unchecked Sendable {
+    private enum Constants {
+        static let minimumLimitML = 1_000
+        static let maximumLimitML = 4_000
+        static let stepML = 250
+    }
+
+    private let model: SystemLanguageModel
+    private let locale: Locale
+
+    public init(
+        model: SystemLanguageModel = .default,
+        locale: Locale = .current
+    ) {
+        self.model = model
+        self.locale = locale
+    }
+
+    public func availability() -> HydrationGoalRecommendationUnavailableReason? {
+        guard model.supportsLocale(locale) else {
+            return .unsupportedLocale
+        }
+
+        switch model.availability {
+        case .available:
+            return nil
+        case let .unavailable(reason):
+            return switch reason {
+            case .deviceNotEligible:
+                .deviceNotEligible
+            case .appleIntelligenceNotEnabled:
+                .appleIntelligenceNotEnabled
+            case .modelNotReady:
+                .modelNotReady
+            @unknown default:
+                .unknown
+            }
+        }
+    }
+
+    public func generateRecommendation(
+        for input: HydrationGoalRecommendationInput
+    ) async throws -> HydrationGoalRecommendation {
+        let session = LanguageModelSession(
+            model: model,
+            instructions: """
+            당신은 수분 섭취 앱의 목표 수분량 추천 도우미입니다.
+            제공된 숫자만 사용해 하루 목표 수분량을 추천하세요.
+            항상 한국어로 응답하세요.
+            추천 목표량은 1000ml 이상 4000ml 이하, 250ml 단위여야 합니다.
+            현재 목표와 너무 큰 차이가 나지 않도록 보수적으로 제안하세요.
+            요약은 한 문장으로 짧게 작성하세요.
+            이유는 짧은 문장 두 개로 작성하세요.
+            주의사항은 필요할 때만 짧게 작성하고, 없으면 빈 문자열을 반환하세요.
+            의학적 진단처럼 단정하지 마세요.
+            """
+        )
+
+        let response = try await session.respond(
+            to: prompt(for: input),
+            generating: GeneratedHydrationGoalRecommendation.self,
+            options: GenerationOptions(
+                sampling: .greedy,
+                maximumResponseTokens: 300
+            )
+        )
+
+        let content = response.content
+
+        return HydrationGoalRecommendation(
+            input: input,
+            recommendedLimitML: normalizedLimit(from: content.recommendedLimitML),
+            summary: content.summary.trimmingCharacters(in: .whitespacesAndNewlines),
+            reasons: [
+                content.primaryReason,
+                content.secondaryReason
+            ]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty },
+            caution: sanitizedCaution(content.caution)
+        )
+    }
+
+    private func prompt(for input: HydrationGoalRecommendationInput) -> String {
+        """
+        다음 정보를 기반으로 오늘의 개인화 목표 수분량을 추천하세요.
+
+        - 키: \(input.heightCM)cm
+        - 몸무게: \(input.weightKG)kg
+        - 현재 목표 수분량: \(input.currentGoalML)ml
+        - 최근 \(input.analysisDays)일 평균 섭취량: \(input.recentAverageIntakeML)ml
+        - 최근 \(input.analysisDays)일 기록이 있었던 날 수: \(input.recentRecordedDays)일
+        - 최근 \(input.analysisDays)일 목표 달성 일수: \(input.recentGoalAchievementDays)일
+
+        현재 목표와 최근 기록의 차이를 함께 고려해서 추천하세요.
+        """
+    }
+
+    private func normalizedLimit(from value: Int) -> Int {
+        let clampedValue = min(max(value, Constants.minimumLimitML), Constants.maximumLimitML)
+        let roundedStep = Int((Double(clampedValue) / Double(Constants.stepML)).rounded()) * Constants.stepML
+        return min(max(roundedStep, Constants.minimumLimitML), Constants.maximumLimitML)
+    }
+
+    private func sanitizedCaution(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Project/Data/Sources/Repository/HydrationGoalRecommendationRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/HydrationGoalRecommendationRepositoryImpl.swift
@@ -1,0 +1,26 @@
+//
+//  HydrationGoalRecommendationRepositoryImpl.swift
+//  DataLayer
+//
+//  Created by Codex on 3/30/26.
+//
+
+import DomainLayerInterface
+
+public struct HydrationGoalRecommendationRepositoryImpl: HydrationGoalRecommendationRepository {
+    private let dataSource: HydrationGoalRecommendationDataSource
+
+    public init(dataSource: HydrationGoalRecommendationDataSource) {
+        self.dataSource = dataSource
+    }
+
+    public func availability() -> HydrationGoalRecommendationUnavailableReason? {
+        dataSource.availability()
+    }
+
+    public func generateRecommendation(
+        for input: HydrationGoalRecommendationInput
+    ) async throws -> HydrationGoalRecommendation {
+        try await dataSource.generateRecommendation(for: input)
+    }
+}

--- a/Project/Domain/Interfaces/Entity/BodyProfileAvailability.swift
+++ b/Project/Domain/Interfaces/Entity/BodyProfileAvailability.swift
@@ -1,0 +1,16 @@
+//
+//  BodyProfileAvailability.swift
+//  DomainLayerInterface
+//
+//  Created by Codex on 3/30/26.
+//
+
+import Foundation
+
+public enum BodyProfileAvailability: Hashable, Sendable {
+    case ready
+    case needsPermission
+    case permissionDenied
+    case noData
+    case incomplete
+}

--- a/Project/Domain/Interfaces/Entity/BodyProfileSnapshot.swift
+++ b/Project/Domain/Interfaces/Entity/BodyProfileSnapshot.swift
@@ -1,0 +1,33 @@
+//
+//  BodyProfileSnapshot.swift
+//  DomainLayerInterface
+//
+//  Created by Codex on 3/30/26.
+//
+
+import Foundation
+
+public struct BodyProfileSnapshot: Hashable, Sendable {
+    public let authorizationStatus: HealthKitAuthorizationStatus
+    public let healthKitBodyProfile: BodyProfile
+    public let manualBodyProfile: BodyProfile
+    public let resolvedBodyProfile: BodyProfile
+    public let availability: BodyProfileAvailability
+    public let didFailHealthKitSync: Bool
+
+    public init(
+        authorizationStatus: HealthKitAuthorizationStatus,
+        healthKitBodyProfile: BodyProfile,
+        manualBodyProfile: BodyProfile,
+        resolvedBodyProfile: BodyProfile,
+        availability: BodyProfileAvailability,
+        didFailHealthKitSync: Bool
+    ) {
+        self.authorizationStatus = authorizationStatus
+        self.healthKitBodyProfile = healthKitBodyProfile
+        self.manualBodyProfile = manualBodyProfile
+        self.resolvedBodyProfile = resolvedBodyProfile
+        self.availability = availability
+        self.didFailHealthKitSync = didFailHealthKitSync
+    }
+}

--- a/Project/Domain/Interfaces/Entity/HealthKitAuthorizationStatus.swift
+++ b/Project/Domain/Interfaces/Entity/HealthKitAuthorizationStatus.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum HealthKitAuthorizationStatus: Int {
+public enum HealthKitAuthorizationStatus: Int, Sendable {
     case notDetermined
     case sharingDenied
     case sharingAuthorized

--- a/Project/Domain/Interfaces/Entity/HydrationGoalRecommendation.swift
+++ b/Project/Domain/Interfaces/Entity/HydrationGoalRecommendation.swift
@@ -1,0 +1,77 @@
+//
+//  HydrationGoalRecommendation.swift
+//  DomainLayerInterface
+//
+//  Created by Codex on 3/30/26.
+//
+
+import Foundation
+
+public struct HydrationGoalRecommendationInput: Hashable, Sendable {
+    public let heightCM: Int
+    public let weightKG: Int
+    public let currentGoalML: Int
+    public let recentAverageIntakeML: Int
+    public let recentRecordedDays: Int
+    public let recentGoalAchievementDays: Int
+    public let analysisDays: Int
+
+    public init(
+        heightCM: Int,
+        weightKG: Int,
+        currentGoalML: Int,
+        recentAverageIntakeML: Int,
+        recentRecordedDays: Int,
+        recentGoalAchievementDays: Int,
+        analysisDays: Int
+    ) {
+        self.heightCM = heightCM
+        self.weightKG = weightKG
+        self.currentGoalML = currentGoalML
+        self.recentAverageIntakeML = recentAverageIntakeML
+        self.recentRecordedDays = recentRecordedDays
+        self.recentGoalAchievementDays = recentGoalAchievementDays
+        self.analysisDays = analysisDays
+    }
+}
+
+public struct HydrationGoalRecommendation: Hashable, Sendable {
+    public let input: HydrationGoalRecommendationInput
+    public let recommendedLimitML: Int
+    public let summary: String
+    public let reasons: [String]
+    public let caution: String?
+
+    public init(
+        input: HydrationGoalRecommendationInput,
+        recommendedLimitML: Int,
+        summary: String,
+        reasons: [String],
+        caution: String?
+    ) {
+        self.input = input
+        self.recommendedLimitML = recommendedLimitML
+        self.summary = summary
+        self.reasons = reasons
+        self.caution = caution
+    }
+}
+
+public enum HydrationGoalRecommendationUnavailableReason: Hashable, Sendable {
+    case deviceNotEligible
+    case appleIntelligenceNotEnabled
+    case modelNotReady
+    case unsupportedLocale
+    case unknown
+}
+
+public enum HydrationGoalRecommendationAvailability: Hashable, Sendable {
+    case ready
+    case bodyProfileRequired(BodyProfileAvailability)
+    case modelUnavailable(HydrationGoalRecommendationUnavailableReason)
+}
+
+public enum HydrationGoalRecommendationError: Error, Hashable, Sendable {
+    case bodyProfileRequired(BodyProfileAvailability)
+    case modelUnavailable(HydrationGoalRecommendationUnavailableReason)
+}

--- a/Project/Domain/Interfaces/Repository/HydrationGoalRecommendationRepository.swift
+++ b/Project/Domain/Interfaces/Repository/HydrationGoalRecommendationRepository.swift
@@ -1,0 +1,15 @@
+//
+//  HydrationGoalRecommendationRepository.swift
+//  DomainLayerInterface
+//
+//  Created by Codex on 3/30/26.
+//
+
+import Foundation
+
+public protocol HydrationGoalRecommendationRepository: Sendable {
+    func availability() -> HydrationGoalRecommendationUnavailableReason?
+    func generateRecommendation(
+        for input: HydrationGoalRecommendationInput
+    ) async throws -> HydrationGoalRecommendation
+}

--- a/Project/Domain/Interfaces/UseCase/BodyProfileUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/BodyProfileUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  BodyProfileUseCase.swift
+//  DomainLayerInterface
+//
+//  Created by Codex on 3/30/26.
+//
+
+import Foundation
+
+public protocol BodyProfileUseCase: Sendable {
+    func loadBodyProfile() async -> BodyProfileSnapshot
+    func requestHealthKitSync() async throws -> BodyProfileSnapshot
+}

--- a/Project/Domain/Interfaces/UseCase/HydrationGoalRecommendationUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/HydrationGoalRecommendationUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  HydrationGoalRecommendationUseCase.swift
+//  DomainLayerInterface
+//
+//  Created by Codex on 3/30/26.
+//
+
+import Foundation
+
+public protocol HydrationGoalRecommendationUseCase: Sendable {
+    func availability(referenceDate: Date) async -> HydrationGoalRecommendationAvailability
+    func generateRecommendation(referenceDate: Date) async throws -> HydrationGoalRecommendation
+}

--- a/Project/Domain/Sources/UseCase/BodyProfileUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/BodyProfileUseCaseImpl.swift
@@ -1,0 +1,96 @@
+//
+//  BodyProfileUseCaseImpl.swift
+//  DomainLayer
+//
+//  Created by Codex on 3/30/26.
+//
+
+import DomainLayerInterface
+
+public struct BodyProfileUseCaseImpl: BodyProfileUseCase {
+    private let healthKitRepository: HealthKitRepository
+
+    public init(
+        healthKitRepository: HealthKitRepository
+    ) {
+        self.healthKitRepository = healthKitRepository
+    }
+
+    public func loadBodyProfile() async -> BodyProfileSnapshot {
+        let authorizationStatus = healthKitRepository.authorisationStatus
+
+        guard authorizationStatus == .sharingAuthorized else {
+            return snapshot(
+                authorizationStatus: authorizationStatus,
+                healthKitBodyProfile: .empty,
+                didFailHealthKitSync: false
+            )
+        }
+
+        do {
+            let healthKitBodyProfile = try await healthKitRepository.fetchBodyProfile()
+            return snapshot(
+                authorizationStatus: authorizationStatus,
+                healthKitBodyProfile: healthKitBodyProfile,
+                didFailHealthKitSync: false
+            )
+        } catch {
+            return snapshot(
+                authorizationStatus: authorizationStatus,
+                healthKitBodyProfile: .empty,
+                didFailHealthKitSync: true
+            )
+        }
+    }
+
+    public func requestHealthKitSync() async throws -> BodyProfileSnapshot {
+        if healthKitRepository.authorisationStatus == .notDetermined {
+            try await healthKitRepository.requestAuthorization()
+        }
+
+        return await loadBodyProfile()
+    }
+
+    private func snapshot(
+        authorizationStatus: HealthKitAuthorizationStatus,
+        healthKitBodyProfile: BodyProfile,
+        didFailHealthKitSync: Bool
+    ) -> BodyProfileSnapshot {
+        let resolvedBodyProfile = healthKitBodyProfile
+
+        return BodyProfileSnapshot(
+            authorizationStatus: authorizationStatus,
+            healthKitBodyProfile: healthKitBodyProfile,
+            manualBodyProfile: .empty,
+            resolvedBodyProfile: resolvedBodyProfile,
+            availability: availability(
+                authorizationStatus: authorizationStatus,
+                healthKitBodyProfile: healthKitBodyProfile,
+                resolvedBodyProfile: resolvedBodyProfile
+            ),
+            didFailHealthKitSync: didFailHealthKitSync
+        )
+    }
+
+    private func availability(
+        authorizationStatus: HealthKitAuthorizationStatus,
+        healthKitBodyProfile: BodyProfile,
+        resolvedBodyProfile: BodyProfile
+    ) -> BodyProfileAvailability {
+        if resolvedBodyProfile.isComplete {
+            return .ready
+        }
+
+        switch authorizationStatus {
+        case .notDetermined:
+            return .needsPermission
+        case .sharingDenied:
+            return .permissionDenied
+        case .sharingAuthorized:
+            if healthKitBodyProfile.isEmpty {
+                return .noData
+            }
+            return .incomplete
+        }
+    }
+}

--- a/Project/Domain/Sources/UseCase/HydrationGoalRecommendationUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/HydrationGoalRecommendationUseCaseImpl.swift
@@ -1,0 +1,115 @@
+//
+//  HydrationGoalRecommendationUseCaseImpl.swift
+//  DomainLayer
+//
+//  Created by Codex on 3/30/26.
+//
+
+import DomainLayerInterface
+import Foundation
+
+public struct HydrationGoalRecommendationUseCaseImpl: HydrationGoalRecommendationUseCase {
+    private enum Constants {
+        static let analysisDays = 7
+    }
+
+    private let bodyProfileUseCase: BodyProfileUseCase
+    private let drinkWaterRepository: DrinkWaterRepository
+    private let userPreferencesRepository: UserPreferencesRepository
+    private let recommendationRepository: HydrationGoalRecommendationRepository
+    private let calendar: Calendar
+
+    public init(
+        bodyProfileUseCase: BodyProfileUseCase,
+        drinkWaterRepository: DrinkWaterRepository,
+        userPreferencesRepository: UserPreferencesRepository,
+        recommendationRepository: HydrationGoalRecommendationRepository,
+        calendar: Calendar = .autoupdatingCurrent
+    ) {
+        self.bodyProfileUseCase = bodyProfileUseCase
+        self.drinkWaterRepository = drinkWaterRepository
+        self.userPreferencesRepository = userPreferencesRepository
+        self.recommendationRepository = recommendationRepository
+        self.calendar = calendar
+    }
+
+    public func availability(referenceDate: Date) async -> HydrationGoalRecommendationAvailability {
+        let snapshot = await bodyProfileUseCase.loadBodyProfile()
+
+        guard snapshot.resolvedBodyProfile.isComplete else {
+            return .bodyProfileRequired(snapshot.availability)
+        }
+
+        if let unavailableReason = recommendationRepository.availability() {
+            return .modelUnavailable(unavailableReason)
+        }
+
+        return .ready
+    }
+
+    public func generateRecommendation(referenceDate: Date) async throws -> HydrationGoalRecommendation {
+        let snapshot = await bodyProfileUseCase.loadBodyProfile()
+
+        guard snapshot.resolvedBodyProfile.isComplete else {
+            throw HydrationGoalRecommendationError.bodyProfileRequired(snapshot.availability)
+        }
+
+        if let unavailableReason = recommendationRepository.availability() {
+            throw HydrationGoalRecommendationError.modelUnavailable(unavailableReason)
+        }
+
+        let input = await buildInput(
+            from: snapshot.resolvedBodyProfile,
+            referenceDate: referenceDate
+        )
+
+        return try await recommendationRepository.generateRecommendation(for: input)
+    }
+
+    private func buildInput(
+        from bodyProfile: BodyProfile,
+        referenceDate: Date
+    ) async -> HydrationGoalRecommendationInput {
+        let dayInterval = analysisInterval(for: referenceDate)
+        let events = await drinkWaterRepository.hydrationEvents(in: dayInterval)
+        let dailyTotals = aggregateDailyTotals(from: events)
+
+        let analysisDays = Constants.analysisDays
+        let currentGoalML = Int(userPreferencesRepository.getDailyWaterLimit().rounded())
+        let totalIntakeML = dailyTotals.values.reduce(0, +)
+        let recentAverageIntakeML = totalIntakeML / analysisDays
+        let recentRecordedDays = dailyTotals.values.filter { $0 > 0 }.count
+        let recentGoalAchievementDays = dailyTotals.values.filter { $0 >= currentGoalML }.count
+
+        return HydrationGoalRecommendationInput(
+            heightCM: Int((bodyProfile.heightCM?.value ?? 0).rounded()),
+            weightKG: Int((bodyProfile.weightKG?.value ?? 0).rounded()),
+            currentGoalML: currentGoalML,
+            recentAverageIntakeML: recentAverageIntakeML,
+            recentRecordedDays: recentRecordedDays,
+            recentGoalAchievementDays: recentGoalAchievementDays,
+            analysisDays: analysisDays
+        )
+    }
+
+    private func analysisInterval(for referenceDate: Date) -> DateInterval {
+        let end = calendar.date(
+            byAdding: .day,
+            value: 1,
+            to: calendar.startOfDay(for: referenceDate)
+        ) ?? referenceDate
+        let start = calendar.date(
+            byAdding: .day,
+            value: -(Constants.analysisDays - 1),
+            to: calendar.startOfDay(for: referenceDate)
+        ) ?? referenceDate
+        return DateInterval(start: start, end: end)
+    }
+
+    private func aggregateDailyTotals(from events: [HydrationEvent]) -> [Date: Int] {
+        events.reduce(into: [:]) { partialResult, event in
+            let dayStart = calendar.startOfDay(for: event.consumedAt)
+            partialResult[dayStart, default: 0] += event.volumeML
+        }
+    }
+}

--- a/Project/Domain/Tests/BodyProfileUseCaseTests.swift
+++ b/Project/Domain/Tests/BodyProfileUseCaseTests.swift
@@ -1,0 +1,63 @@
+import DomainLayer
+import DomainLayerInterface
+import Testing
+
+@Suite("BodyProfileUseCase Tests")
+struct BodyProfileUseCaseTests {
+    @Test("HealthKit 값이 있으면 그대로 resolved profile로 노출한다")
+    func resolvesHealthKitValues() async {
+        let healthKitRepository = MockHealthKitRepository()
+        healthKitRepository.setAuthorizationStatus(.sharingAuthorized)
+        healthKitRepository.setBodyProfile(
+            BodyProfile(
+                heightCM: BodyProfileValue(value: 172, source: .healthKit),
+                weightKG: BodyProfileValue(value: 64, source: .healthKit)
+            )
+        )
+
+        let useCase = BodyProfileUseCaseImpl(
+            healthKitRepository: healthKitRepository
+        )
+
+        let snapshot = await useCase.loadBodyProfile()
+
+        #expect(snapshot.availability == .ready)
+        #expect(snapshot.healthKitBodyProfile.heightCM?.value == 172)
+        #expect(snapshot.healthKitBodyProfile.weightKG?.value == 64)
+        #expect(snapshot.resolvedBodyProfile.heightCM?.source == .healthKit)
+        #expect(snapshot.resolvedBodyProfile.weightKG?.source == .healthKit)
+        #expect(snapshot.manualBodyProfile == .empty)
+    }
+
+    @Test("권한이 없고 값도 없으면 permission 상태를 노출한다")
+    func returnsPermissionStateWhenDenied() async {
+        let healthKitRepository = MockHealthKitRepository()
+        healthKitRepository.setAuthorizationStatus(.sharingDenied)
+
+        let useCase = BodyProfileUseCaseImpl(
+            healthKitRepository: healthKitRepository
+        )
+
+        let snapshot = await useCase.loadBodyProfile()
+
+        #expect(snapshot.availability == .permissionDenied)
+        #expect(snapshot.resolvedBodyProfile == .empty)
+    }
+
+    @Test("권한은 있지만 건강 앱 값이 없으면 noData를 노출한다")
+    func returnsNoDataWhenHealthKitProfileMissing() async {
+        let healthKitRepository = MockHealthKitRepository()
+        healthKitRepository.setAuthorizationStatus(.sharingAuthorized)
+        healthKitRepository.setBodyProfile(.empty)
+
+        let useCase = BodyProfileUseCaseImpl(
+            healthKitRepository: healthKitRepository
+        )
+
+        let snapshot = await useCase.loadBodyProfile()
+
+        #expect(snapshot.healthKitBodyProfile == .empty)
+        #expect(snapshot.resolvedBodyProfile == .empty)
+        #expect(snapshot.availability == .noData)
+    }
+}

--- a/Project/Domain/Tests/HydrationGoalRecommendationUseCaseTests.swift
+++ b/Project/Domain/Tests/HydrationGoalRecommendationUseCaseTests.swift
@@ -1,0 +1,115 @@
+import DomainLayer
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@Suite("HydrationGoalRecommendationUseCase Tests")
+struct HydrationGoalRecommendationUseCaseTests {
+    @Test("신체 정보가 비어 있으면 bodyProfileRequired를 반환한다")
+    func returnsBodyProfileRequiredWhenProfileMissing() async {
+        let bodyProfileUseCase = MockBodyProfileUseCaseForDomain(
+            snapshot: BodyProfileSnapshot(
+                authorizationStatus: .sharingAuthorized,
+                healthKitBodyProfile: .empty,
+                manualBodyProfile: .empty,
+                resolvedBodyProfile: .empty,
+                availability: .noData,
+                didFailHealthKitSync: false
+            )
+        )
+
+        let useCase = HydrationGoalRecommendationUseCaseImpl(
+            bodyProfileUseCase: bodyProfileUseCase,
+            drinkWaterRepository: MockDrinkWaterRepository(),
+            userPreferencesRepository: MockUserPreferencesRepository(),
+            recommendationRepository: MockHydrationGoalRecommendationRepository()
+        )
+
+        let availability = await useCase.availability(referenceDate: .now)
+
+        #expect(availability == .bodyProfileRequired(.noData))
+    }
+
+    @Test("모델이 준비되지 않으면 unavailable 상태를 반환한다")
+    func returnsModelUnavailableWhenModelUnavailable() async {
+        let recommendationRepository = MockHydrationGoalRecommendationRepository()
+        recommendationRepository.unavailableReason = .modelNotReady
+
+        let useCase = HydrationGoalRecommendationUseCaseImpl(
+            bodyProfileUseCase: MockBodyProfileUseCaseForDomain.ready,
+            drinkWaterRepository: MockDrinkWaterRepository(),
+            userPreferencesRepository: MockUserPreferencesRepository(),
+            recommendationRepository: recommendationRepository
+        )
+
+        let availability = await useCase.availability(referenceDate: .now)
+
+        #expect(availability == .modelUnavailable(.modelNotReady))
+    }
+
+    @Test("추천 생성 시 최근 7일 기록과 현재 목표를 입력으로 조합한다")
+    func buildsRecommendationInputFromRecentHistory() async throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 30))!
+
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        drinkWaterRepository.setHydrationEvents([
+            HydrationEvent(id: UUID(), consumedAt: calendar.date(byAdding: .day, value: -6, to: referenceDate)!, volumeML: 500),
+            HydrationEvent(id: UUID(), consumedAt: calendar.date(byAdding: .day, value: -5, to: referenceDate)!, volumeML: 1500),
+            HydrationEvent(id: UUID(), consumedAt: calendar.date(byAdding: .day, value: -1, to: referenceDate)!, volumeML: 2500),
+            HydrationEvent(id: UUID(), consumedAt: referenceDate, volumeML: 1000)
+        ])
+
+        let userPreferencesRepository = MockUserPreferencesRepository()
+        userPreferencesRepository.setDailyWaterLimit(2_000)
+
+        let recommendationRepository = MockHydrationGoalRecommendationRepository()
+
+        let useCase = HydrationGoalRecommendationUseCaseImpl(
+            bodyProfileUseCase: MockBodyProfileUseCaseForDomain.ready,
+            drinkWaterRepository: drinkWaterRepository,
+            userPreferencesRepository: userPreferencesRepository,
+            recommendationRepository: recommendationRepository,
+            calendar: calendar
+        )
+
+        _ = try await useCase.generateRecommendation(referenceDate: referenceDate)
+
+        #expect(recommendationRepository.capturedInput?.heightCM == 172)
+        #expect(recommendationRepository.capturedInput?.weightKG == 64)
+        #expect(recommendationRepository.capturedInput?.currentGoalML == 2_000)
+        #expect(recommendationRepository.capturedInput?.recentAverageIntakeML == 785)
+        #expect(recommendationRepository.capturedInput?.recentRecordedDays == 4)
+        #expect(recommendationRepository.capturedInput?.recentGoalAchievementDays == 1)
+        #expect(recommendationRepository.capturedInput?.analysisDays == 7)
+    }
+}
+
+private struct MockBodyProfileUseCaseForDomain: BodyProfileUseCase {
+    let snapshot: BodyProfileSnapshot
+
+    static let ready = MockBodyProfileUseCaseForDomain(
+        snapshot: BodyProfileSnapshot(
+            authorizationStatus: .sharingAuthorized,
+            healthKitBodyProfile: BodyProfile(
+                heightCM: BodyProfileValue(value: 172, source: .healthKit),
+                weightKG: BodyProfileValue(value: 64, source: .healthKit)
+            ),
+            manualBodyProfile: .empty,
+            resolvedBodyProfile: BodyProfile(
+                heightCM: BodyProfileValue(value: 172, source: .healthKit),
+                weightKG: BodyProfileValue(value: 64, source: .healthKit)
+            ),
+            availability: .ready,
+            didFailHealthKitSync: false
+        )
+    )
+
+    func loadBodyProfile() async -> BodyProfileSnapshot {
+        snapshot
+    }
+
+    func requestHealthKitSync() async throws -> BodyProfileSnapshot {
+        snapshot
+    }
+}

--- a/Project/Domain/Tests/Mock/MockHydrationGoalRecommendationRepository.swift
+++ b/Project/Domain/Tests/Mock/MockHydrationGoalRecommendationRepository.swift
@@ -1,0 +1,41 @@
+import DomainLayerInterface
+
+final class MockHydrationGoalRecommendationRepository: HydrationGoalRecommendationRepository, @unchecked Sendable {
+    var unavailableReason: HydrationGoalRecommendationUnavailableReason?
+    var recommendationToReturn = HydrationGoalRecommendation(
+        input: HydrationGoalRecommendationInput(
+            heightCM: 170,
+            weightKG: 60,
+            currentGoalML: 2_000,
+            recentAverageIntakeML: 1_500,
+            recentRecordedDays: 6,
+            recentGoalAchievementDays: 3,
+            analysisDays: 7
+        ),
+        recommendedLimitML: 2_250,
+        summary: "추천 요약",
+        reasons: ["이유 1", "이유 2"],
+        caution: nil
+    )
+    var generateRecommendationError: Error?
+
+    private(set) var generateRecommendationCallCount = 0
+    private(set) var capturedInput: HydrationGoalRecommendationInput?
+
+    func availability() -> HydrationGoalRecommendationUnavailableReason? {
+        unavailableReason
+    }
+
+    func generateRecommendation(
+        for input: HydrationGoalRecommendationInput
+    ) async throws -> HydrationGoalRecommendation {
+        generateRecommendationCallCount += 1
+        capturedInput = input
+
+        if let generateRecommendationError {
+            throw generateRecommendationError
+        }
+
+        return recommendationToReturn
+    }
+}

--- a/Project/Presentation/Sources/View/Profile/ProfileView.swift
+++ b/Project/Presentation/Sources/View/Profile/ProfileView.swift
@@ -5,15 +5,18 @@ import SwiftUI
 public struct ProfileView: View {
     @Bindable private var settingsViewModel: SettingsViewModel
     @Bindable private var bodyProfileViewModel: BodyProfileViewModel
+    @Bindable private var recommendationViewModel: HydrationGoalRecommendationViewModel
     @Bindable private var routineViewModel: ProfileRoutineViewModel
 
     public init(
         settingsViewModel: SettingsViewModel,
         bodyProfileViewModel: BodyProfileViewModel,
+        recommendationViewModel: HydrationGoalRecommendationViewModel,
         routineViewModel: ProfileRoutineViewModel
     ) {
         self.settingsViewModel = settingsViewModel
         self.bodyProfileViewModel = bodyProfileViewModel
+        self.recommendationViewModel = recommendationViewModel
         self.routineViewModel = routineViewModel
     }
 
@@ -44,7 +47,12 @@ public struct ProfileView: View {
                     }
 
                     NavigationLink {
-                        SettingDetailView(menu: .dailyLimit, viewModel: settingsViewModel)
+                        SettingDetailView(
+                            menu: .dailyLimit,
+                            viewModel: settingsViewModel,
+                            bodyProfileViewModel: bodyProfileViewModel,
+                            recommendationViewModel: recommendationViewModel
+                        )
                     } label: {
                         settingsRow(
                             title: L10n.tr("settingDailyLimitTitle"),

--- a/Project/Presentation/Sources/View/Settings/SettingDetailView.swift
+++ b/Project/Presentation/Sources/View/Settings/SettingDetailView.swift
@@ -15,15 +15,18 @@ public struct SettingDetailView: View {
     let menu: SettingMenu
     private let viewModel: SettingsViewModel
     private let bodyProfileViewModel: BodyProfileViewModel?
+    private let recommendationViewModel: HydrationGoalRecommendationViewModel?
     
     public init(
         menu: SettingMenu,
         viewModel: SettingsViewModel,
-        bodyProfileViewModel: BodyProfileViewModel? = nil
+        bodyProfileViewModel: BodyProfileViewModel? = nil,
+        recommendationViewModel: HydrationGoalRecommendationViewModel? = nil
     ) {
         self.menu = menu
         self.viewModel = viewModel
         self.bodyProfileViewModel = bodyProfileViewModel
+        self.recommendationViewModel = recommendationViewModel
     }
     
     public var body: some View {
@@ -36,7 +39,11 @@ public struct SettingDetailView: View {
                     EmptyView()
                 }
             case .dailyLimit:
-                DailyLimitSettingView(viewModel: viewModel)
+                DailyLimitSettingView(
+                    viewModel: viewModel,
+                    bodyProfileViewModel: bodyProfileViewModel,
+                    recommendationViewModel: recommendationViewModel
+                )
             case .mainIcon:
                 MainIconSettingView(viewModel: viewModel)
             case .withdrawal:
@@ -61,7 +68,6 @@ private struct BodyProfileSettingView: View {
             VStack(alignment: .leading, spacing: 20) {
                 summaryCard
                 healthSyncCard
-                manualInputCard
             }
             .padding()
         }
@@ -146,55 +152,6 @@ private struct BodyProfileSettingView: View {
                 ) {
                     await viewModel.requestHealthKitBodyProfile()
                 }
-            }
-        }
-        .padding()
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(Color(uiColor: .systemGray6))
-        )
-    }
-
-    private var manualInputCard: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text(L10n.tr("bodyProfileManualSectionTitle"))
-                .font(.headline)
-
-            Text(L10n.tr("bodyProfileManualSectionDescription"))
-                .font(.subheadline)
-                .foregroundColor(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            VStack(spacing: 12) {
-                TextField(
-                    L10n.tr("bodyProfileHeightPlaceholder"),
-                    text: $viewModel.heightInput
-                )
-                .keyboardType(.decimalPad)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .padding()
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(Color(uiColor: .secondarySystemBackground))
-                )
-
-                TextField(
-                    L10n.tr("bodyProfileWeightPlaceholder"),
-                    text: $viewModel.weightInput
-                )
-                .keyboardType(.decimalPad)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .padding()
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(Color(uiColor: .secondarySystemBackground))
-                )
-            }
-
-            secondaryButton(title: viewModel.manualSaveButtonTitle) {
-                viewModel.saveManualBodyProfile()
             }
         }
         .padding()
@@ -296,46 +253,421 @@ private struct BodyProfileSettingView: View {
 }
 
 private struct DailyLimitSettingView: View {
-    private let viewModel: SettingsViewModel
+    @Bindable private var viewModel: SettingsViewModel
+    private let bodyProfileViewModel: BodyProfileViewModel?
+    private let recommendationViewModel: HydrationGoalRecommendationViewModel?
     
-    init(viewModel: SettingsViewModel) {
+    init(
+        viewModel: SettingsViewModel,
+        bodyProfileViewModel: BodyProfileViewModel? = nil,
+        recommendationViewModel: HydrationGoalRecommendationViewModel? = nil
+    ) {
         self.viewModel = viewModel
+        self.bodyProfileViewModel = bodyProfileViewModel
+        self.recommendationViewModel = recommendationViewModel
     }
     
     var body: some View {
-        VStack(spacing: 20) {
-            HStack {
-                Text(L10n.tr("settingsDailyLimitValueFormat", Int(viewModel.dailyWaterLimit.rounded())))
-                    .font(.largeTitle)
-                    .fontWeight(.semibold)
-            }
-            
-            Slider(value: Binding(
-                get: { viewModel.dailyWaterLimit },
-                set: {
-                    viewModel.dailyWaterLimit = $0
+        ScrollView {
+            VStack(spacing: 20) {
+                if let recommendationViewModel {
+                    HydrationGoalRecommendationCard(
+                        settingsViewModel: viewModel,
+                        bodyProfileViewModel: bodyProfileViewModel,
+                        recommendationViewModel: recommendationViewModel
+                    )
                 }
-            ), in: 1000...4000, step: 250) {
-                Text(L10n.tr("settingsDailyLimitSliderTitle"))
+
+                VStack(spacing: 20) {
+                    HStack {
+                        Text(L10n.tr("settingsDailyLimitValueFormat", Int(viewModel.dailyWaterLimit.rounded())))
+                            .font(.largeTitle)
+                            .fontWeight(.semibold)
+                    }
+
+                    Slider(value: Binding(
+                        get: { viewModel.dailyWaterLimit },
+                        set: { newValue in
+                            viewModel.dailyWaterLimit = newValue
+                            recommendationViewModel?.clearRecommendation()
+                        }
+                    ), in: 1000...4000, step: 250) {
+                        Text(L10n.tr("settingsDailyLimitSliderTitle"))
+                    }
+                    .padding(.horizontal)
+
+                    HStack {
+                        Text(L10n.tr("commonMilliliterFormat", 1000))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        Text(L10n.tr("commonMilliliterFormat", 4000))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.horizontal)
+                }
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(Color(uiColor: .systemGray6))
+                )
             }
-            .padding(.horizontal)
-            
-            HStack {
-                Text(L10n.tr("commonMilliliterFormat", 1000))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                Spacer()
-                Text(L10n.tr("commonMilliliterFormat", 4000))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-            .padding(.horizontal)
-            
-            Spacer()
+            .padding()
         }
-        .padding()
         .navigationTitle(L10n.tr("settingDailyLimitTitle"))
         .navigationBarTitleDisplayMode(.inline)
+        .task {
+            if let recommendationViewModel {
+                await recommendationViewModel.load()
+            }
+        }
+    }
+}
+
+private struct HydrationGoalRecommendationCard: View {
+    private let settingsViewModel: SettingsViewModel
+    private let bodyProfileViewModel: BodyProfileViewModel?
+    @Bindable private var recommendationViewModel: HydrationGoalRecommendationViewModel
+
+    init(
+        settingsViewModel: SettingsViewModel,
+        bodyProfileViewModel: BodyProfileViewModel?,
+        recommendationViewModel: HydrationGoalRecommendationViewModel
+    ) {
+        self.settingsViewModel = settingsViewModel
+        self.bodyProfileViewModel = bodyProfileViewModel
+        self.recommendationViewModel = recommendationViewModel
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "sparkles")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundColor(.accentColor)
+
+                        Text(L10n.tr("hydrationGoalRecommendationTitle"))
+                            .font(.headline)
+                    }
+
+                    Text(L10n.tr("hydrationGoalRecommendationDescription"))
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+
+            }
+
+            content
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.accentColor.opacity(0.12),
+                            Color(uiColor: .systemGray6)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+        )
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch recommendationViewModel.state {
+        case .idle, .loading:
+            HStack(spacing: 12) {
+                ProgressView()
+                Text(L10n.tr("hydrationGoalRecommendationLoadingDescription"))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+        case .ready:
+            if let recommendation = recommendationViewModel.recommendation {
+                recommendationResultContent(recommendation)
+            } else {
+                VStack(alignment: .leading, spacing: 14) {
+                    Text(L10n.tr("hydrationGoalRecommendationReadyDescription"))
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    primaryAsyncButton(
+                        title: recommendationViewModel.isGenerating
+                            ? L10n.tr("hydrationGoalRecommendationGeneratingTitle")
+                            : L10n.tr("hydrationGoalRecommendationGenerateTitle"),
+                        isLoading: recommendationViewModel.isGenerating
+                    ) {
+                        await recommendationViewModel.generateRecommendation()
+                    }
+
+                    if let errorMessage = recommendationViewModel.errorMessage {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+        case let .bodyProfileRequired(availability):
+            VStack(alignment: .leading, spacing: 14) {
+                    Text(bodyProfileDescription(for: availability))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let bodyProfileViewModel {
+                    NavigationLink {
+                        SettingDetailView(
+                            menu: .bodyProfile,
+                            viewModel: settingsViewModel,
+                            bodyProfileViewModel: bodyProfileViewModel
+                        )
+                    } label: {
+                        actionLabel(
+                            title: L10n.tr("hydrationGoalRecommendationBodyProfileActionTitle"),
+                            fillsBackground: true
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        case let .modelUnavailable(reason):
+            VStack(alignment: .leading, spacing: 10) {
+                Text(unavailableDescription(for: reason))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(L10n.tr("hydrationGoalRecommendationUnavailableFootnote"))
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private func recommendationResultContent(_ recommendation: HydrationGoalRecommendation) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(L10n.tr("hydrationGoalRecommendationRecommendedLabel"))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Text(L10n.tr("commonMilliliterFormat", recommendation.recommendedLimitML))
+                    .font(.system(size: 34, weight: .bold))
+            }
+
+            Text(recommendation.summary)
+                .font(.subheadline)
+                .foregroundColor(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(recommendation.reasons, id: \.self) { reason in
+                    HStack(alignment: .top, spacing: 8) {
+                        Circle()
+                            .fill(Color.accentColor)
+                            .frame(width: 6, height: 6)
+                            .padding(.top, 6)
+
+                        Text(reason)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+
+            if let caution = recommendation.caution {
+                Text(caution)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            recommendationMetricGrid(for: recommendation.input)
+
+            VStack(spacing: 10) {
+                Button {
+                    settingsViewModel.dailyWaterLimit = Double(recommendation.recommendedLimitML)
+                } label: {
+                    actionLabel(
+                        title: L10n.tr("commonApplyTitle"),
+                        fillsBackground: true
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(Int(settingsViewModel.currentDailyWaterLimit.rounded()) == recommendation.recommendedLimitML)
+
+                    primaryAsyncButton(
+                        title: recommendationViewModel.isGenerating
+                            ? L10n.tr("hydrationGoalRecommendationGeneratingTitle")
+                            : L10n.tr("hydrationGoalRecommendationGenerateTitle"),
+                        isLoading: recommendationViewModel.isGenerating,
+                        filled: false
+                    ) {
+                        await recommendationViewModel.generateRecommendation()
+                    }
+            }
+        }
+    }
+
+    private func recommendationMetricGrid(for input: HydrationGoalRecommendationInput) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(L10n.tr("hydrationGoalRecommendationInputSectionTitle"))
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            LazyVGrid(
+                columns: [
+                    GridItem(.flexible(), spacing: 12),
+                    GridItem(.flexible(), spacing: 12)
+                ],
+                spacing: 12
+            ) {
+                metricCard(
+                    title: L10n.tr("hydrationGoalRecommendationCurrentGoalTitle"),
+                    value: L10n.tr("commonMilliliterFormat", input.currentGoalML)
+                )
+                metricCard(
+                    title: L10n.tr("hydrationGoalRecommendationAverageIntakeTitle"),
+                    value: L10n.tr("commonMilliliterFormat", input.recentAverageIntakeML)
+                )
+                metricCard(
+                    title: L10n.tr("hydrationGoalRecommendationBodyProfileTitle"),
+                    value: "\(input.heightCM)cm · \(input.weightKG)kg"
+                )
+                metricCard(
+                    title: L10n.tr("hydrationGoalRecommendationGoalAchievementTitle"),
+                    value: L10n.tr(
+                        "hydrationGoalRecommendationGoalAchievementValueFormat",
+                        input.recentGoalAchievementDays,
+                        input.analysisDays
+                    )
+                )
+            }
+        }
+    }
+
+    private func metricCard(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Text(value)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundColor(.primary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(uiColor: .secondarySystemBackground))
+        )
+    }
+
+    private func bodyProfileDescription(for availability: BodyProfileAvailability) -> String {
+        switch availability {
+        case .needsPermission:
+            L10n.tr("bodyProfilePermissionNeededDescription")
+        case .permissionDenied:
+            L10n.tr("bodyProfilePermissionDeniedDescription")
+        case .noData:
+            L10n.tr("bodyProfileNoDataDescription")
+        case .incomplete:
+            L10n.tr("bodyProfileIncompleteDescription")
+        case .ready:
+            L10n.tr("hydrationGoalRecommendationReadyDescription")
+        }
+    }
+
+    private func unavailableDescription(
+        for reason: HydrationGoalRecommendationUnavailableReason
+    ) -> String {
+        switch reason {
+        case .deviceNotEligible:
+            L10n.tr("hydrationGoalRecommendationDeviceUnavailableDescription")
+        case .appleIntelligenceNotEnabled:
+            L10n.tr("hydrationGoalRecommendationAppleIntelligenceDisabledDescription")
+        case .modelNotReady:
+            L10n.tr("hydrationGoalRecommendationModelNotReadyDescription")
+        case .unsupportedLocale:
+            L10n.tr("hydrationGoalRecommendationUnsupportedLocaleDescription")
+        case .unknown:
+            L10n.tr("hydrationGoalRecommendationUnknownUnavailableDescription")
+        }
+    }
+
+    private func actionLabel(title: String, fillsBackground: Bool) -> some View {
+        Text(title)
+            .fontWeight(.semibold)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(fillsBackground ? Color.accentColor : Color.clear)
+            )
+            .foregroundColor(fillsBackground ? .white : .accentColor)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(
+                        fillsBackground ? Color.clear : Color.accentColor.opacity(0.3),
+                        lineWidth: 1
+                    )
+            )
+    }
+
+    private func primaryAsyncButton(
+        title: String,
+        isLoading: Bool,
+        filled: Bool = true,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button {
+            Task {
+                await action()
+            }
+        } label: {
+            HStack {
+                Spacer()
+
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(filled ? .white : .accentColor)
+                } else {
+                    Text(title)
+                        .fontWeight(.semibold)
+                }
+
+                Spacer()
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(filled ? Color.accentColor : Color.clear)
+            )
+            .foregroundColor(filled ? .white : .accentColor)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(
+                        filled ? Color.clear : Color.accentColor.opacity(0.3),
+                        lineWidth: 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(isLoading)
     }
 }
 

--- a/Project/Presentation/Sources/ViewModel/BodyProfileViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/BodyProfileViewModel.swift
@@ -13,52 +13,28 @@ import Observation
 @Observable
 @MainActor
 public final class BodyProfileViewModel {
-    public enum AvailabilityState: Equatable {
-        case ready
-        case needsPermission
-        case permissionDenied
-        case noData
-        case incomplete
-    }
-
     public private(set) var authorizationStatus: HealthKitAuthorizationStatus
     public private(set) var resolvedBodyProfile: BodyProfile = .empty
     public private(set) var healthKitBodyProfile: BodyProfile = .empty
-    public private(set) var manualBodyProfile: BodyProfile = .empty
     public private(set) var isLoading = false
     public private(set) var hasLoaded = false
-    public var heightInput = ""
-    public var weightInput = ""
     public var errorMessage: String?
 
-    private let healthKitUseCase: HealthKitUseCase
-    private let userPreferencesUseCase: UserPreferencesUseCase
+    private let bodyProfileUseCase: BodyProfileUseCase
 
     public init(
-        healthKitUseCase: HealthKitUseCase,
-        userPreferencesUseCase: UserPreferencesUseCase
+        bodyProfileUseCase: BodyProfileUseCase
     ) {
-        self.healthKitUseCase = healthKitUseCase
-        self.userPreferencesUseCase = userPreferencesUseCase
-        self.authorizationStatus = healthKitUseCase.authorisationStatus
+        self.bodyProfileUseCase = bodyProfileUseCase
+        self.authorizationStatus = .notDetermined
     }
 
-    public var availabilityState: AvailabilityState {
+    public var availabilityState: BodyProfileAvailability {
         if resolvedBodyProfile.isComplete {
             return .ready
         }
 
-        switch authorizationStatus {
-        case .notDetermined:
-            return .needsPermission
-        case .sharingDenied:
-            return .permissionDenied
-        case .sharingAuthorized:
-            if healthKitBodyProfile.isEmpty && manualBodyProfile.isEmpty {
-                return .noData
-            }
-            return .incomplete
-        }
+        return currentSnapshot?.availability ?? .needsPermission
     }
 
     public var summaryText: String {
@@ -112,11 +88,7 @@ public final class BodyProfileViewModel {
         sourceText(for: resolvedBodyProfile.weightKG?.source)
     }
 
-    public var manualSaveButtonTitle: String {
-        manualBodyProfile.isEmpty
-            ? L10n.tr("bodyProfileSaveManualTitle")
-            : L10n.tr("bodyProfileSaveManualChangesTitle")
-    }
+    private var currentSnapshot: BodyProfileSnapshot?
 
     public func load() async {
         guard !hasLoaded else {
@@ -130,18 +102,12 @@ public final class BodyProfileViewModel {
 
     public func refresh() async {
         isLoading = true
-        authorizationStatus = healthKitUseCase.authorisationStatus
-        manualBodyProfile = userPreferencesUseCase.getManualBodyProfile()
-        syncInputsFromManualProfile()
         errorMessage = nil
-
-        if authorizationStatus == .sharingAuthorized {
-            await refreshHealthKitBodyProfile()
-        } else {
-            healthKitBodyProfile = .empty
-            updateResolvedProfile()
+        let snapshot = await bodyProfileUseCase.loadBodyProfile()
+        apply(snapshot)
+        if snapshot.didFailHealthKitSync {
+            errorMessage = L10n.tr("bodyProfileHealthSyncFailureDescription")
         }
-
         isLoading = false
     }
 
@@ -149,70 +115,30 @@ public final class BodyProfileViewModel {
         isLoading = true
         errorMessage = nil
 
-        if authorizationStatus == .notDetermined {
-            do {
-                try await healthKitUseCase.requestAuthorization()
-            } catch {
-                authorizationStatus = healthKitUseCase.authorisationStatus
-                errorMessage = L10n.tr("bodyProfilePermissionRequestFailureDescription")
-                updateResolvedProfile()
-                isLoading = false
-                return
+        do {
+            let snapshot = try await bodyProfileUseCase.requestHealthKitSync()
+            apply(snapshot)
+
+            if snapshot.authorizationStatus != .sharingAuthorized {
+                errorMessage = L10n.tr("bodyProfilePermissionDeniedDescription")
+            } else if snapshot.didFailHealthKitSync {
+                errorMessage = L10n.tr("bodyProfileHealthSyncFailureDescription")
             }
-        }
-
-        authorizationStatus = healthKitUseCase.authorisationStatus
-
-        guard authorizationStatus == .sharingAuthorized else {
-            errorMessage = L10n.tr("bodyProfilePermissionDeniedDescription")
-            updateResolvedProfile()
+        } catch {
+            let snapshot = await bodyProfileUseCase.loadBodyProfile()
+            apply(snapshot)
+            errorMessage = L10n.tr("bodyProfilePermissionRequestFailureDescription")
             isLoading = false
             return
         }
-
-        await refreshHealthKitBodyProfile()
         isLoading = false
     }
 
-    public func saveManualBodyProfile() {
-        let height = parseInput(heightInput)
-        let weight = parseInput(weightInput)
-
-        guard height.isValid, weight.isValid else {
-            errorMessage = L10n.tr("bodyProfileManualInputValidationDescription")
-            return
-        }
-
-        let profile = BodyProfile(
-            heightCM: height.value.map { BodyProfileValue(value: $0, source: .manual) },
-            weightKG: weight.value.map { BodyProfileValue(value: $0, source: .manual) }
-        )
-
-        userPreferencesUseCase.setManualBodyProfile(profile)
-        manualBodyProfile = userPreferencesUseCase.getManualBodyProfile()
-        syncInputsFromManualProfile()
-        updateResolvedProfile()
-        errorMessage = nil
-    }
-
-    private func refreshHealthKitBodyProfile() async {
-        do {
-            healthKitBodyProfile = try await healthKitUseCase.fetchBodyProfile()
-        } catch {
-            healthKitBodyProfile = .empty
-            errorMessage = L10n.tr("bodyProfileHealthSyncFailureDescription")
-        }
-
-        updateResolvedProfile()
-    }
-
-    private func updateResolvedProfile() {
-        resolvedBodyProfile = manualBodyProfile.merging(preferred: healthKitBodyProfile)
-    }
-
-    private func syncInputsFromManualProfile() {
-        heightInput = manualBodyProfile.heightCM.map { Self.inputText(for: $0.value) } ?? ""
-        weightInput = manualBodyProfile.weightKG.map { Self.inputText(for: $0.value) } ?? ""
+    private func apply(_ snapshot: BodyProfileSnapshot) {
+        currentSnapshot = snapshot
+        authorizationStatus = snapshot.authorizationStatus
+        healthKitBodyProfile = snapshot.healthKitBodyProfile
+        resolvedBodyProfile = snapshot.resolvedBodyProfile
     }
 
     private func sourceText(for source: BodyProfileSource?) -> String? {
@@ -226,25 +152,25 @@ public final class BodyProfileViewModel {
         }
     }
 
-    private func parseInput(_ value: String) -> (value: Double?, isValid: Bool) {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard !trimmed.isEmpty else {
-            return (nil, true)
+    private func currentAvailability(
+        authorizationStatus: HealthKitAuthorizationStatus,
+        healthKitBodyProfile: BodyProfile,
+        resolvedBodyProfile: BodyProfile
+    ) -> BodyProfileAvailability {
+        if resolvedBodyProfile.isComplete {
+            return .ready
         }
 
-        guard let number = Double(trimmed), number > 0 else {
-            return (nil, false)
+        switch authorizationStatus {
+        case .notDetermined:
+            return .needsPermission
+        case .sharingDenied:
+            return .permissionDenied
+        case .sharingAuthorized:
+            if healthKitBodyProfile.isEmpty {
+                return .noData
+            }
+            return .incomplete
         }
-
-        return (number, true)
-    }
-
-    private static func inputText(for value: Double) -> String {
-        if value.rounded(.towardZero) == value {
-            return String(Int(value))
-        }
-
-        return String(value)
     }
 }

--- a/Project/Presentation/Sources/ViewModel/HydrationGoalRecommendationViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationGoalRecommendationViewModel.swift
@@ -1,0 +1,89 @@
+//
+//  HydrationGoalRecommendationViewModel.swift
+//  PresentationLayer
+//
+//  Created by Codex on 3/30/26.
+//
+
+import DomainLayerInterface
+import Foundation
+import Localization
+import Observation
+
+@Observable
+@MainActor
+public final class HydrationGoalRecommendationViewModel {
+    public enum State: Equatable {
+        case idle
+        case loading
+        case ready
+        case bodyProfileRequired(BodyProfileAvailability)
+        case modelUnavailable(HydrationGoalRecommendationUnavailableReason)
+    }
+
+    public private(set) var state: State = .idle
+    public private(set) var recommendation: HydrationGoalRecommendation?
+    public private(set) var isGenerating = false
+    public private(set) var errorMessage: String?
+
+    private let useCase: HydrationGoalRecommendationUseCase
+
+    public init(useCase: HydrationGoalRecommendationUseCase) {
+        self.useCase = useCase
+    }
+
+    public func load() async {
+        state = .loading
+        errorMessage = nil
+        recommendation = nil
+        state = map(await useCase.availability(referenceDate: .now))
+    }
+
+    public func generateRecommendation() async {
+        errorMessage = nil
+
+        let availability = await useCase.availability(referenceDate: .now)
+        let mappedState = map(availability)
+        state = mappedState
+
+        guard case .ready = availability else {
+            recommendation = nil
+            return
+        }
+
+        isGenerating = true
+        defer { isGenerating = false }
+
+        do {
+            recommendation = try await useCase.generateRecommendation(referenceDate: .now)
+            state = .ready
+        } catch let error as HydrationGoalRecommendationError {
+            recommendation = nil
+            switch error {
+            case let .bodyProfileRequired(availability):
+                state = .bodyProfileRequired(availability)
+            case let .modelUnavailable(reason):
+                state = .modelUnavailable(reason)
+            }
+        } catch {
+            recommendation = nil
+            errorMessage = L10n.tr("hydrationGoalRecommendationGenerationFailureDescription")
+        }
+    }
+
+    public func clearRecommendation() {
+        recommendation = nil
+        errorMessage = nil
+    }
+
+    private func map(_ availability: HydrationGoalRecommendationAvailability) -> State {
+        switch availability {
+        case .ready:
+            .ready
+        case let .bodyProfileRequired(value):
+            .bodyProfileRequired(value)
+        case let .modelUnavailable(reason):
+            .modelUnavailable(reason)
+        }
+    }
+}

--- a/Project/Presentation/Tests/BodyProfileViewModelTests.swift
+++ b/Project/Presentation/Tests/BodyProfileViewModelTests.swift
@@ -8,24 +8,29 @@ import Testing
 @Suite("BodyProfileViewModel Tests")
 struct BodyProfileViewModelTests {
     @MainActor
-    @Test("HealthKit 값이 있으면 직접 입력값보다 우선한다")
-    func healthKitPreferredOverManualInput() async {
-        let healthKitUseCase = MockHealthKitUseCase()
-        healthKitUseCase.authorizationStatusValue = .sharingAuthorized
-        healthKitUseCase.bodyProfileToReturn = BodyProfile(
-            heightCM: BodyProfileValue(value: 172, source: .healthKit),
-            weightKG: BodyProfileValue(value: 64, source: .healthKit)
-        )
-
-        let userPreferencesUseCase = MockUserPreferencesUseCase()
-        userPreferencesUseCase.manualBodyProfileValue = BodyProfile(
-            heightCM: BodyProfileValue(value: 168, source: .manual),
-            weightKG: BodyProfileValue(value: 60, source: .manual)
+    @Test("HealthKit 값이 있으면 건강 앱 값을 그대로 노출한다")
+    func loadHealthKitProfile() async {
+        let bodyProfileUseCase = MockBodyProfileUseCase()
+        bodyProfileUseCase.snapshot = BodyProfileSnapshot(
+            authorizationStatus: .sharingAuthorized,
+            healthKitBodyProfile: BodyProfile(
+                heightCM: BodyProfileValue(value: 172, source: .healthKit),
+                weightKG: BodyProfileValue(value: 64, source: .healthKit)
+            ),
+            manualBodyProfile: BodyProfile(
+                heightCM: BodyProfileValue(value: 168, source: .manual),
+                weightKG: BodyProfileValue(value: 60, source: .manual)
+            ),
+            resolvedBodyProfile: BodyProfile(
+                heightCM: BodyProfileValue(value: 172, source: .healthKit),
+                weightKG: BodyProfileValue(value: 64, source: .healthKit)
+            ),
+            availability: .ready,
+            didFailHealthKitSync: false
         )
 
         let viewModel = BodyProfileViewModel(
-            healthKitUseCase: healthKitUseCase,
-            userPreferencesUseCase: userPreferencesUseCase
+            bodyProfileUseCase: bodyProfileUseCase
         )
 
         await viewModel.load()
@@ -38,40 +43,45 @@ struct BodyProfileViewModelTests {
     }
 
     @MainActor
-    @Test("HealthKit 값이 없으면 직접 입력값으로 fallback 한다")
-    func manualFallbackWhenHealthKitMissing() async {
-        let healthKitUseCase = MockHealthKitUseCase()
-        healthKitUseCase.authorizationStatusValue = .sharingAuthorized
-        healthKitUseCase.bodyProfileToReturn = .empty
-
-        let userPreferencesUseCase = MockUserPreferencesUseCase()
-        userPreferencesUseCase.manualBodyProfileValue = BodyProfile(
-            heightCM: BodyProfileValue(value: 165, source: .manual),
-            weightKG: BodyProfileValue(value: 55, source: .manual)
+    @Test("HealthKit 값이 없으면 noData 상태를 노출한다")
+    func noDataStateWhenHealthKitMissing() async {
+        let bodyProfileUseCase = MockBodyProfileUseCase()
+        bodyProfileUseCase.snapshot = BodyProfileSnapshot(
+            authorizationStatus: .sharingAuthorized,
+            healthKitBodyProfile: .empty,
+            manualBodyProfile: .empty,
+            resolvedBodyProfile: .empty,
+            availability: .noData,
+            didFailHealthKitSync: false
         )
 
         let viewModel = BodyProfileViewModel(
-            healthKitUseCase: healthKitUseCase,
-            userPreferencesUseCase: userPreferencesUseCase
+            bodyProfileUseCase: bodyProfileUseCase
         )
 
         await viewModel.load()
 
-        #expect(viewModel.availabilityState == .ready)
-        #expect(viewModel.heightSourceText == L10n.tr("bodyProfileSourceManual"))
-        #expect(viewModel.weightSourceText == L10n.tr("bodyProfileSourceManual"))
-        #expect(viewModel.summaryText == "\(L10n.tr("bodyProfileHeightValueFormat", 165)) · \(L10n.tr("bodyProfileWeightValueFormat", 55))")
+        #expect(viewModel.availabilityState == .noData)
+        #expect(viewModel.heightSourceText == nil)
+        #expect(viewModel.weightSourceText == nil)
+        #expect(viewModel.summaryText == L10n.tr("bodyProfileSummaryNeedsInput"))
     }
 
     @MainActor
     @Test("권한이 없고 값도 비어 있으면 permission 상태를 노출한다")
     func permissionStateWhenNoProfileExists() async {
-        let healthKitUseCase = MockHealthKitUseCase()
-        healthKitUseCase.authorizationStatusValue = .sharingDenied
+        let bodyProfileUseCase = MockBodyProfileUseCase()
+        bodyProfileUseCase.snapshot = BodyProfileSnapshot(
+            authorizationStatus: .sharingDenied,
+            healthKitBodyProfile: .empty,
+            manualBodyProfile: .empty,
+            resolvedBodyProfile: .empty,
+            availability: .permissionDenied,
+            didFailHealthKitSync: false
+        )
 
         let viewModel = BodyProfileViewModel(
-            healthKitUseCase: healthKitUseCase,
-            userPreferencesUseCase: MockUserPreferencesUseCase()
+            bodyProfileUseCase: bodyProfileUseCase
         )
 
         await viewModel.load()
@@ -81,40 +91,25 @@ struct BodyProfileViewModelTests {
     }
 
     @MainActor
-    @Test("권한은 있지만 건강 앱과 직접 입력 값이 모두 없으면 noData 상태를 노출한다")
+    @Test("권한은 있지만 건강 앱 값이 없으면 noData 상태를 노출한다")
     func noDataStateWhenAuthorizedButEmpty() async {
-        let healthKitUseCase = MockHealthKitUseCase()
-        healthKitUseCase.authorizationStatusValue = .sharingAuthorized
-        healthKitUseCase.bodyProfileToReturn = .empty
+        let bodyProfileUseCase = MockBodyProfileUseCase()
+        bodyProfileUseCase.snapshot = BodyProfileSnapshot(
+            authorizationStatus: .sharingAuthorized,
+            healthKitBodyProfile: .empty,
+            manualBodyProfile: .empty,
+            resolvedBodyProfile: .empty,
+            availability: .noData,
+            didFailHealthKitSync: false
+        )
 
         let viewModel = BodyProfileViewModel(
-            healthKitUseCase: healthKitUseCase,
-            userPreferencesUseCase: MockUserPreferencesUseCase()
+            bodyProfileUseCase: bodyProfileUseCase
         )
 
         await viewModel.load()
 
         #expect(viewModel.availabilityState == .noData)
         #expect(viewModel.helperText == L10n.tr("bodyProfileNoDataDescription"))
-    }
-
-    @MainActor
-    @Test("직접 입력 저장 시 UseCase와 상태를 함께 갱신한다")
-    func saveManualBodyProfile() {
-        let userPreferencesUseCase = MockUserPreferencesUseCase()
-        let viewModel = BodyProfileViewModel(
-            healthKitUseCase: MockHealthKitUseCase(),
-            userPreferencesUseCase: userPreferencesUseCase
-        )
-
-        viewModel.heightInput = "171"
-        viewModel.weightInput = "59"
-        viewModel.saveManualBodyProfile()
-
-        #expect(userPreferencesUseCase.setManualBodyProfileCallCount == 1)
-        #expect(userPreferencesUseCase.capturedManualBodyProfile?.heightCM?.value == 171)
-        #expect(userPreferencesUseCase.capturedManualBodyProfile?.weightKG?.value == 59)
-        #expect(viewModel.heightSourceText == L10n.tr("bodyProfileSourceManual"))
-        #expect(viewModel.weightSourceText == L10n.tr("bodyProfileSourceManual"))
     }
 }

--- a/Project/Presentation/Tests/HydrationGoalRecommendationViewModelTests.swift
+++ b/Project/Presentation/Tests/HydrationGoalRecommendationViewModelTests.swift
@@ -1,0 +1,68 @@
+import DomainLayerInterface
+import Localization
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("HydrationGoalRecommendationViewModel Tests")
+struct HydrationGoalRecommendationViewModelTests {
+    @MainActor
+    @Test("준비 가능 상태를 로드한다")
+    func loadReadyState() async {
+        let useCase = MockHydrationGoalRecommendationUseCase()
+        useCase.availabilityValue = .ready
+
+        let viewModel = HydrationGoalRecommendationViewModel(useCase: useCase)
+
+        await viewModel.load()
+
+        #expect(viewModel.state == .ready)
+        #expect(viewModel.recommendation == nil)
+        #expect(useCase.availabilityCallCount == 1)
+    }
+
+    @MainActor
+    @Test("신체 정보가 부족하면 입력 유도 상태를 노출한다")
+    func loadBodyProfileRequiredState() async {
+        let useCase = MockHydrationGoalRecommendationUseCase()
+        useCase.availabilityValue = .bodyProfileRequired(.incomplete)
+
+        let viewModel = HydrationGoalRecommendationViewModel(useCase: useCase)
+
+        await viewModel.load()
+
+        #expect(viewModel.state == .bodyProfileRequired(.incomplete))
+    }
+
+    @MainActor
+    @Test("추천 생성 성공 시 결과를 저장한다")
+    func generateRecommendationSuccess() async {
+        let useCase = MockHydrationGoalRecommendationUseCase()
+        let viewModel = HydrationGoalRecommendationViewModel(useCase: useCase)
+
+        await viewModel.generateRecommendation()
+
+        #expect(viewModel.state == .ready)
+        #expect(viewModel.recommendation?.recommendedLimitML == 2_250)
+        #expect(viewModel.errorMessage == nil)
+        #expect(useCase.generateRecommendationCallCount == 1)
+    }
+
+    @MainActor
+    @Test("추천 생성 실패 시 공통 에러 메시지를 노출한다")
+    func generateRecommendationFailure() async {
+        struct DummyError: Error {}
+
+        let useCase = MockHydrationGoalRecommendationUseCase()
+        useCase.generateError = DummyError()
+
+        let viewModel = HydrationGoalRecommendationViewModel(useCase: useCase)
+
+        await viewModel.generateRecommendation()
+
+        #expect(viewModel.recommendation == nil)
+        #expect(
+            viewModel.errorMessage == L10n.tr("hydrationGoalRecommendationGenerationFailureDescription")
+        )
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockBodyProfileUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockBodyProfileUseCase.swift
@@ -1,0 +1,29 @@
+import DomainLayerInterface
+
+final class MockBodyProfileUseCase: BodyProfileUseCase, @unchecked Sendable {
+    var snapshot = BodyProfileSnapshot(
+        authorizationStatus: .notDetermined,
+        healthKitBodyProfile: .empty,
+        manualBodyProfile: .empty,
+        resolvedBodyProfile: .empty,
+        availability: .needsPermission,
+        didFailHealthKitSync: false
+    )
+    var requestHealthKitSyncError: Error?
+
+    private(set) var loadBodyProfileCallCount = 0
+    private(set) var requestHealthKitSyncCallCount = 0
+
+    func loadBodyProfile() async -> BodyProfileSnapshot {
+        loadBodyProfileCallCount += 1
+        return snapshot
+    }
+
+    func requestHealthKitSync() async throws -> BodyProfileSnapshot {
+        requestHealthKitSyncCallCount += 1
+        if let requestHealthKitSyncError {
+            throw requestHealthKitSyncError
+        }
+        return snapshot
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockHydrationGoalRecommendationUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockHydrationGoalRecommendationUseCase.swift
@@ -1,0 +1,41 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockHydrationGoalRecommendationUseCase: HydrationGoalRecommendationUseCase, @unchecked Sendable {
+    var availabilityValue: HydrationGoalRecommendationAvailability = .ready
+    var recommendationValue = HydrationGoalRecommendation(
+        input: HydrationGoalRecommendationInput(
+            heightCM: 172,
+            weightKG: 64,
+            currentGoalML: 2_000,
+            recentAverageIntakeML: 1_700,
+            recentRecordedDays: 6,
+            recentGoalAchievementDays: 4,
+            analysisDays: 7
+        ),
+        recommendedLimitML: 2_250,
+        summary: "최근 기록을 기준으로 현재 목표를 조금 올리는 정도가 적절해 보여요.",
+        reasons: [
+            "최근 평균 섭취량이 현재 목표에 가까워요.",
+            "신체 정보 기준으로 급격한 변화보다 완만한 조정이 자연스러워요."
+        ],
+        caution: "추천값은 참고용이에요."
+    )
+    var generateError: Error?
+
+    private(set) var availabilityCallCount = 0
+    private(set) var generateRecommendationCallCount = 0
+
+    func availability(referenceDate: Date) async -> HydrationGoalRecommendationAvailability {
+        availabilityCallCount += 1
+        return availabilityValue
+    }
+
+    func generateRecommendation(referenceDate: Date) async throws -> HydrationGoalRecommendation {
+        generateRecommendationCallCount += 1
+        if let generateError {
+            throw generateError
+        }
+        return recommendationValue
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockBodyProfileUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockBodyProfileUseCase.swift
@@ -1,0 +1,35 @@
+//
+//  MockBodyProfileUseCase.swift
+//  DependencyInjectionPreview
+//
+//  Created by Codex on 3/30/26.
+//
+
+import DomainLayerInterface
+
+public final class MockBodyProfileUseCase: BodyProfileUseCase, @unchecked Sendable {
+    public var snapshot: BodyProfileSnapshot = BodyProfileSnapshot(
+        authorizationStatus: .sharingAuthorized,
+        healthKitBodyProfile: BodyProfile(
+            heightCM: BodyProfileValue(value: 172, source: .healthKit),
+            weightKG: BodyProfileValue(value: 64, source: .healthKit)
+        ),
+        manualBodyProfile: .empty,
+        resolvedBodyProfile: BodyProfile(
+            heightCM: BodyProfileValue(value: 172, source: .healthKit),
+            weightKG: BodyProfileValue(value: 64, source: .healthKit)
+        ),
+        availability: .ready,
+        didFailHealthKitSync: false
+    )
+
+    public init() {}
+
+    public func loadBodyProfile() async -> BodyProfileSnapshot {
+        snapshot
+    }
+
+    public func requestHealthKitSync() async throws -> BodyProfileSnapshot {
+        snapshot
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockHydrationGoalRecommendationUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockHydrationGoalRecommendationUseCase.swift
@@ -1,0 +1,45 @@
+//
+//  MockHydrationGoalRecommendationUseCase.swift
+//  DependencyInjectionPreview
+//
+//  Created by Codex on 3/30/26.
+//
+
+import DomainLayerInterface
+import Foundation
+
+public final class MockHydrationGoalRecommendationUseCase: HydrationGoalRecommendationUseCase, @unchecked Sendable {
+    public var availabilityValue: HydrationGoalRecommendationAvailability = .ready
+    public var recommendationValue = HydrationGoalRecommendation(
+        input: HydrationGoalRecommendationInput(
+            heightCM: 172,
+            weightKG: 64,
+            currentGoalML: 2_000,
+            recentAverageIntakeML: 1_650,
+            recentRecordedDays: 6,
+            recentGoalAchievementDays: 3,
+            analysisDays: 7
+        ),
+        recommendedLimitML: 2_250,
+        summary: "최근 일주일 섭취량보다 조금 높은 목표가 안정적으로 유지되기 좋아요.",
+        reasons: [
+            "최근 평균 섭취량과 현재 목표의 차이가 크지 않아요.",
+            "신체 정보 기준으로 현재 목표를 약간 올리는 정도가 무리가 적어요."
+        ],
+        caution: "추천값은 참고용이에요. 컨디션에 따라 조정해 주세요."
+    )
+    public var generateError: Error?
+
+    public init() {}
+
+    public func availability(referenceDate: Date) async -> HydrationGoalRecommendationAvailability {
+        availabilityValue
+    }
+
+    public func generateRecommendation(referenceDate: Date) async throws -> HydrationGoalRecommendation {
+        if let generateError {
+            throw generateError
+        }
+        return recommendationValue
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -22,6 +22,14 @@ public final class PreviewAssembly: Assembly {
             MockHealthKitUseCase()
         }
 
+        container.register(BodyProfileUseCase.self) { _ in
+            MockBodyProfileUseCase()
+        }
+
+        container.register(HydrationGoalRecommendationUseCase.self) { _ in
+            MockHydrationGoalRecommendationUseCase()
+        }
+
         container.register(UserPreferencesUseCase.self) { _ in
             MockUserPreferencesUseCase()
         }
@@ -119,10 +127,20 @@ public final class PreviewAssembly: Assembly {
         .inObjectScope(.container)
 
         container.register(BodyProfileViewModel.self) { resolver in
-            BodyProfileViewModel(
-                healthKitUseCase: resolver.resolve(HealthKitUseCase.self)!,
-                userPreferencesUseCase: resolver.resolve(UserPreferencesUseCase.self)!
-            )
+            MainActor.assumeIsolated {
+                BodyProfileViewModel(
+                    bodyProfileUseCase: resolver.resolve(BodyProfileUseCase.self)!
+                )
+            }
+        }
+        .inObjectScope(.container)
+
+        container.register(HydrationGoalRecommendationViewModel.self) { resolver in
+            MainActor.assumeIsolated {
+                HydrationGoalRecommendationViewModel(
+                    useCase: resolver.resolve(HydrationGoalRecommendationUseCase.self)!
+                )
+            }
         }
         .inObjectScope(.container)
 

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewViewModelFactory.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewViewModelFactory.swift
@@ -35,10 +35,12 @@ public struct PreviewViews {
     public static var profile: some View {
         let settingsViewModel = DIContainer.preview.resolve(SettingsViewModel.self)
         let bodyProfileViewModel = DIContainer.preview.resolve(BodyProfileViewModel.self)
+        let recommendationViewModel = DIContainer.preview.resolve(HydrationGoalRecommendationViewModel.self)
         let routineViewModel = DIContainer.preview.resolve(ProfileRoutineViewModel.self)
         return ProfileView(
             settingsViewModel: settingsViewModel,
             bodyProfileViewModel: bodyProfileViewModel,
+            recommendationViewModel: recommendationViewModel,
             routineViewModel: routineViewModel
         )
     }

--- a/Project/Shared/DependencyInjection/Sources/Preview/ViewPreviews.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/ViewPreviews.swift
@@ -38,10 +38,12 @@ import SwiftUI
 #Preview("ProfileView") {
     let settingsViewModel = DIContainer.preview.resolve(SettingsViewModel.self)
     let bodyProfileViewModel = DIContainer.preview.resolve(BodyProfileViewModel.self)
+    let recommendationViewModel = DIContainer.preview.resolve(HydrationGoalRecommendationViewModel.self)
     let routineViewModel = DIContainer.preview.resolve(ProfileRoutineViewModel.self)
     ProfileView(
         settingsViewModel: settingsViewModel,
         bodyProfileViewModel: bodyProfileViewModel,
+        recommendationViewModel: recommendationViewModel,
         routineViewModel: routineViewModel
     )
 }
@@ -75,8 +77,15 @@ import SwiftUI
 
 // MARK: - SettingDetailView Previews
 #Preview("DailyLimit Setting") {
-    let viewModel = DIContainer.preview.resolve(SettingsViewModel.self)
-    SettingDetailView(menu: .dailyLimit, viewModel: viewModel)
+    let settingsViewModel = DIContainer.preview.resolve(SettingsViewModel.self)
+    let bodyProfileViewModel = DIContainer.preview.resolve(BodyProfileViewModel.self)
+    let recommendationViewModel = DIContainer.preview.resolve(HydrationGoalRecommendationViewModel.self)
+    SettingDetailView(
+        menu: .dailyLimit,
+        viewModel: settingsViewModel,
+        bodyProfileViewModel: bodyProfileViewModel,
+        recommendationViewModel: recommendationViewModel
+    )
 }
 
 #Preview("BodyProfile Setting") {

--- a/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
@@ -48,6 +48,16 @@ public final class DataAssembly: Assembly {
             )
         }
 
+        container.register(HydrationGoalRecommendationDataSource.self) { _ in
+            FoundationModelsHydrationGoalRecommendationDataSource()
+        }
+
+        container.register(HydrationGoalRecommendationRepository.self) { resolver in
+            HydrationGoalRecommendationRepositoryImpl(
+                dataSource: resolver.resolve(HydrationGoalRecommendationDataSource.self)!
+            )
+        }
+
         // MARK: - Routine
         container.register(RoutineStorageDataSource.self) { _ in
             RoutineStorageDataSourceImpl(userDefaults: .appGroup)

--- a/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
@@ -43,6 +43,21 @@ public final class DomainAssembly: Assembly {
                 repository: resolver.resolve(HealthKitRepository.self)!
             )
         }
+
+        container.register(BodyProfileUseCase.self) { resolver in
+            BodyProfileUseCaseImpl(
+                healthKitRepository: resolver.resolve(HealthKitRepository.self)!
+            )
+        }
+
+        container.register(HydrationGoalRecommendationUseCase.self) { resolver in
+            HydrationGoalRecommendationUseCaseImpl(
+                bodyProfileUseCase: resolver.resolve(BodyProfileUseCase.self)!,
+                drinkWaterRepository: resolver.resolve(DrinkWaterRepository.self)!,
+                userPreferencesRepository: resolver.resolve(UserPreferencesRepository.self)!,
+                recommendationRepository: resolver.resolve(HydrationGoalRecommendationRepository.self)!
+            )
+        }
         
         // MARK: - UserPreferences
         container.register(UserPreferencesUseCase.self) { resolver in

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -107,14 +107,21 @@ public final class PresentationAssembly: Assembly {
         .inObjectScope(.container)
 
         container.register(BodyProfileViewModel.self) { resolver in
-            let healthKitUseCase = resolver.resolve(HealthKitUseCase.self)!
-            let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
+            let bodyProfileUseCase = resolver.resolve(BodyProfileUseCase.self)!
 
             return MainActor.assumeIsolated {
                 BodyProfileViewModel(
-                    healthKitUseCase: healthKitUseCase,
-                    userPreferencesUseCase: userPreferencesUseCase
+                    bodyProfileUseCase: bodyProfileUseCase
                 )
+            }
+        }
+        .inObjectScope(.container)
+
+        container.register(HydrationGoalRecommendationViewModel.self) { resolver in
+            let useCase = resolver.resolve(HydrationGoalRecommendationUseCase.self)!
+
+            return MainActor.assumeIsolated {
+                HydrationGoalRecommendationViewModel(useCase: useCase)
             }
         }
         .inObjectScope(.container)

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -12,6 +12,237 @@
         }
       }
     },
+    "hydrationGoalRecommendationAppleIntelligenceDisabledDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Intelligence를 켜야 AI 추천을 사용할 수 있어요."
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationAverageIntakeTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 7일 평균"
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationBodyProfileActionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "신체 정보 확인하기"
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationBodyProfileTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "신체 정보"
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationCurrentGoalTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 목표"
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 기록과 신체 정보를 바탕으로 AI가 목표 수분량을 추천해요."
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationDeviceUnavailableDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 기기에서는 AI 추천을 사용할 수 없어요."
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationGenerateTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 추천받기"
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationGeneratingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천 생성 중..."
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationGenerationFailureDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천을 생성하지 못했어요. 잠시 후 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationGoalAchievementTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목표 달성"
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationGoalAchievementValueFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lld일"
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationInputSectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천에 사용한 정보"
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationLoadingDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 추천 가능 여부를 확인하고 있어요."
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationModelNotReadyDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 모델이 아직 준비되지 않았어요. 잠시 후 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationReadyDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 7일 기록과 신체 정보를 바탕으로 하루 목표 수분량을 추천받을 수 있어요."
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationRecommendedLabel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천 목표"
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 목표 추천"
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationUnavailableFootnote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지금은 아래 슬라이더로 목표 수분량을 직접 조정할 수 있어요."
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationUnknownUnavailableDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재는 AI 추천을 사용할 수 없어요."
+          }
+        }
+      }
+    },
+    "hydrationGoalRecommendationUnsupportedLocaleDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 언어 설정에서는 AI 추천을 사용할 수 없어요."
+          }
+        }
+      }
+    },
     "challengeAchievementDaysFormat" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1602,7 +1833,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "건강 앱에서 값을 가져오거나 직접 입력해 주세요. 키와 몸무게가 모두 있어야 추천에 사용할 수 있어요."
+            "value" : "건강 앱에서 키와 몸무게를 다시 가져와 주세요. 두 값이 모두 있어야 추천에 사용할 수 있어요."
           }
         }
       }
@@ -1657,7 +1888,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "건강 앱에 키와 몸무게가 없어요. 직접 입력하거나 건강 앱에 값을 추가한 뒤 다시 가져와 주세요."
+            "value" : "건강 앱에 키와 몸무게가 없어요. 건강 앱에 값을 추가한 뒤 다시 가져와 주세요."
           }
         }
       }
@@ -1679,7 +1910,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "건강 권한이 꺼져 있어요. 설정에서 권한을 다시 허용하거나 직접 입력해 주세요."
+            "value" : "건강 권한이 꺼져 있어요. 설정에서 권한을 다시 허용해 주세요."
           }
         }
       }
@@ -1767,7 +1998,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "추천에는 건강 앱 값이 우선 사용되고, 값이 없으면 직접 입력한 값이 사용돼요."
+            "value" : "추천에는 건강 앱에서 불러온 키와 몸무게가 사용돼요."
           }
         }
       }
@@ -1789,7 +2020,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "키와 몸무게를 입력해 주세요"
+            "value" : "건강 앱에서 키와 몸무게를 불러와 주세요"
           }
         }
       }


### PR DESCRIPTION
## 📝 Summary
AI 기반 개인화 목표 수분량 추천 기능을 추가하고, 추천에 사용하는 신체 정보 흐름을 HealthKit 전용으로 정리했습니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [x] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #89
- Related to #149

## 📋 Changes Made
### Added
- Foundation Models 기반 목표 수분량 추천 도메인/데이터/프레젠테이션 계층 추가
- 최근 7일 섭취 기록과 현재 목표량을 조합하는 추천 입력 모델 및 테스트 추가
- 추천 결과 적용용 ViewModel과 설정 화면 추천 카드 추가

### Changed
- 일일 목표 설정 화면에 `sparkles` 심볼과 AI 추천 UI 추가
- 신체 정보 해석 로직을 `BodyProfileUseCase`로 분리하고 추천 흐름에서 재사용하도록 변경
- 추천 문구를 `Foundation Models` 노출 대신 `AI 기반 추천` 표현으로 정리

### Fixed
- 신체 정보 추천 전제조건을 HealthKit 동기화 상태 기준으로 일관되게 판별하도록 정리
- Preview/DI 경로에서도 추천 기능을 바로 확인할 수 있도록 목과 조립 로직 보강

### Removed
- 신체 정보 직접 입력 및 manual fallback 경로 제거
- 추천 시 HealthKit 외 수동 입력값을 사용하던 분기 제거

## 🔍 Technical Details
- `HydrationGoalRecommendationUseCase`에서 신체 정보, 최근 7일 평균 섭취량, 목표 달성 일수를 입력으로 조합한 뒤 구조화된 추천 결과를 생성합니다.
- `BodyProfileUseCase`는 HealthKit 권한 상태와 키/몸무게 존재 여부를 바탕으로 `ready`, `noData`, `incomplete`, `permissionDenied` 상태를 계산합니다.
- 설정 화면은 추천 가능 상태와 신체 정보 부족 상태를 분리해 보여주고, 적용 시 기존 목표량 저장 경로를 그대로 사용합니다.

## 📸 Screenshots / Videos
### Before
- 없음

### After
- 없음

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [x] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS Simulator 26.4
- Device: iPhone 17 Pro Simulator
- Xcode Version: Xcode 26.4 (17E192)

### Test Results
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer -destination 'platform=iOS Simulator,id=E4179829-6A0A-4225-9948-1D26076E4C30' -sdk iphonesimulator -derivedDataPath /tmp/MulimiDomainBodyProfileTest`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,id=E4179829-6A0A-4225-9948-1D26076E4C30' -sdk iphonesimulator -derivedDataPath /tmp/MulimiPresentationBodyProfileTest`
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- 신체 정보는 이제 HealthKit 값만 사용합니다. 건강 앱에 값이 없으면 추천을 생성하지 않고 신체 정보 확인 화면으로 유도합니다.
- 작업 디렉터리에 있는 미추적 파일 `직접`은 이번 PR에 포함하지 않았습니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
