### PR TITLE
feat: add personalized routine recommendations

### DIFF
--- a/Docs/product-specs/routine-notifications.md
+++ b/Docs/product-specs/routine-notifications.md
@@ -7,6 +7,7 @@
 ## Product Rules
 
 - 루틴은 사용자가 직접 추가, 수정, 삭제할 수 있다
+- 루틴 화면은 최근 기록 기반 추천 루틴을 제안할 수 있다
 - 알림 권한이 없으면 저장 전 또는 저장 후 적절한 안내를 제공한다
 - 시스템 권한 팝업과 앱 내부 안내 문구는 현재 로컬라이제이션 톤을 따른다
 - 루틴이 비활성화되면 해당 스케줄의 알림도 반영돼야 한다
@@ -24,12 +25,14 @@
 
 - 현재 루틴 저장소는 `UserDefaults` JSON
 - 알림 스케줄은 저장된 활성 루틴 기준으로 재구성한다
+- 추천 루틴은 최근 `HealthKit` 기록과 현재 활성 루틴을 바탕으로 계산한다
 
 ## Related Code
 
 - `Project/Presentation/Sources/View/Profile/ProfileRoutineView.swift`
 - `Project/Presentation/Sources/View/Profile/RoutineEditorView.swift`
 - `Project/Presentation/Sources/ViewModel/ProfileRoutineViewModel.swift`
+- `Project/Domain/Sources/UseCase/RoutineRecommendationUseCaseImpl.swift`
 - `Project/Data/Sources/DataSource/RoutineNotificationDataSource.swift`
 
 ## Related Docs

--- a/Project/Domain/Interfaces/Entity/HydrationRoutineRecommendation.swift
+++ b/Project/Domain/Interfaces/Entity/HydrationRoutineRecommendation.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public enum HydrationRoutineRecommendationKind: String, Equatable, Sendable {
+    case morningStart
+    case afternoonGap
+    case frequentHydrationWindow
+}
+
+public struct HydrationRoutineRecommendation: Identifiable, Equatable, Sendable {
+    public let kind: HydrationRoutineRecommendationKind
+    public let hour: Int
+    public let minute: Int
+    public let weekdays: [RoutineWeekday]
+
+    public init(
+        kind: HydrationRoutineRecommendationKind,
+        hour: Int,
+        minute: Int,
+        weekdays: [RoutineWeekday]
+    ) {
+        self.kind = kind
+        self.hour = hour
+        self.minute = minute
+        self.weekdays = RoutineWeekday.normalized(weekdays)
+    }
+
+    public var id: String {
+        let weekdayKey = weekdays.map(\.rawValue).map(String.init).joined(separator: "-")
+        return "\(kind.rawValue)-\(hour)-\(minute)-\(weekdayKey)"
+    }
+}

