### PR TITLE
🐛 HealthKit 기록 실패 복구 처리

### DIFF
--- a/Docs/product-specs/analytics-events.md
+++ b/Docs/product-specs/analytics-events.md
@@ -38,7 +38,7 @@
 | `healthkit_permission_settings_tapped` | `status` | 설정 이동 CTA 탭 |
 | `healthkit_permission_refresh_tapped` | `status` | 설정 복귀 후 상태 재확인 CTA 탭 |
 | `water_logged` | `source`, `serving_type`, `volume_ml`, `daily_goal_ml` | 물 기록 성공 |
-| `water_log_failed` | `source`, `serving_type`, `failure_reason` | 물 기록 전 권한/입력/목표 초과로 차단 |
+| `water_log_failed` | `source`, `serving_type`, `failure_reason` | 물 기록 권한/입력/목표 초과 차단 또는 HealthKit 저장 실패 |
 | `water_preset_logged` | `source`, `preset`, `volume_ml` | 330ml/500ml 프리셋 기록 성공 |
 | `routine_created` | `source`, `enabled`, `weekday_count` | 루틴 생성 저장 성공 |
 | `routine_updated` | `source`, `enabled`, `weekday_count` | 루틴 수정 저장 성공 |
@@ -76,6 +76,7 @@
 ### `failure_reason`
 
 - `healthkit_permission_required`
+- `healthkit_write_failed`
 - `custom_amount_missing`
 - `custom_amount_out_of_range`
 - `daily_goal_exceeded`

--- a/Docs/product-specs/hydration-logging.md
+++ b/Docs/product-specs/hydration-logging.md
@@ -44,9 +44,10 @@
   - 성공: 선택한 수분량이 HealthKit에 기록됐음을 알린다.
   - 목표 초과: 오늘 목표를 넘어서 기록하지 않았음을 알린다.
   - HealthKit 권한 필요: 앱을 foreground로 전환해 권한 흐름을 확인하게 한다.
-- 기록 성공 시 Widget timeline을 갱신한다.
-- 기록 성공 시 analytics `water_logged.source`는 `app_intent`로 기록한다.
-- 권한 부족, 직접 입력 오류, 목표 초과로 기록이 차단되면 analytics `water_log_failed.source`는 `app_intent`로 기록한다.
+- HealthKit 저장 실패: 기록되지 않았음을 알리고, 권한 철회가 원인이면 앱을 foreground로 전환해 권한 흐름을 확인하게 한다.
+- 기록 성공 시에만 Widget timeline을 갱신한다.
+- 기록 성공 시에만 analytics `water_logged.source`는 `app_intent`로 기록한다.
+- 권한 부족, 직접 입력 오류, 목표 초과, HealthKit 저장 실패는 analytics `water_log_failed.source`로 기록한다.
 - Shortcuts 수분량 선택은 기본 기록량 사용자 설정을 바꾸지 않는다. 기본 기록량 개인화는 #203 범위에서 확장한다.
 
 ## AppIntent QA Scenarios
@@ -57,6 +58,7 @@
 - 선택한 수분량이 오늘 목표를 초과하면 HealthKit에 쓰지 않고 목표 초과 메시지를 반환한다.
 - HealthKit 권한이 없으면 앱 foreground 전환으로 권한 흐름을 확인하게 한다.
 - 기록 차단 결과는 `water_log_failed.failure_reason`으로 구분된다.
+- HealthKit 저장 실패 결과는 성공 dialog, Widget timeline 갱신, `water_logged` analytics로 처리하지 않는다.
 - 기록 성공 후 Widget timeline이 갱신된다.
 
 ## User Expectations

--- a/Docs/reliability-recovery.md
+++ b/Docs/reliability-recovery.md
@@ -56,8 +56,10 @@ Mulimi의 HealthKit, 알림, Widget, Watch 실패 상황을 같은 기준으로 
 ## Current Implementation Notes
 
 - HealthKit 권한 게이트는 거부 상태에서 설정 이동과 상태 새로고침을 제공한다.
-- 메인 수분 기록, 기록 삭제, 목표/아이콘 변경 후 Widget timeline reload를 호출한다.
+- 메인 수분 기록은 HealthKit 쓰기 성공 후에만 undo, analytics 성공 이벤트, Widget timeline reload를 실행한다.
+- 기록 삭제, 목표/아이콘 변경 후 Widget timeline reload를 호출한다.
 - AppIntent는 선택된 기록량, Watch는 기본 1잔 기준으로 목표 초과를 차단한다.
+- AppIntent와 Watch는 HealthKit 저장 실패를 조용한 성공으로 처리하지 않고 실패 안내를 반환한다.
 - Watch 목표량은 KVS를 먼저 보고 App Group mirror를 보정한다.
 - 루틴 알림은 권한 상태에 따라 권한 요청, 설정 이동, 알림 없이 저장으로 분기한다.
 
@@ -67,7 +69,6 @@ Mulimi의 HealthKit, 알림, Widget, Watch 실패 상황을 같은 기준으로 
 
 | Area | Follow-up | Gap | Required outcome |
 | --- | --- | --- | --- |
-| HealthKit write result | [#219](https://github.com/gaeng2y/Mulimi/issues/219) | 수분 기록 저장 실패가 앱/AppIntent/Watch UI까지 성공/실패로 명확히 전달되지 않는다. | 실패 시 성공 analytics, undo, timeline reload를 성공 처리하지 않고 사용자에게 재시도 또는 설정 이동을 안내한다. |
 | Routine schedule atomicity | [#220](https://github.com/gaeng2y/Mulimi/issues/220) | 루틴 저장 후 AlarmKit 스케줄 실패가 나면 활성 루틴 표시와 실제 알림 상태가 어긋날 수 있다. | 스케줄 실패 시 활성 루틴을 예약 완료처럼 보여주지 않고, 다시 시도 또는 알림 없이 저장으로 복구한다. |
 
 ## QA Scenarios
@@ -75,6 +76,8 @@ Mulimi의 HealthKit, 알림, Widget, Watch 실패 상황을 같은 기준으로 
 - HealthKit 권한을 거부한 뒤 앱을 재진입하면 권한 게이트가 유지되고 설정 이동 CTA가 보인다.
 - HealthKit 권한을 설정에서 다시 허용한 뒤 앱으로 돌아오면 상태 새로고침 후 메인 화면에 진입한다.
 - 목표까지 남은 양보다 큰 커스텀 용량을 입력하면 HealthKit 쓰기 전에 차단된다.
+- HealthKit 저장 실패가 발생하면 앱은 실패 안내를 보여주고 성공 analytics, undo, Widget timeline reload를 실행하지 않는다.
+- AppIntent/Watch의 HealthKit 저장 실패는 성공 메시지나 성공 상태 갱신으로 표시되지 않는다.
 - 앱에서 수분 기록 또는 삭제 후 Widget이 늦게 갱신돼도 앱 화면의 오늘 합계가 HealthKit 기준으로 유지된다.
 - Watch에서 기본 1잔을 기록한 뒤 앱이 HealthKit을 다시 읽으면 같은 오늘 합계로 수렴한다.
 - 알림 권한이 `notDetermined`이면 활성 루틴 저장 전에 권한 요청 prompt가 나온다.

--- a/Project/App/Sources/AppIntents/LogWaterAppIntent.swift
+++ b/Project/App/Sources/AppIntents/LogWaterAppIntent.swift
@@ -135,7 +135,25 @@ struct LogWaterAppIntent: AppIntent {
             return .result(dialog: overLimitDialog(currentMl: currentMl, dailyLimit: dailyLimit, volumeML: volumeML))
         }
 
-        await waterUseCase.drinkWater(volumeML: volumeML)
+        let writeResult = await waterUseCase.drinkWater(volumeML: volumeML)
+        guard writeResult.isSuccess else {
+            trackWaterLogFailed(
+                failureReason: writeResult.analyticsFailureReason,
+                volumeML: volumeML,
+                dailyLimit: dailyLimit
+            )
+
+            if writeResult.failureReason == .permissionDenied {
+                try await continueInForeground(
+                    IntentDialog("건강 앱 권한이 필요해요. 물리미에서 HealthKit 권한을 허용해 주세요."),
+                    alwaysConfirm: false
+                )
+                return .result(dialog: "건강 앱 권한을 확인해 주세요.")
+            }
+
+            return .result(dialog: "물 기록을 저장하지 못했어요. 잠시 후 다시 시도해 주세요.")
+        }
+
         WidgetCenter.shared.reloadAllTimelines()
         trackWaterLogged(volumeML: volumeML, dailyLimit: dailyLimit)
 
@@ -212,5 +230,16 @@ struct LogWaterAppIntent: AppIntent {
                 dailyGoalML: dailyLimit.map { Int($0.rounded()) }
             )
         )
+    }
+}
+
+private extension HydrationWriteResult {
+    var analyticsFailureReason: String {
+        switch failureReason ?? .systemError {
+        case .permissionDenied:
+            return "healthkit_permission_required"
+        case .invalidObjectType, .systemError:
+            return "healthkit_write_failed"
+        }
     }
 }

