### PR TITLE
feat: add onboarding before HealthKit gate

### DIFF
--- a/Project/App/Sources/DrinkWaterApp.swift
+++ b/Project/App/Sources/DrinkWaterApp.swift
@@ -17,6 +17,7 @@ struct DrinkWaterApp: App {
         WindowGroup {
             RootView(
                 authenticationViewModel: DIContainer.shared.resolve(AuthenticationViewModel.self),
+                onboardingViewModel: DIContainer.shared.resolve(OnboardingViewModel.self),
                 healthKitPermissionViewModel: DIContainer.shared.resolve(HealthKitPermissionViewModel.self)
             ) {
                 ContentView()

--- a/Project/Data/Sources/DataSource/UserPreferencesDataSource.swift
+++ b/Project/Data/Sources/DataSource/UserPreferencesDataSource.swift
@@ -15,6 +15,8 @@ public protocol UserPreferencesDataSource: Sendable {
     func setMainIcon(_ icon: MainIcon)
     func getDailyWaterLimit() -> Double
     func setDailyWaterLimit(_ limit: Double)
+    func hasCompletedOnboarding() -> Bool
+    func setHasCompletedOnboarding(_ completed: Bool)
     func getManualBodyProfile() -> BodyProfile
     func setManualBodyProfile(_ profile: BodyProfile)
 }
@@ -92,6 +94,16 @@ public final class UserPreferencesDataSourceImpl: UserPreferencesDataSource, @un
         userDefaults.synchronize()
         ubiquitousStore.set(limit, forKey: .dailyWaterLimit)
         ubiquitousStore.synchronize()
+    }
+
+    // MARK: - Onboarding
+    public func hasCompletedOnboarding() -> Bool {
+        userDefaults.hasCompletedOnboarding
+    }
+
+    public func setHasCompletedOnboarding(_ completed: Bool) {
+        userDefaults.hasCompletedOnboarding = completed
+        userDefaults.synchronize()
     }
 
     // MARK: - Manual Body Profile

--- a/Project/Data/Sources/Repository/UserPreferencesRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/UserPreferencesRepositoryImpl.swift
@@ -32,6 +32,14 @@ public struct UserPreferencesRepositoryImpl: UserPreferencesRepository {
         dataSource.setDailyWaterLimit(limit)
     }
 
+    public func hasCompletedOnboarding() -> Bool {
+        dataSource.hasCompletedOnboarding()
+    }
+
+    public func setHasCompletedOnboarding(_ completed: Bool) {
+        dataSource.setHasCompletedOnboarding(completed)
+    }
+
     public func getManualBodyProfile() -> BodyProfile {
         dataSource.getManualBodyProfile()
     }

--- a/Project/Domain/Interfaces/Repository/UserPreferencesRepository.swift
+++ b/Project/Domain/Interfaces/Repository/UserPreferencesRepository.swift
@@ -13,6 +13,8 @@ public protocol UserPreferencesRepository: Sendable {
     func setMainIcon(_ icon: MainIcon)
     func getDailyWaterLimit() -> Double
     func setDailyWaterLimit(_ limit: Double)
+    func hasCompletedOnboarding() -> Bool
+    func setHasCompletedOnboarding(_ completed: Bool)
     func getManualBodyProfile() -> BodyProfile
     func setManualBodyProfile(_ profile: BodyProfile)
 }

--- a/Project/Domain/Interfaces/UseCase/UserPreferencesUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/UserPreferencesUseCase.swift
@@ -13,6 +13,8 @@ public protocol UserPreferencesUseCase: Sendable {
     func setMainIcon(_ icon: MainIcon)
     func getDailyWaterLimit() -> Double
     func setDailyWaterLimit(_ limit: Double)
+    func hasCompletedOnboarding() -> Bool
+    func setHasCompletedOnboarding(_ completed: Bool)
     func getManualBodyProfile() -> BodyProfile
     func setManualBodyProfile(_ profile: BodyProfile)
 }

--- a/Project/Domain/Sources/UseCase/UserPreferencesUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/UserPreferencesUseCaseImpl.swift
@@ -31,6 +31,14 @@ public struct UserPreferencesUseCaseImpl: UserPreferencesUseCase {
         repository.setDailyWaterLimit(limit)
     }
 
+    public func hasCompletedOnboarding() -> Bool {
+        repository.hasCompletedOnboarding()
+    }
+
+    public func setHasCompletedOnboarding(_ completed: Bool) {
+        repository.setHasCompletedOnboarding(completed)
+    }
+
     public func getManualBodyProfile() -> BodyProfile {
         repository.getManualBodyProfile()
     }

--- a/Project/Domain/Tests/Mock/MockUserPreferencesRepository.swift
+++ b/Project/Domain/Tests/Mock/MockUserPreferencesRepository.swift
@@ -11,6 +11,7 @@ import DomainLayerInterface
 final class MockUserPreferencesRepository: UserPreferencesRepository, @unchecked Sendable {
     private var _mainIcon: MainIcon = .default
     private var _dailyWaterLimit: Double = 2000.0
+    private var _hasCompletedOnboarding = false
     private var _manualBodyProfile: BodyProfile = .empty
 
     // Call tracking properties
@@ -18,12 +19,15 @@ final class MockUserPreferencesRepository: UserPreferencesRepository, @unchecked
     private(set) var setMainIconCallCount = 0
     private(set) var getDailyWaterLimitCallCount = 0
     private(set) var setDailyWaterLimitCallCount = 0
+    private(set) var hasCompletedOnboardingCallCount = 0
+    private(set) var setHasCompletedOnboardingCallCount = 0
     private(set) var getManualBodyProfileCallCount = 0
     private(set) var setManualBodyProfileCallCount = 0
 
     // Captured values for verification
     private(set) var capturedMainIcon: MainIcon?
     private(set) var capturedDailyWaterLimit: Double?
+    private(set) var capturedHasCompletedOnboarding: Bool?
     private(set) var capturedManualBodyProfile: BodyProfile?
 
     func getMainIcon() -> MainIcon {
@@ -48,6 +52,17 @@ final class MockUserPreferencesRepository: UserPreferencesRepository, @unchecked
         _dailyWaterLimit = limit
     }
 
+    func hasCompletedOnboarding() -> Bool {
+        hasCompletedOnboardingCallCount += 1
+        return _hasCompletedOnboarding
+    }
+
+    func setHasCompletedOnboarding(_ completed: Bool) {
+        setHasCompletedOnboardingCallCount += 1
+        capturedHasCompletedOnboarding = completed
+        _hasCompletedOnboarding = completed
+    }
+
     func getManualBodyProfile() -> BodyProfile {
         getManualBodyProfileCallCount += 1
         return _manualBodyProfile
@@ -66,6 +81,8 @@ final class MockUserPreferencesRepository: UserPreferencesRepository, @unchecked
         setMainIconCallCount = 0
         getDailyWaterLimitCallCount = 0
         setDailyWaterLimitCallCount = 0
+        hasCompletedOnboardingCallCount = 0
+        setHasCompletedOnboardingCallCount = 0
         getManualBodyProfileCallCount = 0
         setManualBodyProfileCallCount = 0
     }
@@ -73,12 +90,14 @@ final class MockUserPreferencesRepository: UserPreferencesRepository, @unchecked
     func resetCapturedValues() {
         capturedMainIcon = nil
         capturedDailyWaterLimit = nil
+        capturedHasCompletedOnboarding = nil
         capturedManualBodyProfile = nil
     }
 
     func resetToDefaults() {
         _mainIcon = .default
         _dailyWaterLimit = 2000.0
+        _hasCompletedOnboarding = false
         _manualBodyProfile = .empty
         resetCallCounts()
         resetCapturedValues()

--- a/Project/Domain/Tests/UserPreferencesUseCaseTests.swift
+++ b/Project/Domain/Tests/UserPreferencesUseCaseTests.swift
@@ -170,6 +170,29 @@ struct UserPreferencesUseCaseTests {
         #expect(mockRepository.capturedDailyWaterLimit == preciseValue)
     }
 
+    // MARK: - Onboarding Tests
+
+    @Test("초기 온보딩 완료 여부 조회 테스트")
+    func getOnboardingCompletionInitial() {
+        let mockRepository = MockUserPreferencesRepository()
+        let useCase = UserPreferencesUseCaseImpl(repository: mockRepository)
+
+        #expect(useCase.hasCompletedOnboarding() == false)
+        #expect(mockRepository.hasCompletedOnboardingCallCount == 1)
+    }
+
+    @Test("온보딩 완료 상태 저장 테스트")
+    func setOnboardingCompletion() {
+        let mockRepository = MockUserPreferencesRepository()
+        let useCase = UserPreferencesUseCaseImpl(repository: mockRepository)
+
+        useCase.setHasCompletedOnboarding(true)
+
+        #expect(mockRepository.setHasCompletedOnboardingCallCount == 1)
+        #expect(mockRepository.capturedHasCompletedOnboarding == true)
+        #expect(useCase.hasCompletedOnboarding() == true)
+    }
+
     // MARK: - Integration Tests
 
     @Test("전체 시나리오 테스트: 외관 및 목표량 변경")

--- a/Project/Presentation/Sources/View/Authentication/OnboardingView.swift
+++ b/Project/Presentation/Sources/View/Authentication/OnboardingView.swift
@@ -1,0 +1,242 @@
+//
+//  OnboardingView.swift
+//  PresentationLayer
+//
+//  Created by Codex on 4/3/26.
+//
+
+import SwiftUI
+
+public struct OnboardingView: View {
+    @Bindable private var viewModel: OnboardingViewModel
+
+    public init(viewModel: OnboardingViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
+        ZStack {
+            backgroundGradient
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                header
+
+                TabView(selection: $viewModel.currentPage) {
+                    ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
+                        pageView(page)
+                            .tag(index)
+                            .padding(.horizontal, 24)
+                            .padding(.top, 20)
+                    }
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+
+                footer
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Capsule()
+                .fill(.white.opacity(0.14))
+                .frame(width: 64, height: 32)
+                .overlay {
+                    Text("\(viewModel.currentPage + 1) / \(viewModel.pageCount)")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.9))
+                }
+
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 20)
+    }
+
+    private func pageView(_ page: OnboardingPage) -> some View {
+        VStack(alignment: .leading, spacing: 24) {
+            RoundedRectangle(cornerRadius: 36, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: page.panelColors,
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .overlay(alignment: .topLeading) {
+                    Circle()
+                        .fill(.white.opacity(0.14))
+                        .frame(width: 160, height: 160)
+                        .offset(x: -36, y: -48)
+                }
+                .overlay(alignment: .bottomTrailing) {
+                    RoundedRectangle(cornerRadius: 28, style: .continuous)
+                        .fill(.black.opacity(0.12))
+                        .frame(width: 140, height: 140)
+                        .rotationEffect(.degrees(18))
+                        .offset(x: 30, y: 34)
+                }
+                .overlay {
+                    VStack(alignment: .leading, spacing: 20) {
+                        Image(systemName: page.systemImage)
+                            .font(.system(size: 60, weight: .semibold))
+                            .foregroundStyle(.white)
+
+                        Spacer()
+
+                        Text(page.eyebrow)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.white.opacity(0.78))
+
+                        Text(page.title)
+                            .font(.system(size: 31, weight: .bold, design: .rounded))
+                            .foregroundStyle(.white)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(28)
+                }
+                .frame(maxHeight: 360)
+
+            VStack(alignment: .leading, spacing: 18) {
+                Text(page.description)
+                    .font(.body)
+                    .foregroundStyle(.white.opacity(0.82))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(page.highlights, id: \.self) { highlight in
+                        HStack(alignment: .top, spacing: 10) {
+                            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                .fill(.teal)
+                                .frame(width: 6, height: 18)
+                                .padding(.top, 2)
+
+                            Text(highlight)
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(.white)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var footer: some View {
+        VStack(spacing: 14) {
+            if viewModel.isLastPage {
+                Text("온보딩을 마치면 다음 단계에서 건강 앱 권한을 안내해요.")
+                    .font(.footnote)
+                    .foregroundStyle(.white.opacity(0.62))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+
+            HStack(spacing: 12) {
+                if viewModel.canGoBack {
+                    Button {
+                        withAnimation(.spring(response: 0.32, dampingFraction: 0.88)) {
+                            viewModel.goToPreviousPage()
+                        }
+                    } label: {
+                        Text("이전")
+                            .font(.headline.weight(.semibold))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 54)
+                            .foregroundStyle(.white)
+                            .background(.white.opacity(0.08))
+                            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    }
+                }
+
+                Button {
+                    withAnimation(.spring(response: 0.32, dampingFraction: 0.9)) {
+                        viewModel.goToNextPage()
+                    }
+                } label: {
+                    Text(viewModel.isLastPage ? "건강 앱 연동 계속하기" : "다음")
+                        .font(.headline.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 54)
+                        .foregroundStyle(.black)
+                        .background(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 24)
+        }
+        .padding(.top, 16)
+    }
+
+    private var backgroundGradient: some View {
+        LinearGradient(
+            colors: [
+                Color(red: 0.03, green: 0.10, blue: 0.15),
+                Color(red: 0.04, green: 0.18, blue: 0.22),
+                Color(red: 0.07, green: 0.33, blue: 0.34)
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    private var pages: [OnboardingPage] {
+        [
+            OnboardingPage(
+                eyebrow: "Quick Logging",
+                title: "기록은\n가볍고 빠르게",
+                description: "오늘 마신 물을 한 번의 탭으로 기록하고, 현재 목표까지 얼마나 남았는지 바로 확인할 수 있어요.",
+                highlights: [
+                    "첫 화면에서 바로 물 마시기 기록",
+                    "현재 섭취량과 목표 진행률을 즉시 확인"
+                ],
+                systemImage: "drop.fill",
+                panelColors: [
+                    Color(red: 0.08, green: 0.47, blue: 0.55),
+                    Color(red: 0.11, green: 0.68, blue: 0.70)
+                ]
+            ),
+            OnboardingPage(
+                eyebrow: "Daily Rhythm",
+                title: "흐름은\n한눈에 읽기",
+                description: "기록, 인사이트, 챌린지로 하루와 일주일의 수분 루틴을 한 번에 파악할 수 있어요.",
+                highlights: [
+                    "월별 기록과 최근 패턴을 빠르게 탐색",
+                    "챌린지와 인사이트로 루틴 유지 상태 확인"
+                ],
+                systemImage: "chart.line.uptrend.xyaxis",
+                panelColors: [
+                    Color(red: 0.18, green: 0.25, blue: 0.56),
+                    Color(red: 0.18, green: 0.49, blue: 0.77)
+                ]
+            ),
+            OnboardingPage(
+                eyebrow: "Health Sync",
+                title: "건강 앱과\n연결해서 시작",
+                description: "물리미는 건강 앱과 연동해 수분 기록과 신체 정보를 함께 활용합니다. 온보딩 뒤에 바로 권한을 안내할게요.",
+                highlights: [
+                    "건강 앱 기반으로 기록과 목표 흐름 유지",
+                    "권한 허용 후 앱의 주요 기능을 바로 사용"
+                ],
+                systemImage: "heart.text.square.fill",
+                panelColors: [
+                    Color(red: 0.13, green: 0.38, blue: 0.33),
+                    Color(red: 0.16, green: 0.62, blue: 0.49)
+                ]
+            )
+        ]
+    }
+}
+
+private struct OnboardingPage {
+    let eyebrow: String
+    let title: String
+    let description: String
+    let highlights: [String]
+    let systemImage: String
+    let panelColors: [Color]
+}

--- a/Project/Presentation/Sources/View/RootView.swift
+++ b/Project/Presentation/Sources/View/RootView.swift
@@ -10,15 +10,18 @@ import SwiftUI
 
 public struct RootView<Content: View>: View {
     @State private var authenticationViewModel: AuthenticationViewModel
+    @State private var onboardingViewModel: OnboardingViewModel
     @State private var healthKitPermissionViewModel: HealthKitPermissionViewModel
     private let content: () -> Content
     
     public init(
         authenticationViewModel: @autoclosure @escaping () -> AuthenticationViewModel,
+        onboardingViewModel: @autoclosure @escaping () -> OnboardingViewModel,
         healthKitPermissionViewModel: @autoclosure @escaping () -> HealthKitPermissionViewModel,
         @ViewBuilder content: @escaping () -> Content
     ) {
         self._authenticationViewModel = State(wrappedValue: authenticationViewModel())
+        self._onboardingViewModel = State(wrappedValue: onboardingViewModel())
         self._healthKitPermissionViewModel = State(wrappedValue: healthKitPermissionViewModel())
         self.content = content
     }
@@ -26,12 +29,17 @@ public struct RootView<Content: View>: View {
     public var body: some View {
         Group {
             if authenticationViewModel.isAuthenticated {
-                HealthKitPermissionGateView(viewModel: healthKitPermissionViewModel) {
-                    content()
+                if onboardingViewModel.hasCompletedOnboarding {
+                    HealthKitPermissionGateView(viewModel: healthKitPermissionViewModel) {
+                        content()
+                    }
+                } else {
+                    OnboardingView(viewModel: onboardingViewModel)
                 }
             } else {
                 SignInView(viewModel: authenticationViewModel)
                     .onAppear {
+                        onboardingViewModel.refreshState()
                         healthKitPermissionViewModel.markSignedOut()
                     }
             }

--- a/Project/Presentation/Sources/ViewModel/OnboardingViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/OnboardingViewModel.swift
@@ -1,0 +1,56 @@
+//
+//  OnboardingViewModel.swift
+//  PresentationLayer
+//
+//  Created by Codex on 4/3/26.
+//
+
+import DomainLayerInterface
+import Observation
+
+@Observable
+@MainActor
+public final class OnboardingViewModel {
+    public var currentPage = 0
+    public private(set) var hasCompletedOnboarding: Bool
+
+    public let pageCount = 3
+
+    private let userPreferencesUseCase: UserPreferencesUseCase
+
+    public init(userPreferencesUseCase: UserPreferencesUseCase) {
+        self.userPreferencesUseCase = userPreferencesUseCase
+        self.hasCompletedOnboarding = userPreferencesUseCase.hasCompletedOnboarding()
+    }
+
+    public var isLastPage: Bool {
+        currentPage == pageCount - 1
+    }
+
+    public var canGoBack: Bool {
+        currentPage > 0
+    }
+
+    public func goToNextPage() {
+        guard !isLastPage else {
+            completeOnboarding()
+            return
+        }
+
+        currentPage += 1
+    }
+
+    public func goToPreviousPage() {
+        guard canGoBack else { return }
+        currentPage -= 1
+    }
+
+    public func completeOnboarding() {
+        userPreferencesUseCase.setHasCompletedOnboarding(true)
+        hasCompletedOnboarding = true
+    }
+
+    public func refreshState() {
+        hasCompletedOnboarding = userPreferencesUseCase.hasCompletedOnboarding()
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockUserPreferencesUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockUserPreferencesUseCase.swift
@@ -3,17 +3,21 @@ import DomainLayerInterface
 final class MockUserPreferencesUseCase: UserPreferencesUseCase, @unchecked Sendable {
     var mainIconValue: MainIcon = .default
     var dailyWaterLimitValue: Double = 2000
+    var hasCompletedOnboardingValue = false
     var manualBodyProfileValue: BodyProfile = .empty
 
     private(set) var getMainIconCallCount = 0
     private(set) var setMainIconCallCount = 0
     private(set) var getDailyWaterLimitCallCount = 0
     private(set) var setDailyWaterLimitCallCount = 0
+    private(set) var hasCompletedOnboardingCallCount = 0
+    private(set) var setHasCompletedOnboardingCallCount = 0
     private(set) var getManualBodyProfileCallCount = 0
     private(set) var setManualBodyProfileCallCount = 0
 
     private(set) var capturedMainIcon: MainIcon?
     private(set) var capturedDailyWaterLimit: Double?
+    private(set) var capturedHasCompletedOnboarding: Bool?
     private(set) var capturedManualBodyProfile: BodyProfile?
 
     func getMainIcon() -> MainIcon {
@@ -36,6 +40,17 @@ final class MockUserPreferencesUseCase: UserPreferencesUseCase, @unchecked Senda
         setDailyWaterLimitCallCount += 1
         capturedDailyWaterLimit = limit
         dailyWaterLimitValue = limit
+    }
+
+    func hasCompletedOnboarding() -> Bool {
+        hasCompletedOnboardingCallCount += 1
+        return hasCompletedOnboardingValue
+    }
+
+    func setHasCompletedOnboarding(_ completed: Bool) {
+        setHasCompletedOnboardingCallCount += 1
+        capturedHasCompletedOnboarding = completed
+        hasCompletedOnboardingValue = completed
     }
 
     func getManualBodyProfile() -> BodyProfile {

--- a/Project/Presentation/Tests/OnboardingViewModelTests.swift
+++ b/Project/Presentation/Tests/OnboardingViewModelTests.swift
@@ -1,0 +1,46 @@
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("OnboardingViewModel Tests")
+struct OnboardingViewModelTests {
+    @MainActor
+    @Test("초기 상태는 저장된 온보딩 완료 여부를 반영한다")
+    func initializeState() {
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.hasCompletedOnboardingValue = true
+
+        let viewModel = OnboardingViewModel(userPreferencesUseCase: userPreferencesUseCase)
+
+        #expect(viewModel.hasCompletedOnboarding == true)
+        #expect(viewModel.currentPage == 0)
+    }
+
+    @MainActor
+    @Test("goToNextPage는 마지막 페이지 전까지 페이지를 이동한다")
+    func advancePage() {
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        let viewModel = OnboardingViewModel(userPreferencesUseCase: userPreferencesUseCase)
+
+        viewModel.goToNextPage()
+        viewModel.goToNextPage()
+
+        #expect(viewModel.currentPage == 2)
+        #expect(viewModel.isLastPage == true)
+        #expect(userPreferencesUseCase.setHasCompletedOnboardingCallCount == 0)
+    }
+
+    @MainActor
+    @Test("마지막 페이지에서 다음을 누르면 온보딩을 완료 처리한다")
+    func completeOnboardingFromLastPage() {
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        let viewModel = OnboardingViewModel(userPreferencesUseCase: userPreferencesUseCase)
+
+        viewModel.currentPage = 2
+        viewModel.goToNextPage()
+
+        #expect(viewModel.hasCompletedOnboarding == true)
+        #expect(userPreferencesUseCase.setHasCompletedOnboardingCallCount == 1)
+        #expect(userPreferencesUseCase.capturedHasCompletedOnboarding == true)
+    }
+}

--- a/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
+++ b/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
@@ -90,6 +90,12 @@ struct ProfileRoutineViewModelTests {
             dailyWaterLimit = limit
         }
 
+        func hasCompletedOnboarding() -> Bool {
+            true
+        }
+
+        func setHasCompletedOnboarding(_ completed: Bool) {}
+
         func getManualBodyProfile() -> BodyProfile {
             .empty
         }

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockUserPreferencesUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockUserPreferencesUseCase.swift
@@ -11,6 +11,7 @@ import DomainLayerInterface
 public final class MockUserPreferencesUseCase: UserPreferencesUseCase, @unchecked Sendable {
     private var mainIcon: MainIcon = .drop
     private var dailyWaterLimit: Double = 2000
+    private var hasCompletedOnboarding = false
     private var manualBodyProfile: BodyProfile = .empty
     private var accentColor: String = "blue"
 
@@ -30,6 +31,14 @@ public final class MockUserPreferencesUseCase: UserPreferencesUseCase, @unchecke
 
     public func setDailyWaterLimit(_ limit: Double) {
         dailyWaterLimit = limit
+    }
+
+    public func hasCompletedOnboarding() -> Bool {
+        hasCompletedOnboarding
+    }
+
+    public func setHasCompletedOnboarding(_ completed: Bool) {
+        hasCompletedOnboarding = completed
     }
 
     public func getManualBodyProfile() -> BodyProfile {

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -117,6 +117,15 @@ public final class PreviewAssembly: Assembly {
         }
         .inObjectScope(.container)
 
+        container.register(OnboardingViewModel.self) { resolver in
+            let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
+
+            return MainActor.assumeIsolated {
+                OnboardingViewModel(userPreferencesUseCase: userPreferencesUseCase)
+            }
+        }
+        .inObjectScope(.container)
+
         container.register(HealthKitPermissionViewModel.self) { resolver in
             let healthKitUseCase = resolver.resolve(HealthKitUseCase.self)!
 

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -95,6 +95,15 @@ public final class PresentationAssembly: Assembly {
         }
         .inObjectScope(.container)
 
+        container.register(OnboardingViewModel.self) { resolver in
+            let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
+
+            return MainActor.assumeIsolated {
+                OnboardingViewModel(userPreferencesUseCase: userPreferencesUseCase)
+            }
+        }
+        .inObjectScope(.container)
+
         container.register(HealthKitPermissionViewModel.self) { resolver in
             let healthKitUseCase = resolver.resolve(HealthKitUseCase.self)!
 

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockUserPreferencesUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockUserPreferencesUseCaseForTesting.swift
@@ -11,6 +11,7 @@ import DomainLayerInterface
 public final class MockUserPreferencesUseCaseForTesting: UserPreferencesUseCase, @unchecked Sendable {
     public var mainIcon: MainIcon = .drop
     public var dailyWaterLimit: Double = 2000
+    public var hasCompletedOnboarding = false
     public var manualBodyProfile: BodyProfile = .empty
     public var accentColor: String = "blue"
 
@@ -30,6 +31,14 @@ public final class MockUserPreferencesUseCaseForTesting: UserPreferencesUseCase,
 
     public func setDailyWaterLimit(_ limit: Double) {
         dailyWaterLimit = limit
+    }
+
+    public func hasCompletedOnboarding() -> Bool {
+        hasCompletedOnboarding
+    }
+
+    public func setHasCompletedOnboarding(_ completed: Bool) {
+        hasCompletedOnboarding = completed
     }
 
     public func getManualBodyProfile() -> BodyProfile {

--- a/Project/Shared/Utils/Sources/String+Extensions.swift
+++ b/Project/Shared/Utils/Sources/String+Extensions.swift
@@ -24,6 +24,7 @@ public extension String {
     static let mainIcon: String = "mainIcon"
     static let legacyMainAppearance: String = "mainAppearance"
     static let dailyWaterLimit: String = "dailyWaterLimit"
+    static let hasCompletedOnboarding: String = "hasCompletedOnboarding"
     static let manualBodyHeightCM: String = "manualBodyHeightCM"
     static let manualBodyWeightKG: String = "manualBodyWeightKG"
     static let hydrationRoutines: String = "hydrationRoutines"

--- a/Project/Shared/Utils/Sources/UserDefaults+Extensions.swift
+++ b/Project/Shared/Utils/Sources/UserDefaults+Extensions.swift
@@ -34,6 +34,11 @@ public extension UserDefaults {
         set { self.set(newValue, forKey: .dailyWaterLimit) }
     }
 
+    @objc dynamic var hasCompletedOnboarding: Bool {
+        get { self.bool(forKey: .hasCompletedOnboarding) }
+        set { self.set(newValue, forKey: .hasCompletedOnboarding) }
+    }
+
     @objc dynamic var manualBodyHeightCM: Double {
         get { self.double(forKey: .manualBodyHeightCM) }
         set { self.set(newValue, forKey: .manualBodyHeightCM) }


### PR DESCRIPTION
## 📝 Summary
로그인 후 바로 HealthKit 프리프롬프트를 띄우던 흐름 앞에 온보딩을 추가했습니다. 이제 사용자는 온보딩을 먼저 완료한 뒤 건강 권한 게이트로 진입합니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #40
- Related to #152

## 📋 Changes Made
### Added
- 로그인 뒤 노출되는 3페이지 온보딩 화면 추가
- 온보딩 완료 상태를 저장하는 사용자 설정 키/뷰모델 추가
- 온보딩 뷰모델 테스트 추가

### Changed
- `RootView` 진입 흐름을 `SignIn -> Onboarding -> HealthKitPermissionGate -> Content` 순서로 변경
- `UserPreferences` 계층이 온보딩 완료 여부를 읽고 쓸 수 있도록 확장
- DI가 `OnboardingViewModel`을 주입하도록 확장
- 프리뷰/테스트용 `UserPreferencesUseCase` mock들을 새 인터페이스에 맞게 갱신

### Fixed
- HealthKit 권한 이유를 설명하기 전에 바로 권한 게이트가 보이던 초기 진입 흐름을 개선

### Removed
- 없음

## 🔍 Technical Details
- 온보딩 완료 여부는 `UserDefaults` 기반 `UserPreferencesUseCase`로 저장합니다.
- 마지막 온보딩 페이지의 CTA는 바로 `HealthKitPermissionGateView`로 이어지도록 루트 분기에서 처리했습니다.
- 기존 HealthKit 권한 플로우는 유지하고, 진입 순서만 앞단에 온보딩을 추가하는 방식으로 구성했습니다.

## 📸 Screenshots / Videos
### Before
- 로그인 직후 HealthKit 프리프롬프트 진입

### After
- 로그인 직후 온보딩 노출
- 온보딩 완료 후 HealthKit 프리프롬프트 진입

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [x] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS Simulator 26.4
- Device: iPhone 17 Pro Simulator
- Xcode Version: Xcode 26.4 (17E192)

### Test Results
- `tuist generate` 성공
- `DomainLayer` 테스트 83개 통과
- `PresentationLayer` 테스트 59개 통과
- `Mulimi` 스킴 `generic/platform=iOS` 빌드 성공

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- 온보딩 완료 여부는 로컬 사용자 설정에 저장되며, 로그아웃 후 재로그인 시에도 유지됩니다.
- 온보딩 마지막 페이지는 별도 권한 요청을 직접 수행하지 않고, 기존 HealthKit 프리프롬프트 단계로 자연스럽게 이어집니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