--- a/Project/Domain/Interfaces/UseCase/RoutineRecommendationUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/RoutineRecommendationUseCase.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public protocol RoutineRecommendationUseCase: Sendable {
+    func fetchRecommendations(
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> [HydrationRoutineRecommendation]
+}

--- a/Project/Domain/Sources/UseCase/RoutineRecommendationUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/RoutineRecommendationUseCaseImpl.swift
@@ -1,0 +1,365 @@
+import DomainLayerInterface
+import Foundation
+
+public struct RoutineRecommendationUseCaseImpl: RoutineRecommendationUseCase {
+    private struct DaySummary {
+        let date: Date
+        let events: [HydrationEvent]
+    }
+
+    private enum Constants {
+        static let analysisDays = 14
+        static let minimumEventDays = 5
+        static let morningCutoffHour = 12
+        static let morningRecommendedHour = 9
+        static let afternoonRecommendedHour = 15
+        static let frequentBucketMinutes = 30
+        static let minimumFrequentDayCount = 3
+        static let minimumAfternoonGapDays = 3
+        static let recommendationProximityMinutes = 60
+        static let problemDayRateThreshold = 0.5
+        static let defaultWeekdays: [RoutineWeekday] = [.monday, .tuesday, .wednesday, .thursday, .friday]
+    }
+
+    private let routineUseCase: RoutineUseCase
+    private let drinkWaterRepository: DrinkWaterRepository
+
+    public init(
+        routineUseCase: RoutineUseCase,
+        drinkWaterRepository: DrinkWaterRepository
+    ) {
+        self.routineUseCase = routineUseCase
+        self.drinkWaterRepository = drinkWaterRepository
+    }
+
+    public func fetchRecommendations(
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> [HydrationRoutineRecommendation] {
+        let enabledRoutines = routineUseCase.fetchRoutines().filter(\.isEnabled)
+        let interval = analysisInterval(referenceDate: referenceDate, calendar: calendar)
+        let events = await drinkWaterRepository.hydrationEvents(in: interval)
+            .sorted { $0.consumedAt < $1.consumedAt }
+
+        let daySummaries = makeDaySummaries(events: events, calendar: calendar)
+        guard !daySummaries.isEmpty else {
+            return []
+        }
+
+        let fallbackWeekdays = fallbackWeekdays(
+            existingRoutines: enabledRoutines,
+            daySummaries: daySummaries,
+            calendar: calendar
+        )
+
+        var recommendations: [HydrationRoutineRecommendation] = []
+
+        if let frequentRecommendation = frequentHydrationRecommendation(
+            from: daySummaries,
+            existingRoutines: enabledRoutines,
+            fallbackWeekdays: fallbackWeekdays,
+            calendar: calendar
+        ) {
+            recommendations.append(frequentRecommendation)
+        }
+
+        if let morningRecommendation = morningStartRecommendation(
+            from: daySummaries,
+            fallbackWeekdays: fallbackWeekdays,
+            calendar: calendar
+        ), isDistinct(
+            morningRecommendation,
+            existingRoutines: enabledRoutines,
+            currentRecommendations: recommendations
+        ) {
+            recommendations.append(morningRecommendation)
+        }
+
+        if let afternoonRecommendation = afternoonGapRecommendation(
+            from: daySummaries,
+            fallbackWeekdays: fallbackWeekdays,
+            calendar: calendar
+        ), isDistinct(
+            afternoonRecommendation,
+            existingRoutines: enabledRoutines,
+            currentRecommendations: recommendations
+        ) {
+            recommendations.append(afternoonRecommendation)
+        }
+
+        return recommendations
+    }
+
+    private func analysisInterval(
+        referenceDate: Date,
+        calendar: Calendar
+    ) -> DateInterval {
+        let startOfReferenceDay = calendar.startOfDay(for: referenceDate)
+        let start = calendar.date(
+            byAdding: .day,
+            value: -(Constants.analysisDays - 1),
+            to: startOfReferenceDay
+        ) ?? startOfReferenceDay
+        let end = calendar.date(byAdding: .day, value: 1, to: startOfReferenceDay) ?? referenceDate
+        return DateInterval(start: start, end: end)
+    }
+
+    private func makeDaySummaries(
+        events: [HydrationEvent],
+        calendar: Calendar
+    ) -> [DaySummary] {
+        let grouped = Dictionary(grouping: events) {
+            calendar.startOfDay(for: $0.consumedAt)
+        }
+
+        return grouped.keys.sorted().compactMap { day in
+            guard let dayEvents = grouped[day]?.sorted(by: { $0.consumedAt < $1.consumedAt }),
+                  !dayEvents.isEmpty else {
+                return nil
+            }
+
+            return DaySummary(date: day, events: dayEvents)
+        }
+    }
+
+    private func frequentHydrationRecommendation(
+        from daySummaries: [DaySummary],
+        existingRoutines: [HydrationRoutine],
+        fallbackWeekdays: [RoutineWeekday],
+        calendar: Calendar
+    ) -> HydrationRoutineRecommendation? {
+        var datesByBucket: [Int: Set<Date>] = [:]
+
+        for daySummary in daySummaries {
+            let bucketMinutes = Set(
+                daySummary.events.map { event in
+                    roundedBucket(minuteOfDay(for: event.consumedAt, calendar: calendar))
+                }
+            )
+
+            for bucketMinute in bucketMinutes {
+                datesByBucket[bucketMinute, default: []].insert(daySummary.date)
+            }
+        }
+
+        let sortedBuckets = datesByBucket.sorted { lhs, rhs in
+            if lhs.value.count != rhs.value.count {
+                return lhs.value.count > rhs.value.count
+            }
+
+            return lhs.key < rhs.key
+        }
+
+        for (bucketMinute, dates) in sortedBuckets {
+            guard dates.count >= Constants.minimumFrequentDayCount else {
+                break
+            }
+
+            let weekdays = preferredWeekdays(
+                from: Array(dates),
+                calendar: calendar,
+                minimumCount: 1
+            )
+            let recommendation = HydrationRoutineRecommendation(
+                kind: .frequentHydrationWindow,
+                hour: bucketMinute / 60,
+                minute: bucketMinute % 60,
+                weekdays: weekdays.isEmpty ? fallbackWeekdays : weekdays
+            )
+
+            if !overlapsExistingRoutine(recommendation, routines: existingRoutines) {
+                return recommendation
+            }
+        }
+
+        return nil
+    }
+
+    private func morningStartRecommendation(
+        from daySummaries: [DaySummary],
+        fallbackWeekdays: [RoutineWeekday],
+        calendar: Calendar
+    ) -> HydrationRoutineRecommendation? {
+        guard daySummaries.count >= Constants.minimumEventDays else {
+            return nil
+        }
+
+        let lateMorningDates = daySummaries.compactMap { summary -> Date? in
+            guard let firstEvent = summary.events.first else {
+                return nil
+            }
+
+            let firstHour = calendar.component(.hour, from: firstEvent.consumedAt)
+            return firstHour >= Constants.morningCutoffHour ? summary.date : nil
+        }
+
+        guard problemDayRate(problemDays: lateMorningDates.count, totalDays: daySummaries.count) >= Constants.problemDayRateThreshold else {
+            return nil
+        }
+
+        let weekdays = preferredWeekdays(
+            from: lateMorningDates,
+            calendar: calendar,
+            minimumCount: 2
+        )
+
+        return HydrationRoutineRecommendation(
+            kind: .morningStart,
+            hour: Constants.morningRecommendedHour,
+            minute: 0,
+            weekdays: weekdays.isEmpty ? fallbackWeekdays : weekdays
+        )
+    }
+
+    private func afternoonGapRecommendation(
+        from daySummaries: [DaySummary],
+        fallbackWeekdays: [RoutineWeekday],
+        calendar: Calendar
+    ) -> HydrationRoutineRecommendation? {
+        let gapDates = daySummaries.compactMap { summary -> Date? in
+            let eventMinutes = summary.events.map { minuteOfDay(for: $0.consumedAt, calendar: calendar) }
+            let hasPreAfternoon = eventMinutes.contains { $0 < 13 * 60 }
+            let hasEvening = eventMinutes.contains { $0 >= 17 * 60 }
+            let hasAfternoon = eventMinutes.contains { $0 >= 13 * 60 && $0 < 17 * 60 }
+
+            guard hasPreAfternoon, hasEvening, !hasAfternoon else {
+                return nil
+            }
+
+            return summary.date
+        }
+
+        guard gapDates.count >= Constants.minimumAfternoonGapDays else {
+            return nil
+        }
+
+        let weekdays = preferredWeekdays(
+            from: gapDates,
+            calendar: calendar,
+            minimumCount: 2
+        )
+
+        return HydrationRoutineRecommendation(
+            kind: .afternoonGap,
+            hour: Constants.afternoonRecommendedHour,
+            minute: 0,
+            weekdays: weekdays.isEmpty ? fallbackWeekdays : weekdays
+        )
+    }
+
+    private func fallbackWeekdays(
+        existingRoutines: [HydrationRoutine],
+        daySummaries: [DaySummary],
+        calendar: Calendar
+    ) -> [RoutineWeekday] {
+        let existingWeekdays = RoutineWeekday.displayOrder.filter { weekday in
+            existingRoutines.contains { $0.weekdays.contains(weekday) }
+        }
+
+        if !existingWeekdays.isEmpty {
+            return existingWeekdays
+        }
+
+        let eventWeekdays = preferredWeekdays(
+            from: daySummaries.map(\.date),
+            calendar: calendar,
+            minimumCount: 1
+        )
+
+        return eventWeekdays.isEmpty ? Constants.defaultWeekdays : eventWeekdays
+    }
+
+    private func preferredWeekdays(
+        from dates: [Date],
+        calendar: Calendar,
+        minimumCount: Int
+    ) -> [RoutineWeekday] {
+        let counts = dates.reduce(into: [RoutineWeekday: Int]()) { partialResult, date in
+            guard let weekday = RoutineWeekday(rawValue: calendar.component(.weekday, from: date)) else {
+                return
+            }
+
+            partialResult[weekday, default: 0] += 1
+        }
+
+        let preferred = RoutineWeekday.displayOrder.filter {
+            counts[$0, default: 0] >= minimumCount
+        }
+
+        if !preferred.isEmpty {
+            return preferred
+        }
+
+        return RoutineWeekday.displayOrder.filter {
+            counts[$0, default: 0] > 0
+        }
+    }
+
+    private func isDistinct(
+        _ recommendation: HydrationRoutineRecommendation,
+        existingRoutines: [HydrationRoutine],
+        currentRecommendations: [HydrationRoutineRecommendation]
+    ) -> Bool {
+        if overlapsExistingRoutine(recommendation, routines: existingRoutines) {
+            return false
+        }
+
+        return !currentRecommendations.contains { existing in
+            overlaps(recommendation, with: existing)
+        }
+    }
+
+    private func overlapsExistingRoutine(
+        _ recommendation: HydrationRoutineRecommendation,
+        routines: [HydrationRoutine]
+    ) -> Bool {
+        routines.contains { routine in
+            let weekdayOverlap = !Set(routine.weekdays).isDisjoint(with: recommendation.weekdays)
+            let minuteDifference = abs(
+                minuteOfDay(hour: routine.hour, minute: routine.minute) -
+                minuteOfDay(hour: recommendation.hour, minute: recommendation.minute)
+            )
+
+            return weekdayOverlap && minuteDifference <= Constants.recommendationProximityMinutes
+        }
+    }
+
+    private func overlaps(
+        _ lhs: HydrationRoutineRecommendation,
+        with rhs: HydrationRoutineRecommendation
+    ) -> Bool {
+        let weekdayOverlap = !Set(lhs.weekdays).isDisjoint(with: rhs.weekdays)
+        let minuteDifference = abs(
+            minuteOfDay(hour: lhs.hour, minute: lhs.minute) -
+            minuteOfDay(hour: rhs.hour, minute: rhs.minute)
+        )
+
+        return weekdayOverlap && minuteDifference <= Constants.recommendationProximityMinutes
+    }
+
+    private func problemDayRate(problemDays: Int, totalDays: Int) -> Double {
+        guard totalDays > 0 else {
+            return 0
+        }
+
+        return Double(problemDays) / Double(totalDays)
+    }
+
+    private func roundedBucket(_ minuteOfDay: Int) -> Int {
+        let rounded = ((minuteOfDay + (Constants.frequentBucketMinutes / 2)) / Constants.frequentBucketMinutes)
+            * Constants.frequentBucketMinutes
+        return min(rounded, (23 * 60) + 30)
+    }
+
+    private func minuteOfDay(
+        for date: Date,
+        calendar: Calendar
+    ) -> Int {
+        let components = calendar.dateComponents([.hour, .minute], from: date)
+        return minuteOfDay(hour: components.hour ?? 0, minute: components.minute ?? 0)
+    }
+
+    private func minuteOfDay(hour: Int, minute: Int) -> Int {
+        hour * 60 + minute
+    }
+}

--- a/Project/Domain/Tests/RoutineRecommendationUseCaseTests.swift
+++ b/Project/Domain/Tests/RoutineRecommendationUseCaseTests.swift
@@ -1,0 +1,166 @@
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import DomainLayer
+
+@Suite("RoutineRecommendationUseCase Tests")
+struct RoutineRecommendationUseCaseTests {
+    @Test("아침 첫 물이 늦어지는 날이 많으면 아침 루틴 추천을 반환한다")
+    func morningStartRecommendation() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: 9, hour: 10))!
+        let routineRepository = MockRoutineRepository()
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        drinkWaterRepository.setHydrationEvents(
+            makeEvents(
+                calendar: calendar,
+                referenceDate: referenceDate,
+                offsets: [0, 1, 2, 3, 6, 7],
+                hours: [13]
+            )
+        )
+        let useCase = RoutineRecommendationUseCaseImpl(
+            routineUseCase: RoutineUseCaseImpl(repository: routineRepository),
+            drinkWaterRepository: drinkWaterRepository
+        )
+
+        let recommendations = await useCase.fetchRecommendations(
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        #expect(recommendations.contains {
+            $0.kind == .morningStart && $0.hour == 9 && $0.minute == 0 && !$0.weekdays.isEmpty
+        })
+    }
+
+    @Test("오후 공백이 반복되면 오후 보충 루틴 추천을 반환한다")
+    func afternoonGapRecommendation() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: 9, hour: 10))!
+        let routineRepository = MockRoutineRepository()
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        drinkWaterRepository.setHydrationEvents(
+            makeEvents(
+                calendar: calendar,
+                referenceDate: referenceDate,
+                offsets: [0, 1, 2, 7, 8, 9],
+                hours: [9, 19]
+            )
+        )
+        let useCase = RoutineRecommendationUseCaseImpl(
+            routineUseCase: RoutineUseCaseImpl(repository: routineRepository),
+            drinkWaterRepository: drinkWaterRepository
+        )
+
+        let recommendations = await useCase.fetchRecommendations(
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        #expect(recommendations.contains {
+            $0.kind == .afternoonGap && $0.hour == 15 && $0.minute == 0
+        })
+    }
+
+    @Test("최근 자주 마신 시간대가 있으면 해당 시간 루틴 추천을 반환한다")
+    func frequentHydrationRecommendation() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: 9, hour: 10))!
+        let routineRepository = MockRoutineRepository()
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        drinkWaterRepository.setHydrationEvents(
+            makeEvents(
+                calendar: calendar,
+                referenceDate: referenceDate,
+                offsets: [0, 2, 4, 7],
+                hours: [11],
+                minute: 30
+            )
+        )
+        let useCase = RoutineRecommendationUseCaseImpl(
+            routineUseCase: RoutineUseCaseImpl(repository: routineRepository),
+            drinkWaterRepository: drinkWaterRepository
+        )
+
+        let recommendations = await useCase.fetchRecommendations(
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        #expect(recommendations.first?.kind == .frequentHydrationWindow)
+        #expect(recommendations.first?.hour == 11)
+        #expect(recommendations.first?.minute == 30)
+    }
+
+    @Test("기존 활성 루틴과 겹치는 추천은 제외한다")
+    func duplicateRecommendationIsFiltered() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: 10, hour: 10))!
+        let routineRepository = MockRoutineRepository()
+        routineRepository.routines = [
+            HydrationRoutine(
+                title: "자주 마시는 시간",
+                hour: 11,
+                minute: 30,
+                weekdays: [.monday, .wednesday, .friday],
+                isEnabled: true
+            )
+        ]
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        drinkWaterRepository.setHydrationEvents(
+            makeEvents(
+                calendar: calendar,
+                referenceDate: referenceDate,
+                offsets: [0, 2, 4],
+                hours: [11],
+                minute: 30
+            )
+        )
+        let useCase = RoutineRecommendationUseCaseImpl(
+            routineUseCase: RoutineUseCaseImpl(repository: routineRepository),
+            drinkWaterRepository: drinkWaterRepository
+        )
+
+        let recommendations = await useCase.fetchRecommendations(
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        #expect(recommendations.contains(where: { $0.kind == .frequentHydrationWindow }) == false)
+    }
+
+    private func makeEvents(
+        calendar: Calendar,
+        referenceDate: Date,
+        offsets: [Int],
+        hours: [Int],
+        minute: Int = 0
+    ) -> [HydrationEvent] {
+        offsets.flatMap { offset in
+            hours.map { hour in
+                let day = calendar.date(byAdding: .day, value: -offset, to: referenceDate) ?? referenceDate
+                let consumedAt = calendar.date(
+                    bySettingHour: hour,
+                    minute: minute,
+                    second: 0,
+                    of: day
+                ) ?? day
+
+                return HydrationEvent(
+                    id: UUID(),
+                    consumedAt: consumedAt,
+                    volumeML: 250
+                )
+            }
+        }
+    }
+
+    private func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
+        return calendar
+    }
+}