--- a/Project/App/Watch/Resources/Localizable.xcstrings
+++ b/Project/App/Watch/Resources/Localizable.xcstrings
@@ -45,6 +45,72 @@
         }
       }
     },
+    "watchCommonConfirmButton" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인"
+          }
+        }
+      }
+    },
+    "watchHydrationMutationFailureTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "처리하지 못했어요"
+          }
+        }
+      }
+    },
+    "watchHydrationRecordFailure" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱에 수분 기록을 저장하지 못했어요. 잠시 후 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "watchHydrationRecordPermissionFailure" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱 권한이 없어 수분 기록을 저장하지 못했어요. iPhone에서 물리미 권한을 확인해 주세요."
+          }
+        }
+      }
+    },
+    "watchHydrationResetFailure" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 기록을 초기화하지 못했어요. 잠시 후 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "watchHydrationResetPermissionFailure" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱 권한이 없어 오늘 기록을 초기화하지 못했어요. iPhone에서 물리미 권한을 확인해 주세요."
+          }
+        }
+      }
+    },
     "watchHomeDrinkCompleteButton" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Project/Data/Sources/DataSource/DrinkWaterHealthKitDataSource.swift
+++ b/Project/Data/Sources/DataSource/DrinkWaterHealthKitDataSource.swift
@@ -7,6 +7,7 @@
 
 import DomainLayerInterface
 import Foundation
