### PR TITLE
Align validation harness docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,8 @@ Mulimi에 새로 들어온 AI 에이전트를 위한 온보딩 문서다. 이 �
   - `tuist generate`
 - 도메인 검증:
   - `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer -destination 'platform=iOS Simulator,id=<SIM_ID>' -sdk iphonesimulator`
+- 데이터 검증:
+  - `xcodebuild test -workspace Mulimi.xcworkspace -scheme DataLayer -destination 'platform=iOS Simulator,id=<SIM_ID>' -sdk iphonesimulator`
 - 프레젠테이션 검증:
   - `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,id=<SIM_ID>' -sdk iphonesimulator`
 - 앱 빌드:

--- a/Docs/quality-gates.md
+++ b/Docs/quality-gates.md
@@ -13,6 +13,18 @@ Mulimi 변경 사항을 PR 전에 어느 수준까지 검증할지 정리한 문
 
 문서만 바뀐 경우에도 `git diff --check`는 확인한다. 실행하지 않은 검증은 PR 본문에 통과했다고 적지 않는다.
 
+`make verify`는 `make lint`와 `make arch-check`를 묶은 lightweight gate다. Unit test와 앱 빌드가 필요한 변경에서는 아래 matrix에 맞는 `xcodebuild test` 또는 `xcodebuild build`를 별도로 실행한다.
+
+## Validation Levels
+
+| Level | Scope | Commands |
+| --- | --- | --- |
+| Lightweight local | 공백, SwiftLint, architecture guardrail | `git diff --check`, `make lint`, `make arch-check` 또는 `make verify` |
+| Unit local | 변경 레이어별 Swift unit test | `DomainLayer`, `DataLayer`, `PresentationLayer` `xcodebuild test` |
+| Build local | 앱/위젯/워치 통합 빌드 | `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi ...` |
+| PR CI | PR 단위 자동 검증 | `.github/workflows/lint.yml`, `.github/workflows/pr-unit-tests.yml` |
+| Release CI | 릴리스 archive 검증 | Xcode Cloud `Release-Build` |
+
 ## Validation Matrix
 
 | 변경 유형 | 최소 검증 | 추가 검증 |

--- a/Docs/skills/xcode-build-test.md
+++ b/Docs/skills/xcode-build-test.md
@@ -12,12 +12,16 @@ Mulimi에서 반복되는 검증 순서를 표준화한다.
 
 ## Default Order
 
-1. `make lint`
-2. `make arch-check`
-3. `tuist generate`
-4. `DomainLayer` 테스트
-5. `PresentationLayer` 테스트
-6. `Mulimi` 앱 빌드
+1. `git diff --check`
+2. `make lint`
+3. `make arch-check`
+4. `tuist generate`
+5. `DomainLayer` 테스트
+6. `DataLayer` 테스트
+7. `PresentationLayer` 테스트
+8. `Mulimi` 앱 빌드
+
+`make verify`는 `make lint`와 `make arch-check`만 실행하는 lightweight gate다. Unit test나 앱 빌드까지 끝났다는 의미로 사용하지 않는다.
 
 ## Commands
 
@@ -26,9 +30,20 @@ make lint
 make arch-check
 tuist generate
 xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer -destination 'platform=iOS Simulator,id=<SIM_ID>' -sdk iphonesimulator
+xcodebuild test -workspace Mulimi.xcworkspace -scheme DataLayer -destination 'platform=iOS Simulator,id=<SIM_ID>' -sdk iphonesimulator
 xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,id=<SIM_ID>' -sdk iphonesimulator
 xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
 ```
+
+## Validation Levels
+
+| Level | Commands | Use when |
+| --- | --- | --- |
+| Lightweight | `git diff --check`, `make lint`, `make arch-check` 또는 `make verify` | 문서 변경, 작은 Swift 변경의 첫 검증 |
+| Unit | `DomainLayer`, `DataLayer`, `PresentationLayer` `xcodebuild test` | UseCase, Repository, ViewModel, shared rule 변경 |
+| Build | `Mulimi` 앱 빌드, 필요 시 Widget/Watch 타깃 빌드 | Project.swift, SwiftUI, App/Widget/Watch 통합 변경 |
+| PR CI | `.github/workflows/lint.yml`, `.github/workflows/pr-unit-tests.yml` | `main`, `develop` 대상 PR 검증 |
+| Release | Xcode Cloud `Release-Build` archive | 태그 기반 릴리스 검증 |
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- 로컬 검증 문서와 실제 PR unit test 하네스 범위를 정렬했습니다.
- `make verify`가 lint/architecture lightweight gate임을 명확히 했습니다.

## Related Issues
- Closes #243

## Changes Made
### Changed
- `Docs/skills/xcode-build-test.md`에 `DataLayer` 테스트와 검증 레벨을 추가했습니다.
- `Docs/quality-gates.md`에 lightweight/unit/build/PR CI/release CI 구분을 추가했습니다.

## Testing
### 실행한 로컬 검증
- [x] `git diff --check origin/develop..docs/243-validation-harness-docs`
- [x] `make lint`
- [x] `make arch-check`

### 실행하지 않은 검증과 이유
- Unit test / app build: 문서 전용 변경이라 실행하지 않았습니다.

### 자동화 결과
- GitHub Actions: PR 생성 후 확인 예정
- Xcode Cloud: 해당 없음

## Documentation
- `Docs/skills/xcode-build-test.md`
- `Docs/quality-gates.md`