### PR TITLE
기본 기록량 설정 구현 상태 재검증 및 스펙 정리

### DIFF
--- a/Docs/product-specs/hydration-logging.md
+++ b/Docs/product-specs/hydration-logging.md
@@ -10,7 +10,7 @@
 - 로컬에 별도 hydration 원장을 다시 두지 않는다
 - `250ml = 1잔` 규칙은 `HydrationServing`으로만 다룬다
 - 메인 화면은 기본 1잔 기록을 유지하고, `HydrationServing`에 정의된 330ml/500ml 프리셋과 직접 ml 입력을 추가로 제공한다
-- 기록 단위 사용자 기본값은 아직 저장하지 않는다. 기본 액션, 위젯, Watch, Siri/AppIntent는 명시적인 단위 선택 UX가 생기기 전까지 기본 1잔을 기록한다
+- 기록 단위 사용자 기본값 설정은 아직 구현하지 않았다. 기본 액션, 위젯, Watch, Siri/AppIntent는 명시적인 단위 선택 UX가 생기기 전까지 기본 1잔을 기록한다
 - 기록 후 오늘 목표를 초과하는 단위는 앱과 AppIntent에서 기록하지 않는다
 - 앱에서 방금 남긴 기록은 최근 기록 되돌리기로 삭제할 수 있다
 - 기록 탭은 HealthKit 샘플 단위 기록을 보여주고, 앱이 생성한 기록만 개별 삭제를 허용한다
@@ -18,6 +18,21 @@
 - 기록 탭의 오늘/주간/월간 요약은 HealthKit 기록을 일별 합산한 표시 모델로 만든다
 - 기록 탭의 잔 수와 달성일 계산은 `HydrationServing`과 사용자 목표 수분량을 기준으로 한다
 - 앱, 위젯, 워치가 서로 다른 계산 규칙을 만들지 않는다
+
+## Default Recording Amount Policy
+
+현재 기본 기록량 설정 저장/적용 흐름은 없다. #203은 닫혔지만 연결된 종료 PR이 없고, 코드 기준으로 `UserPreferencesUseCase`, `SettingMenu`, App Group 저장 키에 기본 기록량 API가 없다. #195 범위에서 330ml/500ml 프리셋과 직접 입력은 추가됐지만, 사용자가 고른 값을 다음 기본 기록량으로 저장하지는 않는다.
+
+| Entry point | Current amount | Decision point | Notes |
+| --- | --- | --- | --- |
+| 앱 기본 기록 버튼 | `HydrationServing.defaultGlassVolumeML` = 250ml | `DrinkWaterViewModel.drinkWater()` | 사용자가 별도 프리셋을 눌러도 다음 기본 버튼 값은 바뀌지 않는다. |
+| 앱 프리셋 버튼 | 330ml, 500ml | `HydrationServing.additionalPresets`, `recordPresetWater(volumeML:)` | 탭 1회에만 적용된다. 사용자 기본값으로 저장하지 않는다. |
+| 앱 직접 입력 | 사용자가 입력한 ml | `recordCustomAmount(_:)` | 유효성 검사 후 1회 기록한다. 사용자 기본값으로 저장하지 않는다. |
+| Widget/AppIntent | `HydrationServing.defaultGlassVolumeML` = 250ml | `LogWaterAppIntent.perform()` | 목표 초과 시 HealthKit에 쓰지 않고 timeline reload를 요청한다. |
+| Watch | `HydrationServing.defaultGlassVolumeML` = 250ml | `WatchHydrationUseCaseImpl.defaultDrinkVolumeML` | Watch 전용 단위 규칙을 만들지 않는다. |
+| Siri/Shortcuts | `HydrationServing.defaultGlassVolumeML` = 250ml | 현재 `LogWaterAppIntent` 기준 | #67에서 App Shortcuts 노출과 결과 메시지를 별도 추적한다. |
+
+기본 기록량 개인화가 필요하면 #203 범위를 기능 이슈로 복원하고, App Group에서 앱/Widget/AppIntent/Watch가 함께 읽을 수 있는 사용자 설정으로 설계한다.
 
 ## User Expectations
 
@@ -59,3 +74,9 @@
 - `Docs/reliability-recovery.md`
 - `Docs/skills/healthkit-flow.md`
 - `Docs/skills/widget-watch-integration.md`
