### PR TITLE
fix: localize permission and notification copy

### DIFF
--- a/Project/App/Supports/Info.plist
+++ b/Project/App/Supports/Info.plist
@@ -23,11 +23,11 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSHealthShareUsageDescription</key>
-	<string>We need access to your health data to display your water intake.</string>
+	<string>물 섭취 기록과 신체 정보를 보여주기 위해 건강 앱 접근 권한이 필요합니다.</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>We need access to your health data to log your water intake.</string>
+	<string>마신 물을 건강 앱에 기록하기 위해 건강 앱 쓰기 권한이 필요합니다.</string>
 	<key>NSAlarmKitUsageDescription</key>
-	<string>Mulimi uses alarms to remind you to drink water on your routine schedule.</string>
+	<string>루틴에 맞춰 물 마실 시간을 알려드리기 위해 알림 권한이 필요합니다.</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Project/App/Watch/Supports/ExtensionInfo.plist
+++ b/Project/App/Watch/Supports/ExtensionInfo.plist
@@ -17,9 +17,9 @@
 	<key>CFBundleVersion</key>
 	<string>$(APP_BUILD_NUMBER)</string>
 	<key>NSHealthShareUsageDescription</key>
-	<string>We need access to your health data to display your water intake.</string>
+	<string>물 섭취 기록과 신체 정보를 보여주기 위해 건강 앱 접근 권한이 필요합니다.</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>We need access to your health data to log your water intake.</string>
+	<string>마신 물을 건강 앱에 기록하기 위해 건강 앱 쓰기 권한이 필요합니다.</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/Project/Presentation/Sources/View/Authentication/HealthKitPermissionGateView.swift
+++ b/Project/Presentation/Sources/View/Authentication/HealthKitPermissionGateView.swift
@@ -6,6 +6,7 @@
 //
 
 import DomainLayerInterface
+import Localization
 import SwiftUI
 import UIKit
 