+import HealthKit
 import OSLog
 
 public protocol DrinkWaterDataSource: Sendable {
@@ -15,10 +16,13 @@ public protocol DrinkWaterDataSource: Sendable {
     func hydrationEvents(on date: Date) async -> [HydrationEvent]
     func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent]
     func migrateLegacyDataIfNeeded() async
-    func drinkWater() async
-    func drinkWater(volumeML: Int) async
+    @discardableResult
+    func drinkWater() async -> HydrationWriteResult
+    @discardableResult
+    func drinkWater(volumeML: Int) async -> HydrationWriteResult
     func deleteHydrationEvent(id: UUID) async -> Bool
-    func reset() async
+    @discardableResult
+    func reset() async -> HydrationWriteResult
 }
 
 public actor DrinkWaterHealthKitDataSource: DrinkWaterDataSource {
@@ -75,15 +79,19 @@ public actor DrinkWaterHealthKitDataSource: DrinkWaterDataSource {
 
     public func migrateLegacyDataIfNeeded() async {}
 
-    public func drinkWater() async {
+    @discardableResult
+    public func drinkWater() async -> HydrationWriteResult {
         await drinkWater(volumeML: HydrationServing.defaultGlassVolumeML)
     }
 
-    public func drinkWater(volumeML: Int) async {
+    @discardableResult
+    public func drinkWater(volumeML: Int) async -> HydrationWriteResult {
         do {
             try await healthKitDataSource.setWaterIntake(volumeML: volumeML)
+            return .success
         } catch {
             logger.error("Failed to save hydration sample to HealthKit: \(String(describing: error))")
+            return .failure(Self.writeFailureReason(for: error))
         }
     }
 
@@ -96,12 +104,41 @@ public actor DrinkWaterHealthKitDataSource: DrinkWaterDataSource {
         }
     }
 
-    public func reset() async {
+    @discardableResult
+    public func reset() async -> HydrationWriteResult {
         do {
             try await healthKitDataSource.resetWaterInTakeInToday()
+            return .success
         } catch {
             logger.error("Failed to reset owned hydration samples: \(String(describing: error))")
+            return .failure(Self.writeFailureReason(for: error))
         }
+    }
+
+    private static func writeFailureReason(for error: Error) -> HydrationWriteFailureReason {
+        if let healthKitError = error as? HealthKitError {
+            switch healthKitError {
+            case .permissionDenied:
+                return .permissionDenied
+            case .invalidObjectType:
+                return .invalidObjectType
+            case .healthKitInternalError, .incompleteExecuteQuery:
+                return .systemError
+            }
+        }
+
+        if let healthKitError = error as? HKError {
+            switch healthKitError.code {
+            case .errorAuthorizationDenied, .errorAuthorizationNotDetermined:
+                return .permissionDenied
+            case .errorInvalidArgument:
+                return .invalidObjectType
+            default:
+                return .systemError
+            }
+        }
+
+        return .systemError
     }
 
     private func dayInterval(for date: Date) -> DateInterval {

--- a/Project/Data/Sources/Repository/DrinkWaterRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/DrinkWaterRepositoryImpl.swift
@@ -34,11 +34,13 @@ public struct DrinkWaterRepositoryImpl: DrinkWaterRepository {
         await dataSource.migrateLegacyDataIfNeeded()
     }
 
-    public func drinkWater() async {
+    @discardableResult
+    public func drinkWater() async -> HydrationWriteResult {
         await drinkWater(volumeML: HydrationServing.defaultGlassVolumeML)
     }
 
-    public func drinkWater(volumeML: Int) async {
+    @discardableResult
+    public func drinkWater(volumeML: Int) async -> HydrationWriteResult {
         await dataSource.drinkWater(volumeML: volumeML)
     }
 
@@ -46,7 +48,8 @@ public struct DrinkWaterRepositoryImpl: DrinkWaterRepository {
         await dataSource.deleteHydrationEvent(id: id)
     }
 
-    public func reset() async {
+    @discardableResult
+    public func reset() async -> HydrationWriteResult {
         await dataSource.reset()
     }
 }

--- a/Project/Data/WatchSources/DataSource/WatchHydrationLocalDataSource.swift
+++ b/Project/Data/WatchSources/DataSource/WatchHydrationLocalDataSource.swift
@@ -5,8 +5,10 @@ import WatchDomainLayerInterface
 
 protocol WatchHydrationLocalDataSource: Sendable {
     func hydrationEvents(on date: Date) async -> [WatchHydrationEvent]
-    func addDrink(volumeML: Int, consumedAt: Date) async
-    func resetEvents(on date: Date) async
+    @discardableResult
+    func addDrink(volumeML: Int, consumedAt: Date) async -> HydrationWriteResult
+    @discardableResult
+    func resetEvents(on date: Date) async -> HydrationWriteResult
 }
 
 actor WatchHydrationHealthKitDataSource: WatchHydrationLocalDataSource {
@@ -68,10 +70,17 @@ actor WatchHydrationHealthKitDataSource: WatchHydrationLocalDataSource {
         }
     }
 
-    func addDrink(volumeML: Int, consumedAt: Date) async {
+    @discardableResult
+    func addDrink(volumeML: Int, consumedAt: Date) async -> HydrationWriteResult {
         guard let waterType = HKObjectType.quantityType(forIdentifier: .dietaryWater) else {
             logger.error("Unable to resolve dietaryWater quantity type on watch.")
-            return
+            return .failure(.invalidObjectType)
+        }
+
+        guard HKHealthStore.isHealthDataAvailable(),
+              healthStore.authorizationStatus(for: waterType) == .sharingAuthorized else {
+            logger.error("HealthKit water write permission is unavailable on watch.")
+            return .failure(.permissionDenied)
         }
 
         let quantity = HKQuantity(unit: .literUnit(with: .milli), doubleValue: Double(volumeML))
@@ -79,15 +88,24 @@ actor WatchHydrationHealthKitDataSource: WatchHydrationLocalDataSource {
 
         do {
             try await healthStore.save(sample)
+            return .success
         } catch {
             logger.error("Failed to save watch hydration sample: \(String(describing: error))")
+            return .failure(Self.writeFailureReason(for: error))
         }
     }
 
-    func resetEvents(on date: Date) async {
+    @discardableResult
+    func resetEvents(on date: Date) async -> HydrationWriteResult {
         guard let waterType = HKObjectType.quantityType(forIdentifier: .dietaryWater) else {
             logger.error("Unable to resolve dietaryWater quantity type on watch.")
-            return
+            return .failure(.invalidObjectType)
+        }
+
+        guard HKHealthStore.isHealthDataAvailable(),
+              healthStore.authorizationStatus(for: waterType) == .sharingAuthorized else {
+            logger.error("HealthKit water reset permission is unavailable on watch.")
+            return .failure(.permissionDenied)
         }
 
         let interval = dayInterval(for: date)
@@ -97,7 +115,7 @@ actor WatchHydrationHealthKitDataSource: WatchHydrationLocalDataSource {
             options: .strictStartDate
         )
 
-        await withCheckedContinuation { continuation in
+        return await withCheckedContinuation { (continuation: CheckedContinuation<HydrationWriteResult, Never>) in
             let query = HKSampleQuery(
                 sampleType: waterType,
                 predicate: predicate,
@@ -106,7 +124,7 @@ actor WatchHydrationHealthKitDataSource: WatchHydrationLocalDataSource {
             ) { _, samples, error in
                 if let error {
                     self.logger.error("Failed to fetch watch samples for reset: \(String(describing: error))")
-                    continuation.resume(returning: ())
+                    continuation.resume(returning: HydrationWriteResult.failure(Self.writeFailureReason(for: error)))
                     return
                 }
 
@@ -115,21 +133,40 @@ actor WatchHydrationHealthKitDataSource: WatchHydrationLocalDataSource {
                 } ?? []
 
                 guard !ownedSamples.isEmpty else {
-                    continuation.resume(returning: ())
+                    continuation.resume(returning: HydrationWriteResult.success)
                     return
                 }
 
                 self.healthStore.delete(ownedSamples) { _, error in
                     if let error {
                         self.logger.error("Failed to reset watch hydration samples: \(String(describing: error))")
+                        continuation.resume(
+                            returning: HydrationWriteResult.failure(Self.writeFailureReason(for: error))
+                        )
+                        return
                     }
 
-                    continuation.resume(returning: ())
+                    continuation.resume(returning: HydrationWriteResult.success)
                 }
             }
 
             healthStore.execute(query)
         }
+    }
+
+    private static func writeFailureReason(for error: Error) -> HydrationWriteFailureReason {
+        if let healthKitError = error as? HKError {
+            switch healthKitError.code {
+            case .errorAuthorizationDenied, .errorAuthorizationNotDetermined:
+                return .permissionDenied
+            case .errorInvalidArgument:
+                return .invalidObjectType
+            default:
+                return .systemError
+            }
+        }
+
+        return .systemError
     }
 
     private func dayInterval(for date: Date) -> DateInterval {

--- a/Project/Data/WatchSources/Repository/WatchHydrationRepositoryImpl.swift
+++ b/Project/Data/WatchSources/Repository/WatchHydrationRepositoryImpl.swift
@@ -16,11 +16,13 @@ public struct WatchHydrationRepositoryImpl: WatchHydrationRepository {
         await localDataSource.hydrationEvents(on: date)
     }
 
-    public func addDrink(volumeML: Int, consumedAt: Date) async {
+    @discardableResult
+    public func addDrink(volumeML: Int, consumedAt: Date) async -> HydrationWriteResult {
         await localDataSource.addDrink(volumeML: volumeML, consumedAt: consumedAt)
     }
 
-    public func resetEvents(on date: Date) async {
+    @discardableResult
+    public func resetEvents(on date: Date) async -> HydrationWriteResult {
         await localDataSource.resetEvents(on: date)
     }
 }

--- a/Project/Domain/Interfaces/Repository/DrinkWaterRepository.swift
+++ b/Project/Domain/Interfaces/Repository/DrinkWaterRepository.swift
@@ -14,8 +14,11 @@ public protocol DrinkWaterRepository: Sendable {
     func hydrationEvents(on date: Date) async -> [HydrationEvent]
     func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent]
     func migrateLegacyDataIfNeeded() async
-    func drinkWater() async
-    func drinkWater(volumeML: Int) async
+    @discardableResult
+    func drinkWater() async -> HydrationWriteResult
+    @discardableResult
+    func drinkWater(volumeML: Int) async -> HydrationWriteResult
     func deleteHydrationEvent(id: UUID) async -> Bool
-    func reset() async
+    @discardableResult
+    func reset() async -> HydrationWriteResult
 }

--- a/Project/Domain/Interfaces/UseCase/DrinkWaterUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/DrinkWaterUseCase.swift
@@ -14,8 +14,11 @@ public protocol DrinkWaterUseCase: Sendable {
     func hydrationEvents(on date: Date) async -> [HydrationEvent]
     func hydrationEvents(in interval: DateInterval) async -> [HydrationEvent]
     func migrateLegacyDataIfNeeded() async
-    func drinkWater() async
-    func drinkWater(volumeML: Int) async
+    @discardableResult
+    func drinkWater() async -> HydrationWriteResult
+    @discardableResult
+    func drinkWater(volumeML: Int) async -> HydrationWriteResult
     func deleteHydrationEvent(id: UUID) async -> Bool
-    func reset() async
+    @discardableResult
+    func reset() async -> HydrationWriteResult
 }

--- a/Project/Domain/SharedInterfaces/Entity/HydrationWriteResult.swift
+++ b/Project/Domain/SharedInterfaces/Entity/HydrationWriteResult.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum HydrationWriteFailureReason: Equatable, Sendable {
+    case permissionDenied
+    case invalidObjectType
+    case systemError
+}
+
+public enum HydrationWriteResult: Equatable, Sendable {
+    case success
+    case failure(HydrationWriteFailureReason)
+
+    public var isSuccess: Bool {
+        self == .success
+    }
+
+    public var failureReason: HydrationWriteFailureReason? {
+        switch self {
+        case .success:
+            return nil
+        case let .failure(reason):
+            return reason
+        }
+    }
+}

--- a/Project/Domain/Sources/UseCase/DrinkWaterUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/DrinkWaterUseCaseImpl.swift
@@ -34,11 +34,13 @@ public struct DrinkWaterUseCaseImpl: DrinkWaterUseCase {
         await repository.migrateLegacyDataIfNeeded()
     }
 
-    public func drinkWater() async {
+    @discardableResult
+    public func drinkWater() async -> HydrationWriteResult {
         await drinkWater(volumeML: HydrationServing.defaultGlassVolumeML)
     }
 
-    public func drinkWater(volumeML: Int) async {
+    @discardableResult
+    public func drinkWater(volumeML: Int) async -> HydrationWriteResult {
         await repository.drinkWater(volumeML: volumeML)
     }
 
@@ -46,7 +48,8 @@ public struct DrinkWaterUseCaseImpl: DrinkWaterUseCase {
         await repository.deleteHydrationEvent(id: id)
     }
 
-    public func reset() async {
+    @discardableResult
+    public func reset() async -> HydrationWriteResult {
         await repository.reset()
     }
 }

--- a/Project/Domain/Tests/DrinkWaterUseCaseTests.swift
+++ b/Project/Domain/Tests/DrinkWaterUseCaseTests.swift
@@ -72,6 +72,20 @@ struct DrinkWaterUseCaseTests {
         #expect(await useCase.currentWaterIntakeML == Double(HydrationServing.tumblerML))
     }
 
+    @Test("물 마시기 실패 결과는 Repository에서 UseCase로 전달된다")
+    func drinkWaterFailureResult() async {
+        let mockRepository = MockDrinkWaterRepository()
+        mockRepository.drinkWaterResult = .failure(.permissionDenied)
+        let useCase = DrinkWaterUseCaseImpl(repository: mockRepository)
+
+        let result = await useCase.drinkWater(volumeML: HydrationServing.tumblerML)
+
+        #expect(result == .failure(.permissionDenied))
+        #expect(mockRepository.drinkWaterCallCount == 1)
+        #expect(mockRepository.recordedVolumesML == [HydrationServing.tumblerML])
+        #expect(await useCase.currentWaterIntakeML == 0)
+    }
+
     @Test("물 마시기 기능을 여러 번 호출할 때")
     func drinkWaterMultipleTimes() async {
         // Given: 초기 상태의 Repository와 UseCase가 있을 때
@@ -105,6 +119,20 @@ struct DrinkWaterUseCaseTests {
         #expect(mockRepository.resetCallCount == 1)
         // Then: 현재 물 섭취량이 0이 된다
         #expect(await useCase.currentWaterIntakeML == 0)
+    }
+
+    @Test("리셋 실패 결과는 Repository에서 UseCase로 전달된다")
+    func resetFailureResult() async {
+        let mockRepository = MockDrinkWaterRepository()
+        mockRepository.setCurrentWaterIntakeML(1_250)
+        mockRepository.resetResult = .failure(.systemError)
+        let useCase = DrinkWaterUseCaseImpl(repository: mockRepository)
+
+        let result = await useCase.reset()
+
+        #expect(result == .failure(.systemError))
+        #expect(mockRepository.resetCallCount == 1)
+        #expect(await useCase.currentWaterIntakeML == 1_250)
     }
 
     @Test("리셋 후 다시 물 마시기 테스트")

--- a/Project/Domain/Tests/Mock/MockDrinkWaterRepository.swift
+++ b/Project/Domain/Tests/Mock/MockDrinkWaterRepository.swift
@@ -22,6 +22,8 @@ final class MockDrinkWaterRepository: DrinkWaterRepository, @unchecked Sendable 
     private(set) var deleteHydrationEventCallCount = 0
     private(set) var recordedVolumesML: [Int] = []
     private(set) var deletedHydrationEventIDs: [UUID] = []
+    var drinkWaterResult: HydrationWriteResult = .success
+    var resetResult: HydrationWriteResult = .success
 
     var currentWaterIntakeML: Double {
         get async {
@@ -45,13 +47,19 @@ final class MockDrinkWaterRepository: DrinkWaterRepository, @unchecked Sendable 
         migrateCallCount += 1
     }
 
-    func drinkWater() async {
+    @discardableResult
+    func drinkWater() async -> HydrationWriteResult {
         await drinkWater(volumeML: HydrationServing.defaultGlassVolumeML)
     }
 
-    func drinkWater(volumeML: Int) async {
+    @discardableResult
+    func drinkWater(volumeML: Int) async -> HydrationWriteResult {
         drinkWaterCallCount += 1
         recordedVolumesML.append(volumeML)
+        guard drinkWaterResult.isSuccess else {
+            return drinkWaterResult
+        }
+
         currentWaterIntakeMLValue += Double(volumeML)
         _events.append(
             HydrationEvent(
@@ -60,12 +68,19 @@ final class MockDrinkWaterRepository: DrinkWaterRepository, @unchecked Sendable 
                 volumeML: volumeML
             )
         )
+        return drinkWaterResult
     }
 
-    func reset() async {
+    @discardableResult
+    func reset() async -> HydrationWriteResult {
         resetCallCount += 1
+        guard resetResult.isSuccess else {
+            return resetResult
+        }
+
         currentWaterIntakeMLValue = 0
         _events.removeAll()
+        return resetResult
     }
 
     func deleteHydrationEvent(id: UUID) async -> Bool {
@@ -100,5 +115,7 @@ final class MockDrinkWaterRepository: DrinkWaterRepository, @unchecked Sendable 
         deleteHydrationEventCallCount = 0
         recordedVolumesML = []
         deletedHydrationEventIDs = []
+        drinkWaterResult = .success
+        resetResult = .success
     }
 }

--- a/Project/Domain/WatchInterfaces/Entities/WatchHydrationMutationResult.swift
+++ b/Project/Domain/WatchInterfaces/Entities/WatchHydrationMutationResult.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public struct WatchHydrationMutationResult: Equatable, Sendable {
+    public let snapshot: WatchHydrationSnapshot
+    public let writeResult: HydrationWriteResult
+
+    public init(
+        snapshot: WatchHydrationSnapshot,
+        writeResult: HydrationWriteResult
+    ) {
+        self.snapshot = snapshot
+        self.writeResult = writeResult
+    }
+}

--- a/Project/Domain/WatchInterfaces/Repositories/WatchHydrationRepository.swift
+++ b/Project/Domain/WatchInterfaces/Repositories/WatchHydrationRepository.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public protocol WatchHydrationRepository: Sendable {
     func hydrationEvents(on date: Date) async -> [WatchHydrationEvent]
-    func addDrink(volumeML: Int, consumedAt: Date) async
-    func resetEvents(on date: Date) async
+    @discardableResult
+    func addDrink(volumeML: Int, consumedAt: Date) async -> HydrationWriteResult
+    @discardableResult
+    func resetEvents(on date: Date) async -> HydrationWriteResult
 }

--- a/Project/Domain/WatchInterfaces/UseCase/WatchHydrationUseCase.swift
+++ b/Project/Domain/WatchInterfaces/UseCase/WatchHydrationUseCase.swift
@@ -2,6 +2,6 @@ import Foundation
 
 public protocol WatchHydrationUseCase: Sendable {
     func loadSnapshot(referenceDate: Date) async -> WatchHydrationSnapshot
-    func drinkWater(referenceDate: Date) async -> WatchHydrationSnapshot
-    func reset(referenceDate: Date) async -> WatchHydrationSnapshot
+    func drinkWater(referenceDate: Date) async -> WatchHydrationMutationResult
+    func reset(referenceDate: Date) async -> WatchHydrationMutationResult
 }

--- a/Project/Domain/WatchSources/UseCase/WatchHydrationUseCaseImpl.swift
+++ b/Project/Domain/WatchSources/UseCase/WatchHydrationUseCaseImpl.swift
@@ -22,27 +22,51 @@ public struct WatchHydrationUseCaseImpl: WatchHydrationUseCase {
         return makeSnapshot(dailyGoalML: dailyGoalML, events: events)
     }
 
-    public func drinkWater(referenceDate: Date) async -> WatchHydrationSnapshot {
+    public func drinkWater(referenceDate: Date) async -> WatchHydrationMutationResult {
         let currentSnapshot = await loadSnapshot(referenceDate: referenceDate)
         let drinkVolumeML = Int(defaultDrinkVolumeML)
 
         guard !currentSnapshot.isGoalReached,
               currentSnapshot.dailyGoalML <= 0 ||
               currentSnapshot.todayIntakeML + drinkVolumeML <= currentSnapshot.dailyGoalML else {
-            return currentSnapshot
+            return WatchHydrationMutationResult(
+                snapshot: currentSnapshot,
+                writeResult: .success
+            )
         }
 
-        await hydrationRepository.addDrink(
+        let writeResult = await hydrationRepository.addDrink(
             volumeML: drinkVolumeML,
             consumedAt: referenceDate
         )
 
-        return await loadSnapshot(referenceDate: referenceDate)
+        let snapshot: WatchHydrationSnapshot
+        if writeResult.isSuccess {
+            snapshot = await loadSnapshot(referenceDate: referenceDate)
+        } else {
+            snapshot = currentSnapshot
+        }
+
+        return WatchHydrationMutationResult(
+            snapshot: snapshot,
+            writeResult: writeResult
+        )
     }
 
-    public func reset(referenceDate: Date) async -> WatchHydrationSnapshot {
-        await hydrationRepository.resetEvents(on: referenceDate)
-        return await loadSnapshot(referenceDate: referenceDate)
+    public func reset(referenceDate: Date) async -> WatchHydrationMutationResult {
+        let currentSnapshot = await loadSnapshot(referenceDate: referenceDate)
+        let writeResult = await hydrationRepository.resetEvents(on: referenceDate)
+        let snapshot: WatchHydrationSnapshot
+        if writeResult.isSuccess {
+            snapshot = await loadSnapshot(referenceDate: referenceDate)
+        } else {
+            snapshot = currentSnapshot
+        }
+
+        return WatchHydrationMutationResult(
+            snapshot: snapshot,
+            writeResult: writeResult
+        )
     }
 
     private func makeSnapshot(

--- a/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
+++ b/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
@@ -9,10 +9,12 @@ import DesignSystem
 import DomainLayerInterface
 import Localization
 import SwiftUI
+import UIKit
 
 public struct DrinkWaterView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.openURL) private var openURL
     private var viewModel: DrinkWaterViewModel
     @State private var isCustomAmountPresented = false
 
@@ -106,6 +108,30 @@ public struct DrinkWaterView: View {
         }
         .sheet(isPresented: $isCustomAmountPresented) {
             CustomHydrationAmountSheet(viewModel: viewModel)
+        }
+        .alert(
+            viewModel.recordFailureAlert?.title ?? "",
+            isPresented: Binding(
+                get: { viewModel.recordFailureAlert != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        viewModel.clearRecordFailureAlert()
+                    }
+                }
+            )
+        ) {
+            if viewModel.recordFailureAlert?.showsOpenSettingsAction == true {
+                Button(L10n.tr("healthKitPermissionOpenSettingsTitle")) {
+                    openSettings()
+                    viewModel.clearRecordFailureAlert()
+                }
+            }
+
+            Button(L10n.tr("commonConfirmTitle"), role: .cancel) {
+                viewModel.clearRecordFailureAlert()
+            }
+        } message: {
+            Text(viewModel.recordFailureAlert?.message ?? "")
         }
         .alert(
             L10n.tr("drinkWaterUndoRecordFailureTitle"),
@@ -349,6 +375,14 @@ public struct DrinkWaterView: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .fill(Color(uiColor: .systemBackground).opacity(0.86))
         )
+    }
+
+    private func openSettings() {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+
+        openURL(settingsURL)
     }
 }
 

--- a/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
@@ -36,6 +36,12 @@ struct RecentHydrationRecordUndoModel: Equatable {
     let actionTitle: String
 }
 
+struct HydrationRecordFailureAlertModel: Equatable {
+    let title: String
+    let message: String
+    let showsOpenSettingsAction: Bool
+}
+
 @MainActor
 @Observable
 public final class DrinkWaterViewModel {
@@ -46,6 +52,7 @@ public final class DrinkWaterViewModel {
     private(set) var currentDailyLimit: Double
     private(set) var recentRecordUndo: RecentHydrationRecordUndoModel?
     private(set) var undoErrorMessage: String?
+    private(set) var recordFailureAlert: HydrationRecordFailureAlertModel?
 
     private let waterUseCase: DrinkWaterUseCase
     private let userPreferencesUseCase: UserPreferencesUseCase
@@ -239,7 +246,21 @@ public final class DrinkWaterViewModel {
             return false
         }
 
-        await waterUseCase.drinkWater(volumeML: volumeML)
+        let writeResult = await waterUseCase.drinkWater(volumeML: volumeML)
+        guard writeResult.isSuccess else {
+            recordFailureAlert = makeRecordFailureAlert(
+                reason: writeResult.failureReason ?? .systemError
+            )
+            trackWaterLogFailed(
+                volumeML: volumeML,
+                servingType: servingType,
+                failureReason: writeResult.analyticsFailureReason,
+                dailyGoalML: Int(dailyLimit.rounded())
+            )
+            return false
+        }
+
+        recordFailureAlert = nil
         await refreshState()
         await updateRecentRecordUndo()
         widgetTimelineReloader.reloadAllTimelines()
@@ -311,7 +332,15 @@ public final class DrinkWaterViewModel {
     }
 
     func reset() async {
-        await waterUseCase.reset()
+        let writeResult = await waterUseCase.reset()
+        guard writeResult.isSuccess else {
+            recordFailureAlert = makeResetFailureAlert(
+                reason: writeResult.failureReason ?? .systemError
+            )
+            return
+        }
+
+        recordFailureAlert = nil
         recentRecordUndo = nil
         undoErrorMessage = nil
         await refreshState()
@@ -339,6 +368,10 @@ public final class DrinkWaterViewModel {
 
     func clearUndoErrorMessage() {
         undoErrorMessage = nil
+    }
+
+    func clearRecordFailureAlert() {
+        recordFailureAlert = nil
     }
 
     func resetAnimation() {
@@ -419,6 +452,65 @@ public final class DrinkWaterViewModel {
         )
     }
 
+    private func trackWaterLogFailed(
+        volumeML: Int,
+        servingType: String,
+        failureReason: String,
+        dailyGoalML: Int
+    ) {
+        analyticsUseCase.track(
+            .waterLogFailed(
+                source: "drink_water_main",
+                servingType: servingType,
+                failureReason: failureReason,
+                volumeML: volumeML,
+                dailyGoalML: dailyGoalML
+            )
+        )
+    }
+
+    private func makeRecordFailureAlert(
+        reason: HydrationWriteFailureReason
+    ) -> HydrationRecordFailureAlertModel {
+        HydrationRecordFailureAlertModel(
+            title: L10n.tr("drinkWaterRecordFailureTitle"),
+            message: recordFailureMessage(for: reason),
+            showsOpenSettingsAction: reason == .permissionDenied
+        )
+    }
+
+    private func makeResetFailureAlert(
+        reason: HydrationWriteFailureReason
+    ) -> HydrationRecordFailureAlertModel {
+        HydrationRecordFailureAlertModel(
+            title: L10n.tr("drinkWaterResetFailureTitle"),
+            message: resetFailureMessage(for: reason),
+            showsOpenSettingsAction: reason == .permissionDenied
+        )
+    }
+
+    private func recordFailureMessage(
+        for reason: HydrationWriteFailureReason
+    ) -> String {
+        switch reason {
+        case .permissionDenied:
+            return L10n.tr("drinkWaterRecordPermissionFailureDescription")
+        case .invalidObjectType, .systemError:
+            return L10n.tr("drinkWaterRecordFailureDescription")
+        }
+    }
+
+    private func resetFailureMessage(
+        for reason: HydrationWriteFailureReason
+    ) -> String {
+        switch reason {
+        case .permissionDenied:
+            return L10n.tr("drinkWaterResetPermissionFailureDescription")
+        case .invalidObjectType, .systemError:
+            return L10n.tr("drinkWaterResetFailureDescription")
+        }
+    }
+
     private func inferredServingType(for volumeML: Int) -> String {
         if volumeML == HydrationServing.defaultGlassVolumeML {
             return "default_glass"
@@ -454,5 +546,16 @@ public final class DrinkWaterViewModel {
 
     private func volumeText(_ volumeML: Int) -> String {
         L10n.tr("commonMilliliterFormat", volumeML)
+    }
+}
+
+private extension HydrationWriteResult {
+    var analyticsFailureReason: String {
+        switch failureReason ?? .systemError {
+        case .permissionDenied:
+            return "healthkit_permission_required"
+        case .invalidObjectType, .systemError:
+            return "healthkit_write_failed"
+        }
     }
 }

--- a/Project/Presentation/Sources/ViewModel/HydrationInsightViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationInsightViewModel.swift
@@ -501,7 +501,20 @@ public final class HydrationInsightViewModel {
             return false
         }
 
-        await waterUseCase.drinkWater(volumeML: HydrationServing.defaultGlassVolumeML)
+        let writeResult = await waterUseCase.drinkWater(volumeML: HydrationServing.defaultGlassVolumeML)
+        guard writeResult.isSuccess else {
+            analyticsUseCase.track(
+                .waterLogFailed(
+                    source: "insight_recovery",
+                    servingType: "default_glass",
+                    failureReason: analyticsFailureReason(for: writeResult),
+                    volumeML: HydrationServing.defaultGlassVolumeML,
+                    dailyGoalML: Int(dailyGoalML.rounded())
+                )
+            )
+            return false
+        }
+
         analyticsUseCase.track(
             .insightCTATapped(
                 source: "insight_recovery",
@@ -1038,6 +1051,15 @@ public final class HydrationInsightViewModel {
             return "create_routine"
         case .edit:
             return "edit_routine"
+        }
+    }
+
+    private func analyticsFailureReason(for writeResult: HydrationWriteResult) -> String {
+        switch writeResult.failureReason ?? .systemError {
+        case .permissionDenied:
+            return "healthkit_permission_required"
+        case .invalidObjectType, .systemError:
+            return "healthkit_write_failed"
         }
     }
 }

--- a/Project/Presentation/Tests/DrinkWaterViewModelTests.swift
+++ b/Project/Presentation/Tests/DrinkWaterViewModelTests.swift
@@ -125,6 +125,42 @@ struct DrinkWaterViewModelTests {
     }
 
     @MainActor
+    @Test("HealthKit 기록 실패 시 성공 후처리를 실행하지 않고 복구 안내를 노출한다")
+    func recordWaterFailureDoesNotRunSuccessEffects() async {
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.drinkWaterResult = .failure(.permissionDenied)
+        let widgetReloader = SpyWidgetTimelineReloader()
+        let analyticsUseCase = MockAnalyticsUseCase()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 1000
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            nextActionGuideUseCase: StubHydrationNextActionGuideUseCase(),
+            widgetTimelineReloader: widgetReloader,
+            analyticsUseCase: analyticsUseCase
+        )
+
+        await viewModel.loadInitialState()
+        let didRecord = await viewModel.recordWater(volumeML: HydrationServing.defaultGlassVolumeML)
+
+        #expect(didRecord == false)
+        #expect(viewModel.currentWaterIntakeML == 0)
+        #expect(viewModel.recentRecordUndo == nil)
+        #expect(viewModel.recordFailureAlert?.showsOpenSettingsAction == true)
+        #expect(
+            viewModel.recordFailureAlert?.message ==
+            L10n.tr("drinkWaterRecordPermissionFailureDescription")
+        )
+        #expect(widgetReloader.reloadCallCount == 0)
+        #expect(analyticsUseCase.trackedEvents.map(\.name) == ["water_log_failed"])
+        #expect(
+            analyticsUseCase.trackedEvents.first?.parameters["failure_reason"] ==
+            AnalyticsParameterValue.string("healthkit_permission_required")
+        )
+    }
+
+    @MainActor
     @Test("직접 입력값은 숫자와 목표 초과 여부를 검증한다")
     func customAmountValidation() async {
         let waterUseCase = MockDrinkWaterUseCase()
@@ -278,6 +314,31 @@ struct DrinkWaterViewModelTests {
 
         #expect(viewModel.drinkWaterCount == 0)
         #expect(waterUseCase.resetCallCount == 1)
+    }
+
+    @MainActor
+    @Test("reset 실패 시 기존 상태를 유지하고 위젯을 갱신하지 않는다")
+    func resetFailureDoesNotRunSuccessEffects() async {
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.currentWaterIntakeMLValue = 750
+        waterUseCase.resetResult = .failure(.systemError)
+        let widgetReloader = SpyWidgetTimelineReloader()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            nextActionGuideUseCase: StubHydrationNextActionGuideUseCase(),
+            widgetTimelineReloader: widgetReloader
+        )
+
+        await viewModel.loadInitialState()
+        await viewModel.reset()
+
+        #expect(viewModel.currentWaterIntakeML == 750)
+        #expect(waterUseCase.resetCallCount == 1)
+        #expect(viewModel.recordFailureAlert?.title == L10n.tr("drinkWaterResetFailureTitle"))
+        #expect(widgetReloader.reloadCallCount == 0)
     }
 
     @MainActor

--- a/Project/Presentation/Tests/HydrationInsightViewModelTests.swift
+++ b/Project/Presentation/Tests/HydrationInsightViewModelTests.swift
@@ -349,6 +349,50 @@ struct HydrationInsightViewModelTests {
     }
 
     @MainActor
+    @Test("복구 기록 실패 시 성공 analytics를 남기지 않는다")
+    func recordRecoveryDrinkFailureDoesNotTrackSuccess() async {
+        let calendar = makeCalendar()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 3, day: 12, hour: 10))!
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.drinkWaterResult = .failure(.systemError)
+        let progressUseCase = MockHydrationProgressUseCase()
+        let routineAdherenceUseCase = MockHydrationRoutineAdherenceUseCase()
+        let routineUseCase = SpyRoutineUseCase()
+        let analyticsUseCase = MockAnalyticsUseCase()
+        progressUseCase.snapshot = HydrationProgressSnapshot(
+            dailyGoalML: 2000,
+            todayIntakeML: 500,
+            weeklyAverageML: 500,
+            monthlyAverageML: 500,
+            weeklyAchievementRate: 0,
+            monthlyAchievementRate: 0,
+            weeklyAchievedDays: 0,
+            monthlyAchievedDays: 0,
+            weeklyElapsedDays: 4,
+            monthlyElapsedDays: 12,
+            currentStreak: 0,
+            isEmpty: false
+        )
+
+        let viewModel = HydrationInsightViewModel(
+            waterUseCase: waterUseCase,
+            progressUseCase: progressUseCase,
+            routineAdherenceUseCase: routineAdherenceUseCase,
+            routineUseCase: routineUseCase,
+            analyticsUseCase: analyticsUseCase,
+            calendar: calendar,
+            currentDateProvider: { referenceDate }
+        )
+
+        await viewModel.loadInsights()
+        let didRecord = await viewModel.recordRecoveryDrink()
+
+        #expect(didRecord == false)
+        #expect(waterUseCase.recordedVolumesML == [HydrationServing.defaultGlassVolumeML])
+        #expect(analyticsUseCase.trackedEvents.map(\.name) == ["water_log_failed"])
+    }
+
+    @MainActor
     @Test("주간 코칭은 놓친 기존 루틴을 수정 CTA로 연결한다")
     func weeklyCoachingMissedRoutineAction() async {
         let calendar = makeCalendar()

--- a/Project/Presentation/Tests/Mock/MockDrinkWaterUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockDrinkWaterUseCase.swift
@@ -10,6 +10,8 @@ final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable {
     var resetCallCount: Int = 0
     var deleteHydrationEventCallCount: Int = 0
     var deletedHydrationEventIDs: [UUID] = []
+    var drinkWaterResult: HydrationWriteResult = .success
+    var resetResult: HydrationWriteResult = .success
     var shouldDeleteHydrationEventSucceed = true
 
     private var hydrationEventsByDay: [String: [HydrationEvent]] = [:]
@@ -35,13 +37,19 @@ final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable {
         migrateLegacyDataIfNeededCallCount += 1
     }
 
-    func drinkWater() async {
+    @discardableResult
+    func drinkWater() async -> HydrationWriteResult {
         await drinkWater(volumeML: HydrationServing.defaultGlassVolumeML)
     }
 
-    func drinkWater(volumeML: Int) async {
+    @discardableResult
+    func drinkWater(volumeML: Int) async -> HydrationWriteResult {
         drinkWaterCallCount += 1
         recordedVolumesML.append(volumeML)
+        guard drinkWaterResult.isSuccess else {
+            return drinkWaterResult
+        }
+
         currentWaterIntakeMLValue += Double(volumeML)
         let now = Date.now
         hydrationEventsByDay[dayKey(for: now), default: []].append(
@@ -51,12 +59,19 @@ final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable {
                 volumeML: volumeML
             )
         )
+        return drinkWaterResult
     }
 
-    func reset() async {
+    @discardableResult
+    func reset() async -> HydrationWriteResult {
         resetCallCount += 1
+        guard resetResult.isSuccess else {
+            return resetResult
+        }
+
         currentWaterIntakeMLValue = 0
         hydrationEventsByDay.removeAll()
+        return resetResult
     }
 
     func deleteHydrationEvent(id: UUID) async -> Bool {

--- a/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
+++ b/Project/Presentation/Tests/ProfileRoutineViewModelTests.swift
@@ -68,15 +68,21 @@ struct ProfileRoutineViewModelTests {
 
         func migrateLegacyDataIfNeeded() async {}
 
-        func drinkWater() async {}
+        func drinkWater() async -> HydrationWriteResult {
+            .success
+        }
 
-        func drinkWater(volumeML: Int) async {}
+        func drinkWater(volumeML: Int) async -> HydrationWriteResult {
+            .success
+        }
 
         func deleteHydrationEvent(id: UUID) async -> Bool {
             false
         }
 
-        func reset() async {}
+        func reset() async -> HydrationWriteResult {
+            .success
+        }
     }
 
     private final class SpyRoutineRecommendationUseCase: RoutineRecommendationUseCase, @unchecked Sendable {

--- a/Project/Presentation/WatchSources/View/WatchRootView.swift
+++ b/Project/Presentation/WatchSources/View/WatchRootView.swift
@@ -58,6 +58,23 @@ public struct WatchRootView: View {
                 await viewModel.load()
             }
         }
+        .alert(
+            WatchL10n.tr("watchHydrationMutationFailureTitle"),
+            isPresented: Binding(
+                get: { viewModel.mutationErrorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        viewModel.clearMutationError()
+                    }
+                }
+            )
+        ) {
+            Button(WatchL10n.tr("watchCommonConfirmButton")) {
+                viewModel.clearMutationError()
+            }
+        } message: {
+            Text(viewModel.mutationErrorMessage ?? "")
+        }
     }
 
     private var heroCard: some View {

--- a/Project/Presentation/WatchSources/ViewModel/WatchHydrationViewModel.swift
+++ b/Project/Presentation/WatchSources/ViewModel/WatchHydrationViewModel.swift
@@ -10,6 +10,7 @@ public final class WatchHydrationViewModel {
 
     var snapshot: WatchHydrationSnapshot
     var isMutating = false
+    var mutationErrorMessage: String?
 
     var canDrinkWater: Bool {
         snapshot.dailyGoalML <= 0 ||
@@ -37,7 +38,9 @@ public final class WatchHydrationViewModel {
 
         isMutating = true
         defer { isMutating = false }
-        snapshot = await useCase.drinkWater(referenceDate: now())
+        let result = await useCase.drinkWater(referenceDate: now())
+        snapshot = result.snapshot
+        mutationErrorMessage = errorMessage(for: result.writeResult, action: .record)
     }
 
     func resetToday() async {
@@ -47,6 +50,37 @@ public final class WatchHydrationViewModel {
 
         isMutating = true
         defer { isMutating = false }
-        snapshot = await useCase.reset(referenceDate: now())
+        let result = await useCase.reset(referenceDate: now())
+        snapshot = result.snapshot
+        mutationErrorMessage = errorMessage(for: result.writeResult, action: .reset)
+    }
+
+    func clearMutationError() {
+        mutationErrorMessage = nil
+    }
+
+    private func errorMessage(
+        for writeResult: HydrationWriteResult,
+        action: MutationAction
+    ) -> String? {
+        guard let failureReason = writeResult.failureReason else {
+            return nil
+        }
+
+        switch (action, failureReason) {
+        case (.record, .permissionDenied):
+            return WatchL10n.tr("watchHydrationRecordPermissionFailure")
+        case (.record, .invalidObjectType), (.record, .systemError):
+            return WatchL10n.tr("watchHydrationRecordFailure")
+        case (.reset, .permissionDenied):
+            return WatchL10n.tr("watchHydrationResetPermissionFailure")
+        case (.reset, .invalidObjectType), (.reset, .systemError):
+            return WatchL10n.tr("watchHydrationResetFailure")
+        }
+    }
+
+    private enum MutationAction {
+        case record
+        case reset
     }
 }

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockDrinkWaterUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockDrinkWaterUseCase.swift
@@ -11,6 +11,8 @@ import Foundation
 public final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable {
     public var currentWaterIntakeMLValue: Double = 750
     public var events: [HydrationEvent] = []
+    public var drinkWaterResult: HydrationWriteResult = .success
+    public var resetResult: HydrationWriteResult = .success
 
     public init() {}
 
@@ -30,11 +32,17 @@ public final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable
 
     public func migrateLegacyDataIfNeeded() async {}
 
-    public func drinkWater() async {
+    @discardableResult
+    public func drinkWater() async -> HydrationWriteResult {
         await drinkWater(volumeML: HydrationServing.defaultGlassVolumeML)
     }
 
-    public func drinkWater(volumeML: Int) async {
+    @discardableResult
+    public func drinkWater(volumeML: Int) async -> HydrationWriteResult {
+        guard drinkWaterResult.isSuccess else {
+            return drinkWaterResult
+        }
+
         currentWaterIntakeMLValue += Double(volumeML)
         events.append(
             HydrationEvent(
@@ -43,6 +51,7 @@ public final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable
                 volumeML: volumeML
             )
         )
+        return drinkWaterResult
     }
 
     public func deleteHydrationEvent(id: UUID) async -> Bool {
@@ -55,8 +64,14 @@ public final class MockDrinkWaterUseCase: DrinkWaterUseCase, @unchecked Sendable
         return true
     }
 
-    public func reset() async {
+    @discardableResult
+    public func reset() async -> HydrationWriteResult {
+        guard resetResult.isSuccess else {
+            return resetResult
+        }
+
         currentWaterIntakeMLValue = 0
         events.removeAll()
+        return resetResult
     }
 }

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockDrinkWaterUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockDrinkWaterUseCaseForTesting.swift
@@ -18,6 +18,8 @@ public final class MockDrinkWaterUseCaseForTesting: DrinkWaterUseCase, @unchecke
     public var deleteHydrationEventCallCount = 0
     public var deletedHydrationEventIDs: [UUID] = []
     public var events: [HydrationEvent] = []
+    public var drinkWaterResult: HydrationWriteResult = .success
+    public var resetResult: HydrationWriteResult = .success
 
     public init() {}
 
@@ -41,13 +43,19 @@ public final class MockDrinkWaterUseCaseForTesting: DrinkWaterUseCase, @unchecke
         migrateCallCount += 1
     }
 
-    public func drinkWater() async {
+    @discardableResult
+    public func drinkWater() async -> HydrationWriteResult {
         await drinkWater(volumeML: HydrationServing.defaultGlassVolumeML)
     }
 
-    public func drinkWater(volumeML: Int) async {
+    @discardableResult
+    public func drinkWater(volumeML: Int) async -> HydrationWriteResult {
         drinkWaterCallCount += 1
         recordedVolumesML.append(volumeML)
+        guard drinkWaterResult.isSuccess else {
+            return drinkWaterResult
+        }
+
         currentWaterIntakeMLValue += Double(volumeML)
         events.append(
             HydrationEvent(
@@ -56,13 +64,20 @@ public final class MockDrinkWaterUseCaseForTesting: DrinkWaterUseCase, @unchecke
                 volumeML: volumeML
             )
         )
+        return drinkWaterResult
     }
 
-    public func reset() async {
+    @discardableResult
+    public func reset() async -> HydrationWriteResult {
         resetCallCount += 1
+        guard resetResult.isSuccess else {
+            return resetResult
+        }
+
         currentWaterIntakeMLValue = 0
         recordedVolumesML = []
         events.removeAll()
+        return resetResult
     }
 
     public func deleteHydrationEvent(id: UUID) async -> Bool {

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -1585,6 +1585,72 @@
         }
       }
     },
+    "drinkWaterRecordFailureDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HealthKit에 수분 기록을 저장하지 못했어요. 잠시 후 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "drinkWaterRecordFailureTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기록하지 못했어요"
+          }
+        }
+      }
+    },
+    "drinkWaterRecordPermissionFailureDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱 권한이 꺼져 있어 수분 기록을 저장하지 못했어요. 설정에서 권한을 확인한 뒤 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "drinkWaterResetFailureDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 수분 기록을 초기화하지 못했어요. 잠시 후 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "drinkWaterResetFailureTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "초기화하지 못했어요"
+          }
+        }
+      }
+    },
+    "drinkWaterResetPermissionFailureDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건강 앱 권한이 꺼져 있어 오늘 수분 기록을 초기화하지 못했어요. 설정에서 권한을 확인한 뒤 다시 시도해 주세요."
+          }
+        }
+      }
+    },
     "drinkWaterUndoRecordTitle" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## 📝 Summary
HealthKit 수분 기록 쓰기 실패가 앱, AppIntent, Watch에서 조용한 성공으로 처리되지 않도록 복구 가능한 실패 상태를 전달합니다.

## 🎯 Type of Change
- [ ] ✨ New feature (새로운 기능 추가)
- [x] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [x] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues
- Closes #219

## 📋 Changes Made
### Added
- `HydrationWriteResult` / `HydrationWriteFailureReason`를 추가해 HealthKit 쓰기 성공/실패를 Domain 경계에서 표현
- Watch mutation 결과 모델을 추가해 snapshot과 쓰기 결과를 함께 전달
- 앱/Watch 실패 안내 문구 및 ViewModel 테스트 추가

### Changed
- 앱 물 기록/초기화 흐름이 HealthKit 쓰기 성공 후에만 refresh, undo, Widget timeline reload, 성공 analytics를 실행하도록 변경
- AppIntent가 HealthKit 저장 실패 시 성공 dialog, Widget reload, `water_logged` analytics를 실행하지 않도록 변경
- Watch 기록/초기화 실패 시 snapshot을 성공처럼 갱신하지 않고 사용자 안내 메시지를 표시하도록 변경
- hydration logging, reliability recovery, analytics 문서에 HealthKit 쓰기 실패 처리 기준 반영

### Fixed
- Data layer에서 로깅 후 삼켜지던 HealthKit 쓰기 실패가 앱, AppIntent, Watch 진입점까지 전달되지 않던 문제 수정
- 권한 철회로 인한 쓰기 실패가 설정 이동 CTA 없이 성공처럼 보일 수 있던 문제 수정

### Removed
- 없음

## 🔍 Technical Details
- `DrinkWaterUseCase` / `DrinkWaterRepository`의 수분 쓰기 API를 `HydrationWriteResult` 반환 방식으로 변경했습니다.
- `DrinkWaterHealthKitDataSource`와 Watch HealthKit data source에서 `HealthKitError` / `HKError`를 domain-safe failure reason으로 매핑합니다.
- 실패 analytics는 `water_log_failed.failure_reason`으로 기록하며, 일반 HealthKit 저장 실패는 `healthkit_write_failed`로 구분합니다.
- HealthKit source of truth 정책은 유지하고, 실패한 기록을 로컬 pending queue나 별도 원장으로 저장하지 않습니다.

## 📸 Screenshots / Videos
### Before
첨부 없음

### After
첨부 없음

## ✅ Testing
### Test Plan
- [ ] 앱 빌드 성공
- [ ] Debug 모드 정상 작동
- [ ] Release 모드 정상 작동
- [x] 기존 기능 영향 없음
- [ ] Widget Extension 정상 작동 (해당시)

### Test Environment
- iOS Version: N/A
- Device: N/A
- Xcode Version: 로컬 Xcode 환경에서 CoreSimulator/iOS platform 불일치 확인

### Test Results
- `tuist generate` 통과
- `make lint` 통과
- `make arch-check` 통과
- `git diff --check` 통과
- 변경 Domain/Data/WatchData slice `swiftc -typecheck` 통과
- `xcodebuild test` / generic iOS build는 로컬 환경의 CoreSimulator 버전 불일치 및 iOS 26.5 platform 미설치로 destination 확인 단계에서 실패

## 🚨 Breaking Changes
- [x] Yes (아래에 설명)
- [ ] No

`DrinkWaterUseCase`, `DrinkWaterRepository`, Watch hydration mutation API가 쓰기 결과를 반환하도록 바뀌었습니다. 현재 repo 내부 호출부와 테스트 mock은 함께 갱신했습니다.

## 📌 Additional Notes
- 실패한 HealthKit 쓰기는 성공 analytics, undo, Widget timeline reload를 발생시키지 않습니다.
- 권한 관련 실패는 설정 이동 CTA를 제공하고, 일반 저장 실패는 재시도 가능한 오류로 안내합니다.

## 👀 Review Checklist
- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [ ] 새로운 의존성이 필요한가요?
- [x] 문서 업데이트가 필요한가요?
- [ ] 데이터베이스 마이그레이션이 필요한가요?
- [ ] 환경 설정 변경이 필요한가요?
