### PR TITLE
fix: reset onboarding state and watch serving guardrails

### DIFF
--- a/Project/Domain/WatchInterfaces/Entities/HydrationServing.swift
+++ b/Project/Domain/WatchInterfaces/Entities/HydrationServing.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public enum HydrationServing {
+    public static let defaultGlassML = 250.0
+
+    public static func glassCount(for intakeML: Double) -> Int {
+        Int((intakeML / defaultGlassML).rounded())
+    }
+
+    public static func intakeML(forGlassCount glassCount: Int) -> Double {
+        Double(glassCount) * defaultGlassML
+    }
+}

--- a/Project/Domain/WatchSources/UseCase/WatchHydrationUseCaseImpl.swift
+++ b/Project/Domain/WatchSources/UseCase/WatchHydrationUseCaseImpl.swift
@@ -4,12 +4,12 @@ import WatchDomainLayerInterface
 public struct WatchHydrationUseCaseImpl: WatchHydrationUseCase {
     private let hydrationRepository: WatchHydrationRepository
     private let dailyGoalRepository: WatchDailyGoalRepository
-    private let defaultDrinkVolumeML: Int
+    private let defaultDrinkVolumeML: Double
 
     public init(
         hydrationRepository: WatchHydrationRepository,
         dailyGoalRepository: WatchDailyGoalRepository,
-        defaultDrinkVolumeML: Int = 250
+        defaultDrinkVolumeML: Double = HydrationServing.defaultGlassML
     ) {
         self.hydrationRepository = hydrationRepository
         self.dailyGoalRepository = dailyGoalRepository
@@ -30,7 +30,7 @@ public struct WatchHydrationUseCaseImpl: WatchHydrationUseCase {
         }
 
         await hydrationRepository.addDrink(
-            volumeML: defaultDrinkVolumeML,
+            volumeML: Int(defaultDrinkVolumeML),
             consumedAt: referenceDate
         )
 

--- a/Project/Presentation/Sources/View/RootView.swift
+++ b/Project/Presentation/Sources/View/RootView.swift
@@ -42,7 +42,7 @@ public struct RootView<Content: View>: View {
             } else {
                 SignInView(viewModel: authenticationViewModel)
                     .onAppear {
-                        onboardingViewModel.refreshState()
+                        onboardingViewModel.prepareForSignedOutState()
                         healthKitPermissionViewModel.markSignedOut()
                     }
             }

--- a/Project/Presentation/Sources/ViewModel/OnboardingViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/OnboardingViewModel.swift
@@ -48,9 +48,19 @@ public final class OnboardingViewModel {
     public func completeOnboarding() {
         userPreferencesUseCase.setHasCompletedOnboarding(true)
         hasCompletedOnboarding = true
+        resetProgress()
     }
 
     public func refreshState() {
         hasCompletedOnboarding = userPreferencesUseCase.hasCompletedOnboarding()
+    }
+
+    func prepareForSignedOutState() {
+        refreshState()
+        resetProgress()
+    }
+
+    private func resetProgress() {
+        currentPage = 0
     }
 }

--- a/Project/Presentation/Tests/OnboardingViewModelTests.swift
+++ b/Project/Presentation/Tests/OnboardingViewModelTests.swift
@@ -42,5 +42,22 @@ struct OnboardingViewModelTests {
         #expect(viewModel.hasCompletedOnboarding == true)
         #expect(userPreferencesUseCase.setHasCompletedOnboardingCallCount == 1)
         #expect(userPreferencesUseCase.capturedHasCompletedOnboarding == true)
+        #expect(viewModel.currentPage == 0)
+    }
+
+    @MainActor
+    @Test("prepareForSignedOutState는 온보딩 상태를 다시 읽고 페이지를 처음으로 되돌린다")
+    func prepareForSignedOutStateResetsProgress() {
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        let viewModel = OnboardingViewModel(userPreferencesUseCase: userPreferencesUseCase)
+
+        viewModel.currentPage = 2
+        userPreferencesUseCase.hasCompletedOnboardingValue = false
+
+        viewModel.prepareForSignedOutState()
+
+        #expect(viewModel.currentPage == 0)
+        #expect(viewModel.hasCompletedOnboarding == false)
+        #expect(userPreferencesUseCase.hasCompletedOnboardingCallCount == 2)
     }
 }

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -136,7 +136,6 @@ public final class PreviewAssembly: Assembly {
                 OnboardingViewModel(userPreferencesUseCase: userPreferencesUseCase)
             }
         }
-        .inObjectScope(.container)
 
         container.register(HealthKitPermissionViewModel.self) { resolver in
             let healthKitUseCase = resolver.resolve(HealthKitUseCase.self)!

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -113,7 +113,6 @@ public final class PresentationAssembly: Assembly {
                 OnboardingViewModel(userPreferencesUseCase: userPreferencesUseCase)
             }
         }
-        .inObjectScope(.container)
 
         container.register(HealthKitPermissionViewModel.self) { resolver in
             let healthKitUseCase = resolver.resolve(HealthKitUseCase.self)!

--- a/scripts/check-architecture.sh
+++ b/scripts/check-architecture.sh
@@ -50,7 +50,18 @@ for FILE in Project/Presentation/Sources/ViewModel/*ViewModel.swift; do
 done
 report_violation "ViewModels must not directly reference other ViewModel types." "$CROSS_VIEWMODEL_REFERENCES"
 
-HARD_CODED_GLASS_COUNT="$(rg -n '\b250(\.0)?\b' Project/Domain/Sources Project/Data/Sources Project/Presentation Project/Widget --glob '!**/Tests/**' --glob '!**/Derived/**' || true)"
+HARD_CODED_GLASS_COUNT="$(rg -n '\b250(\.0)?\b' \
+  Project/Domain/Sources \
+  Project/Domain/WatchSources \
+  Project/Domain/WatchInterfaces \
+  Project/Data/Sources \
+  Project/Data/WatchSources \
+  Project/Presentation \
+  Project/Widget \
+  --glob '!**/Tests/**' \
+  --glob '!**/Derived/**' \
+  --glob '!**/HydrationServing.swift' \
+  || true)"
 report_violation "Use HydrationServing instead of hard-coded 250ml literals." "$HARD_CODED_GLASS_COUNT"
 
 if [ "$FAILED" -ne 0 ]; then


### PR DESCRIPTION
## Summary
- reset onboarding progress when the signed-out flow reappears and stop sharing the onboarding view model as a container singleton
- reuse `HydrationServing` inside the watch hydration use case so watch builds follow the same serving rule as iOS
- extend the architecture check to scan watch sources for hard-coded `250ml` values and add onboarding regression coverage

## Validation
- `tuist generate`
- `make lint`
- `make arch-check`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,id=E4179829-6A0A-4225-9948-1D26076E4C30' -sdk iphonesimulator -derivedDataPath /tmp/MulimiPresentationCheck3`\n- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`\n\nRelated: #167