### PR TITLE
Document PR test harness flow

### DIFF
--- a/Docs/harness-engineering.md
+++ b/Docs/harness-engineering.md
@@ -25,6 +25,10 @@ Docs/documentation-maintenance.md -> 문서 유지보수 규칙
 Docs/delivery-workflow.md -> 이슈, 브랜치, PR 전달 흐름
 Docs/security-privacy.md -> 보안/개인정보 운영 기준
 Docs/*.md          -> 도메인/설계 배경 문서
+.github/workflows/lint.yml -> PR lint와 architecture check
+.github/workflows/pr-unit-tests.yml -> PR 단위 Unit Test
+.github/workflows/ai-pr-review.yml -> Git Flow PR AI 리뷰
+ci_scripts/ci_post_clone.sh -> Xcode Cloud post-clone 준비
 ```
 
 ## Reading Path
@@ -96,6 +100,21 @@ Docs/*.md          -> 도메인/설계 배경 문서
 ### `Docs/security-privacy.md`
 - 민감 데이터 저장소, 권한, 외부 SDK, App Store privacy label 영향 검토 기준
 - 광고/IAP/서버 연동 전 확인할 개인정보 체크리스트
+
+## Automation Harness
+
+하네스 자동화는 로컬, GitHub Actions, Xcode Cloud의 책임을 분리한다.
+
+| Surface | File | Responsibility |
+| --- | --- | --- |
+| Local | `Makefile`, `scripts/lint.sh`, `scripts/lint-fix.sh`, `scripts/check-architecture.sh` | 개발자와 에이전트가 같은 lint/architecture guardrail을 실행한다. |
+| Local | `.githooks/pre-commit` | staged Swift 파일이 있을 때 SwiftLint와 architecture check를 커밋 전에 차단한다. |
+| GitHub Actions | `.github/workflows/lint.yml` | `main`, `develop` 대상 PR에서 SwiftLint와 architecture check를 실행한다. |
+| GitHub Actions | `.github/workflows/pr-unit-tests.yml` | `main`, `develop` 대상 PR에서 `DomainLayer`, `DataLayer`, `PresentationLayer` 테스트를 실행한다. |
+| GitHub Actions | `.github/workflows/ai-pr-review.yml` | Git Flow에 맞는 non-draft PR이 열리거나 ready 상태가 될 때 AI 리뷰 코멘트를 생성한다. |
+| Xcode Cloud | `ci_scripts/ci_post_clone.sh`, `Docs/xcode-cloud-release-build.md` | 태그 기반 Release archive를 준비한다. PR 유닛 테스트 게이트는 GitHub Actions가 담당한다. |
+
+PR 본문에는 로컬에서 직접 실행한 검증과 GitHub Actions/Xcode Cloud가 실행한 검증을 구분해서 적는다.
 
 ## Update Rules
 

--- a/Docs/xcode-cloud-release-build.md
+++ b/Docs/xcode-cloud-release-build.md
@@ -1,7 +1,7 @@
 # Xcode Cloud: Release Build Only Setup
 
 이 문서는 `#15` 이슈 범위를 "Release Build"로 한정해서 설정하는 절차입니다.
-`PR-UnitTests` 워크플로는 만들지 않습니다.
+Xcode Cloud에는 PR 유닛 테스트 워크플로를 만들지 않습니다. PR lint와 유닛 테스트 게이트는 GitHub Actions의 `.github/workflows/lint.yml`, `.github/workflows/pr-unit-tests.yml`가 담당합니다.
 
 ## 1) 저장소 준비
 - 커스텀 스크립트 경로를 Xcode Cloud 표준인 `ci_scripts/`로 사용
@@ -41,4 +41,5 @@ Xcode > Report navigator > Cloud 또는 App Store Connect > Xcode Cloud에서 �
 
 ## 5) 현재 범위
 - 포함: Release Archive 자동화
-- 제외: PR 생성 시 유닛 테스트 게이팅
+- 제외: Xcode Cloud 기반 PR 유닛 테스트 게이팅
+- GitHub Actions 담당: PR lint, architecture check, `DomainLayer`/`DataLayer`/`PresentationLayer` 유닛 테스트


### PR DESCRIPTION
## Summary
- GitHub Actions PR lint/test/AI review와 Xcode Cloud release archive의 책임 경계를 문서화했습니다.
- `Docs/xcode-cloud-release-build.md`의 PR 유닛 테스트 제외 표현을 현재 구성에 맞게 바로잡았습니다.

## Related Issues
- Closes #242

## Changes Made
### Changed
- `Docs/harness-engineering.md`에 automation harness 표를 추가했습니다.
- Xcode Cloud는 release archive 준비, PR 게이트는 GitHub Actions가 담당한다고 명시했습니다.

## Testing
### 실행한 로컬 검증
- [x] `git diff --check origin/develop..docs/242-pr-test-harness-flow`
- [x] `make lint`
- [x] `make arch-check`

### 실행하지 않은 검증과 이유
- Unit test / app build: 문서 전용 변경이라 실행하지 않았습니다.

### 자동화 결과
- GitHub Actions: PR 생성 후 확인 예정
- Xcode Cloud: 해당 없음

## Documentation
- `Docs/harness-engineering.md`
- `Docs/xcode-cloud-release-build.md`