--- a/Project/Presentation/Sources/Extensions/HydrationRoutineRecommendation+Presentation.swift
+++ b/Project/Presentation/Sources/Extensions/HydrationRoutineRecommendation+Presentation.swift
@@ -1,0 +1,21 @@
+import DomainLayerInterface
+import Foundation
+import Localization
+
+extension HydrationRoutineRecommendation {
+    var timeText: String {
+        var calendar = Calendar.current
+        calendar.locale = .current
+
+        let date = calendar.date(from: DateComponents(hour: hour, minute: minute)) ?? .now
+        return DateFormatter.localizedString(from: date, dateStyle: .none, timeStyle: .short)
+    }
+
+    var weekdayText: String {
+        if weekdays.count == RoutineWeekday.allCases.count {
+            return L10n.tr("profileRoutineRepeatEverydayValue")
+        }
+
+        return weekdays.map(\.shortDisplayName).joined(separator: ", ")
+    }
+}

--- a/Project/Presentation/Sources/View/Profile/ProfileRoutineView.swift
+++ b/Project/Presentation/Sources/View/Profile/ProfileRoutineView.swift
@@ -17,6 +17,22 @@ public struct ProfileRoutineView: View {
                 guidanceCard
             }
 
+            if !viewModel.recommendationCards.isEmpty {
+                Section(
+                    content: {
+                    ForEach(viewModel.recommendationCards) { recommendation in
+                        recommendationCard(recommendation)
+                    }
+                    },
+                    header: {
+                        Text(L10n.tr("profileRoutineRecommendationSectionTitle"))
+                    },
+                    footer: {
+                        Text(L10n.tr("profileRoutineRecommendationSectionFootnote"))
+                    }
+                )
+            }
+
             permissionSection
 
             Section {
@@ -258,6 +274,45 @@ public struct ProfileRoutineView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
+    private func recommendationCard(_ recommendation: RoutineRecommendationCard) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: recommendationIconName(for: recommendation.id))
+                    .font(.title3)
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(recommendation.title)
+                        .font(.headline)
+                        .foregroundColor(.primary)
+
+                    Text(recommendation.description)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Label(
+                L10n.tr(
+                    "profileRoutineRecommendationTimeValueFormat",
+                    recommendation.timeText,
+                    recommendation.weekdayText
+                ),
+                systemImage: "clock"
+            )
+            .font(.subheadline.weight(.semibold))
+            .foregroundColor(.primary)
+
+            Button(recommendation.applyButtonTitle) {
+                viewModel.presentRecommendation(id: recommendation.id)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding(.vertical, 4)
+    }
+
     private func guidanceSlotChip(_ slot: RoutineGuidanceSlot) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(slot.timeText)