@@ -102,7 +103,7 @@ public struct HealthKitPermissionGateView<Content: View>: View {
                     Button {
                         viewModel.refreshStatus()
                     } label: {
-                        Text("다시 확인하기")
+                        Text(L10n.tr("healthKitPermissionRefreshTitle"))
                             .font(.headline)
                             .fontWeight(.semibold)
                             .frame(maxWidth: .infinity)
@@ -116,7 +117,7 @@ public struct HealthKitPermissionGateView<Content: View>: View {
             .padding(.horizontal, 24)
 
             if viewModel.authorizationStatus == .sharingDenied {
-                Text("설정 앱에서 건강 > 데이터 접근 및 기기 > 물리미 경로로 들어가 권한을 다시 켤 수 있어요.")
+                Text(L10n.tr("healthKitPermissionSettingsFootnote"))
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -131,33 +132,33 @@ public struct HealthKitPermissionGateView<Content: View>: View {
     private var primaryButtonTitle: String {
         switch viewModel.authorizationStatus {
         case .notDetermined:
-            return "건강 권한 허용하기"
+            return L10n.tr("healthKitPermissionAllowTitle")
         case .sharingDenied:
-            return "설정 열기"
+            return L10n.tr("bodyProfileOpenSettingsTitle")
         case .sharingAuthorized:
-            return "계속하기"
+            return L10n.tr("commonConfirmTitle")
         }
     }
 
     private var titleText: String {
         switch viewModel.authorizationStatus {
         case .notDetermined:
-            return "건강 접근 권한이 필요해요"
+            return L10n.tr("healthKitPermissionNeededTitle")
         case .sharingDenied:
-            return "건강 권한이 꺼져 있어요"
+            return L10n.tr("healthKitPermissionDeniedTitle")
         case .sharingAuthorized:
-            return "건강 접근 권한이 필요해요"
+            return L10n.tr("healthKitPermissionNeededTitle")
         }
     }
 
     private var descriptionText: String {
         switch viewModel.authorizationStatus {
         case .notDetermined:
-            return "물리미는 물 섭취 기록과 신체 정보를 불러오기 위해 건강 앱 권한이 필요합니다."
+            return L10n.tr("healthKitPermissionNeededDescription")
         case .sharingDenied:
-            return "한 번 거부한 권한은 앱에서 다시 요청할 수 없어요. 설정에서 건강 권한을 허용한 뒤 다시 돌아와 주세요."
+            return L10n.tr("healthKitPermissionDeniedDescription")
         case .sharingAuthorized:
-            return "물리미는 물 섭취 기록과 신체 정보를 불러오기 위해 건강 앱 권한이 필요합니다."
+            return L10n.tr("healthKitPermissionNeededDescription")
         }
     }
 

--- a/Project/Presentation/Sources/View/Authentication/OnboardingView.swift
+++ b/Project/Presentation/Sources/View/Authentication/OnboardingView.swift
@@ -187,7 +187,7 @@ public struct OnboardingView: View {
     private var pages: [OnboardingPage] {
         [
             OnboardingPage(
-                eyebrow: "Quick Logging",
+                eyebrow: "빠른 기록",
                 title: "기록은\n가볍고 빠르게",
                 description: "오늘 마신 물을 한 번의 탭으로 기록하고, 현재 목표까지 얼마나 남았는지 바로 확인할 수 있어요.",
                 highlights: [
@@ -201,7 +201,7 @@ public struct OnboardingView: View {
                 ]
             ),
             OnboardingPage(
-                eyebrow: "Daily Rhythm",
+                eyebrow: "루틴 흐름",
                 title: "흐름은\n한눈에 읽기",
                 description: "기록, 인사이트, 챌린지로 하루와 일주일의 수분 루틴을 한 번에 파악할 수 있어요.",
                 highlights: [
@@ -215,7 +215,7 @@ public struct OnboardingView: View {
                 ]
             ),
             OnboardingPage(
-                eyebrow: "Health Sync",
+                eyebrow: "건강 연동",
                 title: "건강 앱과\n연결해서 시작",
                 description: "물리미는 건강 앱과 연동해 수분 기록과 신체 정보를 함께 활용합니다. 온보딩 뒤에 바로 권한을 안내할게요.",
                 highlights: [

--- a/Project/Presentation/Sources/ViewModel/HealthKitPermissionViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HealthKitPermissionViewModel.swift
@@ -7,6 +7,7 @@
 
 import DomainLayerInterface
 import Foundation
+import Localization
 import Observation
 
 @Observable
@@ -73,10 +74,10 @@ public final class HealthKitPermissionViewModel {
     }
 
     private var deniedMessage: String {
-        "한 번 거부한 건강 권한은 앱에서 다시 요청할 수 없어요. 설정에서 다시 허용해 주세요."
+        L10n.tr("healthKitPermissionDeniedErrorDescription")
     }
 
     private var defaultErrorMessage: String {
-        "건강 권한을 확인하는 중 문제가 발생했어요. 잠시 후 다시 시도해 주세요."
+        L10n.tr("healthKitPermissionRequestFailureDescription")
     }
 }

--- a/Project/Presentation/Tests/HealthKitPermissionViewModelTests.swift
+++ b/Project/Presentation/Tests/HealthKitPermissionViewModelTests.swift
@@ -1,5 +1,6 @@
 import DomainLayerInterface
 import Foundation
+import Localization
 import Testing
 
 @testable import PresentationLayer
@@ -73,7 +74,7 @@ struct HealthKitPermissionViewModelTests {
 
         #expect(healthKitUseCase.requestAuthorizationCallCount == 1)
         #expect(viewModel.isAuthorized == false)
-        #expect(viewModel.errorMessage == "건강 권한을 확인하는 중 문제가 발생했어요. 잠시 후 다시 시도해 주세요.")
+        #expect(viewModel.errorMessage == L10n.tr("healthKitPermissionRequestFailureDescription"))
     }
 
     @MainActor
@@ -88,7 +89,7 @@ struct HealthKitPermissionViewModelTests {
         await viewModel.requestAuthorization()
 
         #expect(viewModel.isAuthorized == false)
-        #expect(viewModel.errorMessage == "한 번 거부한 건강 권한은 앱에서 다시 요청할 수 없어요. 설정에서 다시 허용해 주세요.")
+        #expect(viewModel.errorMessage == L10n.tr("healthKitPermissionDeniedErrorDescription"))
     }
 
     @MainActor

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -1948,6 +1948,105 @@
         }
       }
     },
+    "healthKitPermissionAllowTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 권한 허용하기"
+          }
+        }
+      }
+    },
+    "healthKitPermissionDeniedDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "한 번 거부한 권한은 앱에서 다시 요청할 수 없어요. 설정에서 건강 권한을 허용한 뒤 다시 돌아와 주세요."
+          }
+        }
+      }
+    },
+    "healthKitPermissionDeniedErrorDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 권한이 꺼져 있어요. 설정에서 다시 허용해 주세요."
+          }
+        }
+      }
+    },
+    "healthKitPermissionDeniedTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 권한이 꺼져 있어요"
+          }
+        }
+      }
+    },
+    "healthKitPermissionNeededDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "물리미는 물 섭취 기록과 신체 정보를 불러오기 위해 건강 앱 권한이 필요해요."
+          }
+        }
+      }
+    },
+    "healthKitPermissionNeededTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 접근 권한이 필요해요"
+          }
+        }
+      }
+    },
+    "healthKitPermissionRefreshTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다시 확인하기"
+          }
+        }
+      }
+    },
+    "healthKitPermissionRequestFailureDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 권한을 확인하는 중 문제가 발생했어요. 잠시 후 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "healthKitPermissionSettingsFootnote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정 앱에서 건강 > 데이터 접근 및 기기 > 물리미 경로로 들어가 권한을 다시 켤 수 있어요."
+          }
+        }
+      }
+    },
     "bodyProfileSaveManualChangesTitle" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## 📝 Summary
