### PR TITLE
Document harness toolchain policy

### DIFF
--- a/Docs/harness-engineering.md
+++ b/Docs/harness-engineering.md
@@ -97,6 +97,17 @@ Docs/*.md          -> 도메인/설계 배경 문서
 - 민감 데이터 저장소, 권한, 외부 SDK, App Store privacy label 영향 검토 기준
 - 광고/IAP/서버 연동 전 확인할 개인정보 체크리스트
 
+## Toolchain Policy
+
+현재 하네스는 최신 Apple 개발 환경을 빠르게 따라가는 운영을 기본값으로 둔다.
+
+- Tuist는 `.mise.toml`의 `tuist = "latest"`를 사용한다.
+- GitHub Actions는 `macos-15` runner와 `latest-stable` Xcode를 사용한다.
+- CI 시뮬레이터 destination은 hosted runner에서 안정적으로 찾을 수 있는 이름 기반 값을 사용한다.
+- 로컬 `xcodebuild test`는 가능하면 시뮬레이터 `id`를 사용해 같은 이름의 여러 런타임 충돌을 피한다.
+
+최신 도구 drift로 CI나 로컬 검증이 반복 실패하면, 실패 로그와 영향 범위를 남기고 `.mise.toml`, GitHub Actions Xcode 버전, 문서의 기준 버전을 같은 PR에서 pin한다.
+
 ## Update Rules
 
 - 제품 요구 변경: `Docs/product-specs/` 우선 갱신

--- a/Docs/harness-engineering.md
+++ b/Docs/harness-engineering.md
@@ -97,17 +97,6 @@ Docs/*.md          -> 도메인/설계 배경 문서
 - 민감 데이터 저장소, 권한, 외부 SDK, App Store privacy label 영향 검토 기준
 - 광고/IAP/서버 연동 전 확인할 개인정보 체크리스트
 
-## Toolchain Policy
-
-현재 하네스는 최신 Apple 개발 환경을 빠르게 따라가는 운영을 기본값으로 둔다.
-
-- Tuist는 `.mise.toml`의 `tuist = "latest"`를 사용한다.
-- GitHub Actions는 `macos-15` runner와 `latest-stable` Xcode를 사용한다.
-- CI 시뮬레이터 destination은 hosted runner에서 안정적으로 찾을 수 있는 이름 기반 값을 사용한다.
-- 로컬 `xcodebuild test`는 가능하면 시뮬레이터 `id`를 사용해 같은 이름의 여러 런타임 충돌을 피한다.
-
-최신 도구 drift로 CI나 로컬 검증이 반복 실패하면, 실패 로그와 영향 범위를 남기고 `.mise.toml`, GitHub Actions Xcode 버전, 문서의 기준 버전을 같은 PR에서 pin한다.
-
 ## Update Rules
 
 - 제품 요구 변경: `Docs/product-specs/` 우선 갱신
@@ -120,6 +109,17 @@ Docs/*.md          -> 도메인/설계 배경 문서
 - 긴 작업 시작: `Docs/exec-plans/active/`에 계획 기록
 - 긴 작업 종료: `Docs/exec-plans/completed/`로 이동하거나 `tech-debt-tracker.md`에 후속 항목 기록
 - 코드와 문서가 어긋나면 코드를 먼저 확인하고 작업 끝에 문서를 맞춘다
+
+## Toolchain Policy
+
+현재 하네스는 최신 Apple 개발 환경을 빠르게 따라가는 운영을 기본값으로 둔다.
+
+- Tuist는 `.mise.toml`의 `tuist = "latest"`를 사용한다.
+- GitHub Actions는 `macos-15` runner와 `latest-stable` Xcode를 사용한다.
+- CI 시뮬레이터 destination은 hosted runner에서 안정적으로 찾을 수 있는 이름 기반 값을 사용한다.
+- 로컬 `xcodebuild test`는 가능하면 시뮬레이터 `id`를 사용해 같은 이름의 여러 런타임 충돌을 피한다.
+
+최신 도구 drift로 CI나 로컬 검증이 반복 실패하면, 실패 로그와 영향 범위를 남기고 `.mise.toml`, GitHub Actions Xcode 버전, 문서의 기준 버전을 같은 PR에서 pin한다.
 
 ## What Is Intentionally Missing
 

--- a/Docs/skills/xcode-build-test.md
+++ b/Docs/skills/xcode-build-test.md
@@ -33,5 +33,24 @@ xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'gene
 ## Notes
 
 - 시뮬레이터 이름보다 `id`가 더 안정적이다.
+- GitHub Actions는 ephemeral runner라서 `id`를 고정하지 않고 `.github/workflows/pr-unit-tests.yml`의 이름 기반 destination을 사용한다.
 - watch나 widget 변경이 직접 범위면 해당 타깃 빌드도 추가한다.
 - 실행하지 않은 검증은 PR에 적지 않는다.
+
+## Simulator Discovery
+
+로컬 테스트 destination은 아래 순서로 확인한다.
+
+```bash
+xcodebuild -version
+xcodebuild -showsdks
+xcrun simctl list devices available
+```
+
+동일한 기기 이름이 여러 OS runtime에 있으면 `id`를 골라 `-destination 'platform=iOS Simulator,id=<SIM_ID>'` 형식으로 실행한다.
+
+## Toolchain Troubleshooting
+
+- `.mise.toml`은 현재 `tuist = "latest"`를 사용한다. Tuist 최신 버전 변경으로 생성 결과가 달라지면 `.mise.toml` pinning과 문서 갱신을 같은 변경으로 처리한다.
+- GitHub Actions는 `latest-stable` Xcode를 사용한다. Xcode 업데이트로 SDK, simulator, Swift 컴파일 결과가 달라지면 실패 로그의 `xcodebuild -version`, `xcodebuild -showsdks` 출력부터 확인한다.
+- Metal shader 또는 SwiftUI shader asset 빌드가 Metal toolchain 누락으로 실패하면 Xcode component 상태를 확인한다. CLI에서 가능한 환경이면 `xcodebuild -downloadComponent MetalToolchain` 실행 후 같은 빌드를 다시 확인한다.


### PR DESCRIPTION
## Summary
- 하네스 도구체인과 시뮬레이터 재현성 정책을 문서화했습니다.
- Tuist latest, GitHub Actions latest-stable Xcode, 로컬 simulator id 사용 기준을 정리했습니다.

## Related Issues
- Closes #244

## Changes Made
### Changed
- `Docs/harness-engineering.md`에 Toolchain Policy를 추가했습니다.
- `Docs/skills/xcode-build-test.md`에 simulator discovery와 toolchain troubleshooting을 추가했습니다.

## Testing
### 실행한 로컬 검증
- [x] `git diff --check origin/develop..docs/244-toolchain-policy`
- [x] `make lint`
- [x] `make arch-check`

### 실행하지 않은 검증과 이유
- Unit test / app build: 문서 전용 변경이라 실행하지 않았습니다.

### 자동화 결과
- GitHub Actions: PR 생성 후 확인 예정
- Xcode Cloud: 해당 없음

## Documentation
- `Docs/harness-engineering.md`
- `Docs/skills/xcode-build-test.md`