+
+## Related Issues
+
+- #203 기본 수분 기록량 및 즐겨찾는 용량 설정 추가
+- #195 다양한 수분 기록 단위 프리셋 추가
+- #67 Siri/Shortcuts 물 기록 적용

--- a/Docs/skills/widget-watch-integration.md
+++ b/Docs/skills/widget-watch-integration.md
@@ -18,6 +18,8 @@
 - 다음 한 잔 계산은 `HydrationNextActionGuide`
 - 목표량은 앱과 동일한 `iCloud KVS + App Group mirror` 흐름을 따른다
 - 위젯/워치만의 독자 단위 규칙을 만들지 않는다
+- 기본 기록량 사용자 설정은 아직 없다. Widget/AppIntent/Watch 기본 기록은 `HydrationServing.defaultGlassVolumeML`을 사용한다
+- 기본 기록량 개인화를 구현할 때는 앱, Widget/AppIntent, Watch가 같은 App Group 기반 설정을 읽도록 설계한다
 
 ## Where to look
 
@@ -26,6 +28,7 @@
 - watch 앱 진입: `Project/App/Watch/Sources/App/MulimiWatchApp.swift`
 - watch DI: `Project/Shared/DependencyInjection/Sources/Watch`
 - 공용 수분 계산: `Project/Domain/SharedInterfaces/`
+- 앱 기본 기록: `Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift`
 
 ## Validation
 


### PR DESCRIPTION
## 📝 Summary
#212 범위로 기본 수분 기록량 설정 구현 상태를 재검증하고, 현재 제품 스펙을 코드 상태에 맞게 정리했습니다.

현재 구현 기준으로 기본 기록량 사용자 설정 저장/적용 흐름은 없으며, 앱 기본 기록 버튼, Widget/AppIntent, Watch, Siri/Shortcuts 기준 진입점은 모두 `HydrationServing.defaultGlassVolumeML` 250ml를 사용합니다. #203은 연결된 종료 PR 없이 닫혀 있었고 실제 구현이 확인되지 않아 재검증 근거 댓글을 남긴 뒤 다시 열었습니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [x] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [ ] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #212
- Related to #203
- Related to #67
- Related to #195

## 📋 Changes Made
### Added
- `Docs/product-specs/hydration-logging.md`에 기본 기록량 정책 표 추가
- 앱 기본 버튼, 앱 프리셋, 직접 입력, Widget/AppIntent, Watch, Siri/Shortcuts별 현재 기록량 결정 경로 문서화
- `Docs/skills/widget-watch-integration.md`에 Widget/AppIntent/Watch 기본 기록량 기준과 향후 개인화 설계 원칙 추가

### Changed
- 기본 기록량 사용자 기본값은 아직 구현되지 않았다는 표현을 명확하게 정리
- #203, #195, #67 관련 이슈를 hydration logging spec에 연결

### Fixed
- 닫힌 #203과 현재 코드/스펙이 충돌할 수 있던 이해 경로를 정리

### Removed
- 없음

## 🔍 Technical Details
재검증 근거:
- `DrinkWaterViewModel.drinkWater()`는 `HydrationServing.defaultGlassVolumeML` 250ml를 사용합니다.
- `LogWaterAppIntent.perform()`도 같은 250ml를 사용합니다.
- `WatchHydrationUseCaseImpl.defaultDrinkVolumeML` 기본값도 250ml입니다.
- `UserPreferencesUseCase`, `UserPreferencesRepository`, `SettingMenu`, App Group 저장 키에는 기본 기록량 저장/조회 API가 없습니다.

#203에는 위 근거를 댓글로 남기고 구현 추적 이슈로 reopen 했습니다.

## 📸 Screenshots / Videos
문서 전용 변경이라 첨부 없음.

## ✅ Testing
### Test Plan
- [x] 문서 diff whitespace 검사
- [ ] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [ ] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: N/A
- Device: N/A
- Xcode Version: N/A

### Test Results
- `git diff --check` 통과
- 문서 전용 변경이라 `make lint`, `make arch-check`, 앱 빌드는 실행하지 않았습니다.

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- #203은 기본 기록량 개인화 구현 이슈로 다시 열어두었습니다.

## 👀 Review Checklist
- [x] 코드 기준 재검증 근거가 문서에 남았나요?
- [x] 새로운 의존성이 필요한가요? 아니요
- [x] 문서 업데이트가 필요한가요? 반영됨
- [x] 데이터베이스 마이그레이션이 필요한가요? 아니요
- [x] 환경 설정 변경이 필요한가요? 아니요