알림 권한 설명뿐 아니라 HealthKit 권한 확인 흐름 전반의 문구를 한국어로 정리했습니다. iOS 앱, Watch 확장, 앱 내부 권한 게이트, 온보딩 권한 안내를 한 흐름으로 맞췄습니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [x] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #165
- Related to #

## 📋 Changes Made
### Added
- HealthKit 권한 게이트 전용 로컬라이제이션 키 추가

### Changed
- iOS 앱 `Info.plist`와 Watch `ExtensionInfo.plist`의 시스템 권한 설명을 한국어로 변경
- HealthKit 권한 확인 화면의 타이틀, 설명, 버튼, 보조 안내 문구를 로컬라이제이션 키 기반으로 정리
- 온보딩 마지막 권한 안내 카드의 영어 eyebrow를 한국어 흐름에 맞게 수정

### Fixed
- 권한 거부/요청 실패 시 노출되는 HealthKit 에러 메시지를 한국어로 통일
- 테스트가 새 로컬라이제이션 키를 검증하도록 갱신

### Removed
- 없음

## 🔍 Technical Details
`HealthKitPermissionGateView`와 `HealthKitPermissionViewModel`이 하드코딩 문자열 대신 `Localization` 모듈을 사용하도록 바꿨습니다. 시스템 권한 팝업은 plist usage description으로 노출되므로 앱/워치 양쪽 plist를 함께 수정했습니다.

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [x] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS Simulator 26.4
- Device: iOS Simulator
- Xcode Version: Xcode 26.x

### Test Results
- `make lint`
- `make arch-check`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,id=E4179829-6A0A-4225-9948-1D26076E4C30' -sdk iphonesimulator -derivedDataPath /tmp/MulimiIssue165Presentation`
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
리뷰 시 권한 팝업 문구와 앱 내부 권한 안내가 한국어 톤으로 자연스럽게 이어지는지 확인해주시면 됩니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [ ] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
