### PR TITLE
💄 홈 탭 내비게이션 UI 정리

### DIFF
--- a/Project/App/Sources/ContentView.swift
+++ b/Project/App/Sources/ContentView.swift
@@ -99,8 +99,6 @@ struct ContentView: View {
                     Label(L10n.tr("profileTitle"), systemImage: "person.crop.circle")
                 }
             }
-            .navigationTitle(navigationTitle)
-            .navigationBarTitleDisplayMode(.large)
             .navigationDestination(for: AppRoute.self) { route in
                 destinationView(for: route)
             }
@@ -153,21 +151,6 @@ struct ContentView: View {
             case .withdrawal:
                 SettingDetailView(menu: .withdrawal, viewModel: settingsViewModel)
             }
-        }
-    }
-
-    private var navigationTitle: String {
-        switch selectedTab {
-        case .drink:
-            L10n.tr("drinkTitle")
-        case .history:
-            L10n.tr("historyTitle")
-        case .insight:
-            L10n.tr("insightNavigationTitle")
-        case .challenge:
-            L10n.tr("challengeTitle")
-        case .profile:
-            L10n.tr("profileTitle")
         }
     }
 

--- a/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
+++ b/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
@@ -23,8 +23,13 @@ public struct DrinkWaterView: View {
                 .ignoresSafeArea()
 
             VStack {
+                nextActionCard
+                    .padding(.horizontal)
+                    .padding(.top, 12)
+                    .padding(.bottom, 8)
+
                 GeometryReader { proxy in
-                    let dropSize = min(proxy.size.width, proxy.size.height) * 0.78
+                    let dropSize = min(proxy.size.width, proxy.size.height) * 0.88
 
                     WaterDropView(
                         appearance: viewModel.mainIcon,
@@ -69,10 +74,6 @@ public struct DrinkWaterView: View {
                     }
                 }
                 .padding()
-
-                nextActionCard
-                    .padding(.horizontal)
-                    .padding(.bottom, 8)
 
                 HStack {
                     Button {


### PR DESCRIPTION
## 📝 Summary

탭 루트 화면의 navigation title을 제거하고, 홈의 다음 한 잔 가이드를 물방울 UI보다 먼저 읽히도록 배치했습니다. 함께 `WaterDropView` 크기를 키워 다음 한 잔 카드가 상단으로 이동한 뒤에도 홈 화면의 핵심 시각 요소가 유지되도록 조정했습니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [ ] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #184

## 📋 Changes Made
### Added
- 없음

### Changed
- `ContentView`의 탭 루트 navigation title 표시를 제거했습니다.
- `DrinkWaterView`에서 다음 한 잔 가이드를 `WaterDropView` 위로 이동했습니다.
- `WaterDropView` 표시 비율을 `0.78`에서 `0.88`로 키웠습니다.

### Fixed
- 탭 루트 화면에서 large navigation title로 인해 상단 여백이 커지던 UI 위계를 정리했습니다.

### Removed
- 탭별 navigation title 계산 프로퍼티를 제거했습니다.

## 🔍 Technical Details

- 루트 `NavigationStack`과 `AppCoordinator` 구조는 유지했습니다.
- 상세 화면의 개별 navigation title은 변경하지 않았고, 탭 루트 화면의 title만 제거했습니다.
- 다음 한 잔 가이드 계산 로직은 변경하지 않고 View 배치만 조정했습니다.

## 📸 Screenshots / Videos
### Before
- 첨부 없음

### After
- 첨부 없음

## ✅ Testing
### Test Plan
- [x] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: generic/platform=iOS
- Device: generic iOS destination
- Xcode Version: Xcode 26.4 (17E192)

### Test Results
- `make lint` 통과
- `make arch-check` 통과
- `git diff --check` 통과
- `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -derivedDataPath /tmp/MulimiIssue184PR -quiet` 통과

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes

- 빌드 중 기존 경고인 `dummy.o has no symbols`와 `AccentColor` asset 경고가 출력됐습니다. 이번 변경으로 새로 발생한 실패는 없습니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [x] 새로운 의존성이 필요한가요? 아니요
- [x] 문서 업데이트가 필요한가요? 아니요
- [x] 데이터베이스 마이그레이션이 필요한가요? 아니요
- [x] 환경 설정 변경이 필요한가요? 아니요
