### PR TITLE
fix: restore root navigation titles

### DIFF
--- a/Project/App/Sources/ContentView.swift
+++ b/Project/App/Sources/ContentView.swift
@@ -12,7 +12,16 @@ import PresentationLayer
 import SwiftUI
 
 struct ContentView: View {
+    private enum AppTab: Hashable {
+        case drink
+        case history
+        case insight
+        case challenge
+        case profile
+    }
+
     @State private var appCoordinator: AppCoordinator
+    @State private var selectedTab: AppTab = .drink
     @State private var drinkWaterViewModel: DrinkWaterViewModel
     @State private var hydrationRecordListViewModel: HydrationRecordListViewModel
     @State private var hydrationInsightViewModel: HydrationInsightViewModel
@@ -47,23 +56,27 @@ struct ContentView: View {
                 set: { appCoordinator.path = $0 }
             )
         ) {
-            TabView {
+            TabView(selection: $selectedTab) {
                 DrinkWaterView(viewModel: drinkWaterViewModel)
+                    .tag(AppTab.drink)
                     .tabItem {
                         Label(L10n.tr("drinkTitle"), systemImage: "waterbottle")
                     }
 
                 HydrationRecordListView(viewModel: hydrationRecordListViewModel)
+                    .tag(AppTab.history)
                     .tabItem {
                         Label(L10n.tr("historyTitle"), systemImage: "calendar")
                     }
 
                 HydrationInsightView(viewModel: hydrationInsightViewModel)
+                    .tag(AppTab.insight)
                     .tabItem {
                         Label(L10n.tr("insightNavigationTitle"), systemImage: "chart.bar.xaxis")
                     }
 
                 ChallengeView(viewModel: challengeViewModel)
+                    .tag(AppTab.challenge)
                     .tabItem {
                         Label(L10n.tr("challengeTitle"), systemImage: "trophy")
                     }
@@ -74,10 +87,13 @@ struct ContentView: View {
                     recommendationViewModel: recommendationViewModel,
                     routineViewModel: routineViewModel
                 )
+                .tag(AppTab.profile)
                 .tabItem {
                     Label(L10n.tr("profileTitle"), systemImage: "person.crop.circle")
                 }
             }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.large)
             .navigationDestination(for: AppRoute.self) { route in
                 destinationView(for: route)
             }
@@ -110,6 +126,21 @@ struct ContentView: View {
             case .withdrawal:
                 SettingDetailView(menu: .withdrawal, viewModel: settingsViewModel)
             }
+        }
+    }
+
+    private var navigationTitle: String {
+        switch selectedTab {
+        case .drink:
+            L10n.tr("drinkTitle")
+        case .history:
+            L10n.tr("historyTitle")
+        case .insight:
+            L10n.tr("insightNavigationTitle")
+        case .challenge:
+            L10n.tr("challengeTitle")
+        case .profile:
+            L10n.tr("profileTitle")
         }
     }
 }

--- a/Project/Presentation/Sources/View/Challenge/ChallengeView.swift
+++ b/Project/Presentation/Sources/View/Challenge/ChallengeView.swift
@@ -33,7 +33,6 @@ public struct ChallengeView: View {
             }
             .padding(.horizontal, 20)
         }
-        .navigationTitle(L10n.tr("challengeTitle"))
         .task {
             await viewModel.loadChallenges()
         }

--- a/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
+++ b/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
@@ -100,8 +100,6 @@ public struct DrinkWaterView: View {
                 }
             }
         }
-        .navigationTitle(L10n.tr("drinkTitle"))
-        .navigationBarTitleDisplayMode(.large)
         .task {
             // Refresh data when view appears to catch any Widget changes.
             await viewModel.loadInitialState()

--- a/Project/Presentation/Sources/View/HydrationInsight/HydrationInsightView.swift
+++ b/Project/Presentation/Sources/View/HydrationInsight/HydrationInsightView.swift
@@ -41,7 +41,6 @@ public struct HydrationInsightView: View {
             }
             .padding(.horizontal, 20)
         }
-        .navigationTitle(L10n.tr("insightNavigationTitle"))
         .task {
             await viewModel.loadInsights()
         }

--- a/Project/Presentation/Sources/View/HydrationRecord/HydrationRecordListView.swift
+++ b/Project/Presentation/Sources/View/HydrationRecord/HydrationRecordListView.swift
@@ -20,8 +20,6 @@ public struct HydrationRecordListView: View {
     
     public var body: some View {
         RecordCalendarView(viewModel: viewModel)
-        .navigationTitle(L10n.tr("historyTitle"))
-        .navigationBarTitleDisplayMode(.large)
         .background(
             Color.background
                 .ignoresSafeArea()

--- a/Project/Presentation/Sources/View/Profile/ProfileView.swift
+++ b/Project/Presentation/Sources/View/Profile/ProfileView.swift
@@ -86,7 +86,6 @@ public struct ProfileView: View {
                 )
             }
         }
-        .navigationTitle(L10n.tr("profileTitle"))
         .task {
             await routineViewModel.load()
             await bodyProfileViewModel.load()


### PR DESCRIPTION
## 📝 Summary
루트 `NavigationStack` 구조로 바뀐 뒤 탭 루트 화면의 `navigationTitle`이 숨겨지던 문제를 정리했습니다. `ContentView`가 현재 선택된 탭 기준으로 내비게이션 타이틀을 직접 관리하도록 바꿔 탭 전환 시 타이틀이 다시 정상 노출됩니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [x] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [ ] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #159
- Related to #157

## 📋 Changes Made
### Added
- `ContentView`에 현재 선택된 탭별 루트 타이틀 매핑을 추가했습니다.

### Changed
- 루트 `NavigationStack` 아래의 `TabView`가 `navigationTitle`과 `large` title display mode를 직접 관리하도록 변경했습니다.

### Fixed
- 수분 기록, 기록, 인사이트, 챌린지, 프로필 탭에서 상단 내비게이션 타이틀이 숨겨지던 문제를 수정했습니다.

### Removed
- 각 탭 루트 화면에 중복으로 선언돼 있던 최상위 `navigationTitle`을 제거했습니다.

## 🔍 Technical Details
`TabView`가 루트 컨텐츠일 때 하위 탭 뷰의 타이틀이 안정적으로 반영되지 않아, 탭 루트 타이틀 책임을 `ContentView`로 올렸습니다. 상세 화면 타이틀은 기존처럼 각 화면에서 유지합니다.

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS 26.4 SDK
- Device: generic iOS, generic iOS Simulator
- Xcode Version: Xcode 26.4 (17E192)

### Test Results
- `tuist generate` 없이 기존 워크스페이스 기준으로 `Mulimi` iOS 빌드에 성공했습니다.
- `PresentationLayer`는 iOS Simulator SDK 기준 컴파일 빌드에 성공했습니다.
- CoreSimulator 서비스가 불안정해 실제 시뮬레이터 실행 테스트는 이번 확인에서 진행하지 못했습니다.

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
리뷰 시 탭 전환 직후 각 루트 화면의 large title 노출과, 프로필 상세 진입 시 상세 타이틀이 기존대로 유지되는지만 확인하면 됩니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