@@ -312,6 +367,18 @@ public struct ProfileRoutineView: View {
         case .upcoming:
             return L10n.tr("profileRoutineGuidanceSlotUpcomingTitle")
         }
+    }
+
+    private func recommendationIconName(for id: String) -> String {
+        if id.hasPrefix(HydrationRoutineRecommendationKind.morningStart.rawValue) {
+            return "sun.max.fill"
+        }
+
+        if id.hasPrefix(HydrationRoutineRecommendationKind.afternoonGap.rawValue) {
+            return "sun.haze.fill"
+        }
+
+        return "sparkles"
     }
 
     private func openSettings() {

--- a/Project/Presentation/Sources/ViewModel/ProfileRoutineViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/ProfileRoutineViewModel.swift
@@ -56,6 +56,15 @@ struct RoutinePermissionGuidance: Equatable {
     let showsOpenSettingsAction: Bool
 }
 
+struct RoutineRecommendationCard: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let description: String
+    let timeText: String
+    let weekdayText: String
+    let applyButtonTitle: String
+}
+
 struct RoutineEditorDraft: Equatable {
     var id: UUID?
     var title: String
@@ -83,6 +92,14 @@ struct RoutineEditorDraft: Equatable {
         self.time = Self.date(hour: routine.hour, minute: routine.minute)
         self.selectedWeekdays = Set(routine.weekdays)
         self.isEnabled = routine.isEnabled
+    }
+
+    init(recommendation: HydrationRoutineRecommendation, title: String) {
+        self.id = nil
+        self.title = title
+        self.time = Self.date(hour: recommendation.hour, minute: recommendation.minute)
+        self.selectedWeekdays = Set(recommendation.weekdays)
+        self.isEnabled = true
     }
 
     var isEditing: Bool {
@@ -118,6 +135,7 @@ struct RoutineEditorDraft: Equatable {
 @Observable
 public final class ProfileRoutineViewModel {
     private let routineUseCase: RoutineUseCase
+    private let routineRecommendationUseCase: RoutineRecommendationUseCase
     private let drinkWaterUseCase: DrinkWaterUseCase
     private let userPreferencesUseCase: UserPreferencesUseCase
     private let calendar: Calendar
@@ -125,6 +143,7 @@ public final class ProfileRoutineViewModel {
 
     public private(set) var notificationStatus: RoutineNotificationAuthorizationStatus = .notDetermined
     public private(set) var routines: [HydrationRoutine] = []
+    private var routineRecommendations: [HydrationRoutineRecommendation] = []
     public private(set) var currentWaterIntakeML = 0.0
     public private(set) var dailyWaterLimitML = 0
     public var isEditorPresented = false
@@ -135,12 +154,14 @@ public final class ProfileRoutineViewModel {
 
     public init(
         routineUseCase: RoutineUseCase,
+        routineRecommendationUseCase: RoutineRecommendationUseCase,
         drinkWaterUseCase: DrinkWaterUseCase,
         userPreferencesUseCase: UserPreferencesUseCase,
         calendar: Calendar = .current,
         nowProvider: @escaping @Sendable () -> Date = { .now }
     ) {
         self.routineUseCase = routineUseCase
+        self.routineRecommendationUseCase = routineRecommendationUseCase
         self.drinkWaterUseCase = drinkWaterUseCase
         self.userPreferencesUseCase = userPreferencesUseCase
         self.calendar = calendar
@@ -182,6 +203,19 @@ public final class ProfileRoutineViewModel {
 
     var displayedRoutines: [HydrationRoutine] {
         routines
+    }
+
+    var recommendationCards: [RoutineRecommendationCard] {
+        routineRecommendations.map { recommendation in
+            RoutineRecommendationCard(
+                id: recommendation.id,
+                title: recommendationTitle(for: recommendation.kind),
+                description: recommendationDescription(for: recommendation.kind),
+                timeText: recommendation.timeText,
+                weekdayText: recommendation.weekdayText,
+                applyButtonTitle: L10n.tr("profileRoutineRecommendationApplyTitle")
+            )
+        }
     }
 
     var canSaveDraft: Bool {
@@ -334,6 +368,10 @@ public final class ProfileRoutineViewModel {
     public func load() async {
         notificationStatus = await routineUseCase.notificationAuthorizationStatus()
         routines = routineUseCase.fetchRoutines()
+        routineRecommendations = await routineRecommendationUseCase.fetchRecommendations(
+            referenceDate: nowProvider(),
+            calendar: calendar
+        )
         currentWaterIntakeML = await drinkWaterUseCase.currentWaterIntakeML
         dailyWaterLimitML = Int(userPreferencesUseCase.getDailyWaterLimit().rounded())
     }
@@ -359,6 +397,19 @@ public final class ProfileRoutineViewModel {
     public func presentEditRoutine(_ routine: HydrationRoutine) {
         permissionPrompt = nil
         editorDraft = RoutineEditorDraft(routine: routine)
+        isEditorPresented = true
+    }
+
+    public func presentRecommendation(id: String) {
+        guard let recommendation = routineRecommendations.first(where: { $0.id == id }) else {
+            return
+        }
+
+        permissionPrompt = nil
+        editorDraft = RoutineEditorDraft(
+            recommendation: recommendation,
+            title: recommendationRoutineTitle(for: recommendation.kind)
+        )
         isEditorPresented = true
     }
 
@@ -460,6 +511,40 @@ public final class ProfileRoutineViewModel {
             errorMessage = L10n.tr("profileRoutineSaveError")
         }
     }
+
+    private func recommendationTitle(for kind: HydrationRoutineRecommendationKind) -> String {
+        switch kind {
+        case .morningStart:
+            return L10n.tr("profileRoutineRecommendationMorningTitle")
+        case .afternoonGap:
+            return L10n.tr("profileRoutineRecommendationAfternoonTitle")
+        case .frequentHydrationWindow:
+            return L10n.tr("profileRoutineRecommendationFrequentTitle")
+        }
+    }
+
+    private func recommendationDescription(for kind: HydrationRoutineRecommendationKind) -> String {
+        switch kind {
+        case .morningStart:
+            return L10n.tr("profileRoutineRecommendationMorningDescription")
+        case .afternoonGap:
+            return L10n.tr("profileRoutineRecommendationAfternoonDescription")
+        case .frequentHydrationWindow:
+            return L10n.tr("profileRoutineRecommendationFrequentDescription")
+        }
+    }
+
+    private func recommendationRoutineTitle(for kind: HydrationRoutineRecommendationKind) -> String {
+        switch kind {
+        case .morningStart:
+            return L10n.tr("profileRoutineRecommendationMorningRoutineName")
+        case .afternoonGap:
+            return L10n.tr("profileRoutineRecommendationAfternoonRoutineName")
+        case .frequentHydrationWindow:
+            return L10n.tr("profileRoutineRecommendationFrequentRoutineName")
+        }
+    }
+
     private var primaryRoutine: HydrationRoutine? {
         routines.first(where: \.isEnabled) ?? routines.first
     }

--- a/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
+++ b/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
@@ -73,6 +73,19 @@ struct ProfileRoutineViewModelTests {
         func reset() async {}
     }
 
+    private final class SpyRoutineRecommendationUseCase: RoutineRecommendationUseCase, @unchecked Sendable {
+        var recommendations: [HydrationRoutineRecommendation] = []
+        private(set) var fetchCallCount = 0
+
+        func fetchRecommendations(
+            referenceDate: Date,
+            calendar: Calendar
+        ) async -> [HydrationRoutineRecommendation] {
+            fetchCallCount += 1
+            return recommendations
+        }
+    }
+
     private final class SpyUserPreferencesUseCase: UserPreferencesUseCase, @unchecked Sendable {
         var dailyWaterLimit: Double = 2000
 
@@ -106,6 +119,7 @@ struct ProfileRoutineViewModelTests {
     @MainActor
     private func makeViewModel(
         routineUseCase: SpyRoutineUseCase = SpyRoutineUseCase(),
+        routineRecommendationUseCase: SpyRoutineRecommendationUseCase = SpyRoutineRecommendationUseCase(),
         drinkWaterUseCase: SpyDrinkWaterUseCase = SpyDrinkWaterUseCase(),
         userPreferencesUseCase: SpyUserPreferencesUseCase = SpyUserPreferencesUseCase(),
         now: Date? = nil
@@ -116,6 +130,7 @@ struct ProfileRoutineViewModelTests {
 
         return ProfileRoutineViewModel(
             routineUseCase: routineUseCase,
+            routineRecommendationUseCase: routineRecommendationUseCase,
             drinkWaterUseCase: drinkWaterUseCase,
             userPreferencesUseCase: userPreferencesUseCase,
             calendar: calendar,
@@ -170,6 +185,49 @@ struct ProfileRoutineViewModelTests {
         #expect(viewModel.summaryDescription == "\(routine.timeText) · \(routine.weekdayText)")
         #expect(viewModel.notificationStatus == .authorized)
         #expect(viewModel.displayedRoutines == [routine])
+    }
+
+    @MainActor
+    @Test("load는 추천 루틴 카드를 함께 계산한다")
+    func loadRecommendations() async {
+        let recommendationUseCase = SpyRoutineRecommendationUseCase()
+        recommendationUseCase.recommendations = [
+            HydrationRoutineRecommendation(
+                kind: .morningStart,
+                hour: 9,
+                minute: 0,
+                weekdays: [.monday, .tuesday, .wednesday, .thursday, .friday]
+            )
+        ]
+        let viewModel = makeViewModel(routineRecommendationUseCase: recommendationUseCase)
+
+        await viewModel.load()
+
+        #expect(recommendationUseCase.fetchCallCount == 1)
+        #expect(viewModel.recommendationCards.count == 1)
+        #expect(viewModel.recommendationCards.first?.title == L10n.tr("profileRoutineRecommendationMorningTitle"))
+    }
+
+    @MainActor
+    @Test("추천 루틴을 선택하면 초안이 채워진 상태로 에디터를 연다")
+    func presentRecommendation() async {
+        let recommendationUseCase = SpyRoutineRecommendationUseCase()
+        recommendationUseCase.recommendations = [
+            HydrationRoutineRecommendation(
+                kind: .afternoonGap,
+                hour: 15,
+                minute: 0,
+                weekdays: [.monday, .wednesday, .friday]
+            )
+        ]
+        let viewModel = makeViewModel(routineRecommendationUseCase: recommendationUseCase)
+
+        await viewModel.load()
+        viewModel.presentRecommendation(id: viewModel.recommendationCards[0].id)
+
+        #expect(viewModel.isEditorPresented)
+        #expect(viewModel.editorDraft.title == L10n.tr("profileRoutineRecommendationAfternoonRoutineName"))
+        #expect(viewModel.editorDraft.selectedWeekdays == Set([.monday, .wednesday, .friday]))
     }
 
     @MainActor

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockRoutineRecommendationUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockRoutineRecommendationUseCase.swift
@@ -1,0 +1,26 @@
+import DomainLayerInterface
+import Foundation
+
+public final class MockRoutineRecommendationUseCase: RoutineRecommendationUseCase, @unchecked Sendable {
+    public var recommendations: [HydrationRoutineRecommendation]
+
+    public init(
+        recommendations: [HydrationRoutineRecommendation] = [
+            HydrationRoutineRecommendation(
+                kind: .afternoonGap,
+                hour: 15,
+                minute: 0,
+                weekdays: [.monday, .tuesday, .wednesday, .thursday, .friday]
+            )
+        ]
+    ) {
+        self.recommendations = recommendations
+    }
+
+    public func fetchRecommendations(
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> [HydrationRoutineRecommendation] {
+        recommendations
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -47,6 +47,9 @@ public final class PreviewAssembly: Assembly {
         container.register(PersonalizedChallengeUseCase.self) { _ in
             MockPersonalizedChallengeUseCase()
         }
+        container.register(RoutineRecommendationUseCase.self) { _ in
+            MockRoutineRecommendationUseCase()
+        }
 
         container.register(SignInUseCase.self) { _ in
             MockSignInUseCase()
@@ -101,12 +104,14 @@ public final class PreviewAssembly: Assembly {
 
         container.register(ProfileRoutineViewModel.self) { resolver in
             let routineUseCase = resolver.resolve(RoutineUseCase.self)!
+            let routineRecommendationUseCase = resolver.resolve(RoutineRecommendationUseCase.self)!
             let drinkWaterUseCase = resolver.resolve(DrinkWaterUseCase.self)!
             let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
 
             return MainActor.assumeIsolated {
                 ProfileRoutineViewModel(
                     routineUseCase: routineUseCase,
+                    routineRecommendationUseCase: routineRecommendationUseCase,
                     drinkWaterUseCase: drinkWaterUseCase,
                     userPreferencesUseCase: userPreferencesUseCase
                 )

--- a/Project/Shared/DependencyInjection/Sources/Preview/ViewPreviews.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/ViewPreviews.swift
@@ -61,6 +61,16 @@ import SwiftUI
         ],
         authorizationStatus: .authorized
     )
+    let mockRecommendationUseCase = MockRoutineRecommendationUseCase(
+        recommendations: [
+            HydrationRoutineRecommendation(
+                kind: .afternoonGap,
+                hour: 15,
+                minute: 0,
+                weekdays: [.monday, .tuesday, .wednesday, .thursday, .friday]
+            )
+        ]
+    )
     let mockDrinkWaterUseCase = MockDrinkWaterUseCase()
     mockDrinkWaterUseCase.currentWaterIntakeMLValue = 500
     let mockUserPreferencesUseCase = MockUserPreferencesUseCase()
@@ -69,6 +79,7 @@ import SwiftUI
     ProfileRoutineView(
         viewModel: ProfileRoutineViewModel(
             routineUseCase: mockUseCase,
+            routineRecommendationUseCase: mockRecommendationUseCase,
             drinkWaterUseCase: mockDrinkWaterUseCase,
             userPreferencesUseCase: mockUserPreferencesUseCase
         )

--- a/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
@@ -36,6 +36,12 @@ public final class DomainAssembly: Assembly {
                 drinkWaterRepository: resolver.resolve(DrinkWaterRepository.self)!
             )
         }
+        container.register(RoutineRecommendationUseCase.self) { resolver in
+            RoutineRecommendationUseCaseImpl(
+                routineUseCase: resolver.resolve(RoutineUseCase.self)!,
+                drinkWaterRepository: resolver.resolve(DrinkWaterRepository.self)!
+            )
+        }
 
         // MARK: - HealthKit
         container.register(HealthKitUseCase.self) { resolver in

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -84,12 +84,14 @@ public final class PresentationAssembly: Assembly {
 
         container.register(ProfileRoutineViewModel.self) { resolver in
             let routineUseCase = resolver.resolve(RoutineUseCase.self)!
+            let routineRecommendationUseCase = resolver.resolve(RoutineRecommendationUseCase.self)!
             let drinkWaterUseCase = resolver.resolve(DrinkWaterUseCase.self)!
             let userPreferencesUseCase = resolver.resolve(UserPreferencesUseCase.self)!
 
             return MainActor.assumeIsolated {
                 ProfileRoutineViewModel(
                     routineUseCase: routineUseCase,
+                    routineRecommendationUseCase: routineRecommendationUseCase,
                     drinkWaterUseCase: drinkWaterUseCase,
                     userPreferencesUseCase: userPreferencesUseCase
                 )

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockRoutineRecommendationUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockRoutineRecommendationUseCaseForTesting.swift
@@ -1,0 +1,15 @@
+import DomainLayerInterface
+import Foundation
+
+public final class MockRoutineRecommendationUseCaseForTesting: RoutineRecommendationUseCase, @unchecked Sendable {
+    public var recommendations: [HydrationRoutineRecommendation] = []
+
+    public init() {}
+
+    public func fetchRecommendations(
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> [HydrationRoutineRecommendation] {
+        recommendations
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Testing/TestingAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/TestingAssembly.swift
@@ -33,6 +33,9 @@ public final class TestingAssembly: Assembly {
         container.register(PersonalizedChallengeUseCase.self) { _ in
             MockPersonalizedChallengeUseCaseForTesting()
         }
+        container.register(RoutineRecommendationUseCase.self) { _ in
+            MockRoutineRecommendationUseCaseForTesting()
+        }
 
         container.register(RoutineUseCase.self) { _ in
             MockRoutineUseCaseForTesting()

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -3246,6 +3246,149 @@
         }
       }
     },
+    "profileRoutineRecommendationAfternoonDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오후 공백이 길어지는 날이 많아 중간 보충 루틴을 추천해요."
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationAfternoonRoutineName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오후 물 보충"
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationAfternoonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오후 보충 루틴"
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationApplyTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천 적용하기"
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationFrequentDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 자주 마신 시간대를 루틴으로 고정해 꾸준함을 만들 수 있어요."
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationFrequentRoutineName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자주 마시는 시간"
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationFrequentTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자주 마시는 시간 루틴"
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationMorningDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첫 물 마시기가 자주 늦어져서 아침 시작 루틴을 추천해요."
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationMorningRoutineName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아침 물 마시기"
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationMorningTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아침 시작 루틴"
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationSectionFootnote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 기록과 현재 루틴을 바탕으로 바로 추가할 만한 시간을 골랐어요."
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationSectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천 루틴"
+          }
+        }
+      }
+    },
+    "profileRoutineRecommendationTimeValueFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · %@"
+          }
+        }
+      }
+    },
     "profileRoutineRequestPermissionTitle" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## 📝 Summary
최근 수분 기록과 현재 활성 루틴을 기반으로 개인화 루틴 추천을 추가했습니다. 추천 카드를 통해 아침 첫 물, 오후 공백, 자주 마시는 시간대 후보를 제안하고, 탭 시 루틴 에디터 초안이 바로 채워지도록 연결했습니다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #174

## 📋 Changes Made
### Added
- 최근 기록과 활성 루틴을 바탕으로 추천 후보를 계산하는 `RoutineRecommendationUseCase` 추가
- 개인화 루틴 추천 도메인 엔티티 및 도메인 테스트 추가
- 프로필 루틴 화면의 추천 카드 UI 및 추천 선택 시 루틴 초안 프리필 흐름 추가
- Preview/Testing DI용 mock recommendation use case 추가

### Changed
- `ProfileRoutineViewModel`이 루틴 목록과 함께 추천 카드도 계산하도록 확장
- `DomainAssembly`, `PresentationAssembly`, `TestingAssembly`, `PreviewAssembly`에 추천 use case 주입 추가
- 루틴/알림 product spec 문서에 추천 루틴 흐름 반영
- 로컬라이제이션 문자열 추가

### Fixed
- 기존 활성 루틴과 중복되는 추천 후보가 노출되지 않도록 보정

## 🔍 Technical Details
- 추천 규칙은 `Domain` 계층에 두고 최근 14일 수분 기록을 기반으로 계산합니다.
- 추천 타입은 `morningStart`, `afternoonGap`, `frequentHydrationWindow`로 분리했습니다.
- 기존 활성 루틴과 요일/시간이 겹치는 후보는 필터링하고, Presentation에서는 추천을 편집 초안으로만 변환합니다.

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: iOS Simulator
- Device: Simulator (`E4179829-6A0A-4225-9948-1D26076E4C30`)
- Xcode Version: 26.4 (17E192)

### Test Results
- `tuist generate`
- `make lint`
- `make arch-check`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer -destination 'platform=iOS Simulator,id=E4179829-6A0A-4225-9948-1D26076E4C30' -sdk iphonesimulator`
- `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,id=E4179829-6A0A-4225-9948-1D26076E4C30' -sdk iphonesimulator`
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- 알림 권한이 없어도 추천 카드를 통해 루틴 초안 생성까지는 가능하도록 유지했습니다.
- 추천 규칙과 표현 로직은 `Domain` / `Presentation` 경계를 유지하도록 분리했습니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [x] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
