### PR TITLE
권한 허용 직후 메인 화면에 첫 기록 안내 노출

### DIFF
--- a/Docs/product-specs/hydration-logging.md
+++ b/Docs/product-specs/hydration-logging.md
@@ -13,6 +13,9 @@
 - 다음 한 잔 안내는 화면 상단, `WaterDrop`과 오늘 섭취 요약은 화면 중앙, 기본 기록 CTA는 하단에 둔다. `WaterDrop`은 고정 시각 anchor로, 되돌리기나 기록 성공 피드백 상태 변화로 밀리지 않는다
 - 되돌리기(최근 앱 생성 기록 1건)와 초기화는 기본 기록 CTA 옆 더보기 메뉴에서 Label 형태로 제공한다. 되돌리기는 최근 기록이 있을 때만 메뉴에 나타나고, 초기화는 destructive action으로 구분한다
 - 기본 1잔 기록은 HealthKit 쓰기 중 중복 탭을 막고, 성공 후 사용자가 즉시 인지할 수 있는 짧은 완료 피드백을 primary CTA 상태 변화로 제공한다
+- 메인 화면은 Metal shader 기반 `WaterDrop`, 오늘 섭취 잔 수/용량 요약, 다음 한 잔 안내, 기본 1잔 기록, 최근 앱 생성 기록 1건 되돌리기, 오늘 물리미 기록 초기화만 노출한다
+- 기본 1잔 기록은 HealthKit 쓰기 중 중복 탭을 막고, 성공 후 사용자가 즉시 인지할 수 있는 짧은 완료 피드백을 제공한다
+- 오늘 기록이 0이고 다음 한 잔 안내가 기본 상태(`readyToDrink`)면, 같은 안내 카드의 문구를 첫 기록 유도로 바꿔 기본 1잔 기록 CTA와 건강 앱 저장을 안내한다. 별도 배너나 레이아웃 요소를 추가하지 않으며, 루틴 임박/목표 미설정 안내가 우선한다. 온보딩 전환 실험 H4 기준(`Docs/product-specs/onboarding-healthkit-conversion-experiments.md`)과 정렬된다
 - 기록 단위 사용자 기본값 설정은 아직 구현하지 않았다. 기본 액션, 위젯, Watch는 기본 1잔을 유지하고, Siri/Shortcuts는 실행 시 선택한 단위를 1회 기록한다
 - 기록 후 오늘 목표를 초과하는 단위는 앱과 AppIntent에서 기록하지 않는다
 - 메인 화면의 오늘 기록 초기화는 확인 후 물리미가 오늘 만든 HealthKit 샘플만 삭제한다
@@ -102,6 +105,7 @@
 
 - `ARCHITECTURE.md`
 - `Docs/reliability-recovery.md`
+- `Docs/product-specs/onboarding-healthkit-conversion-experiments.md`
 - `Docs/skills/healthkit-flow.md`
 - `Docs/skills/widget-watch-integration.md`
 

--- a/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
@@ -102,10 +102,16 @@ public final class DrinkWaterViewModel {
         L10n.tr("drinkWaterNextActionBadge")
     }
 
+    var isFirstRecordGuideActive: Bool {
+        nextActionGuide.state == .readyToDrink && nextActionGuide.currentIntakeML == 0
+    }
+
     var nextActionHeadline: String {
         switch nextActionGuide.state {
         case .readyToDrink:
-            return L10n.tr("drinkWaterNextActionReadyHeadline")
+            return isFirstRecordGuideActive
+                ? L10n.tr("drinkWaterNextActionFirstRecordHeadline")
+                : L10n.tr("drinkWaterNextActionReadyHeadline")
         case .approachingRoutine:
             guard let nextRoutine = nextActionGuide.nextRoutine else {
                 return L10n.tr("drinkWaterNextActionReadyHeadline")
@@ -129,6 +135,14 @@ public final class DrinkWaterViewModel {
         case .needsGoal:
             return L10n.tr("drinkWaterNextActionNeedsGoalDescription")
         case .readyToDrink, .approachingRoutine:
+            if isFirstRecordGuideActive {
+                return L10n.tr(
+                    "drinkWaterNextActionFirstRecordDescriptionFormat",
+                    L10n.tr("drinkWaterButtonTitle"),
+                    L10n.tr("commonMilliliterFormat", HydrationServing.defaultGlassVolumeML)
+                )
+            }
+
             let remainingText = L10n.tr("commonMilliliterFormat", nextActionGuide.remainingML)
 
             if let nextRoutine = nextActionGuide.nextRoutine {

--- a/Project/Presentation/Tests/DrinkWaterViewModelTests.swift
+++ b/Project/Presentation/Tests/DrinkWaterViewModelTests.swift
@@ -511,6 +511,137 @@ struct DrinkWaterViewModelTests {
         )
     }
 
+    @MainActor
+    @Test("오늘 기록이 0이면 다음 한 잔 안내를 첫 기록 안내로 바꾼다")
+    func firstRecordGuideWhenNoIntakeToday() async {
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.currentWaterIntakeMLValue = 0
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 2_000
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            nextActionGuideUseCase: StubHydrationNextActionGuideUseCase(),
+            widgetTimelineReloader: NoOpWidgetTimelineReloader()
+        )
+
+        await viewModel.loadInitialState()
+
+        #expect(viewModel.isFirstRecordGuideActive)
+        #expect(
+            viewModel.nextActionHeadline ==
+            L10n.tr("drinkWaterNextActionFirstRecordHeadline")
+        )
+        #expect(
+            viewModel.nextActionDescription ==
+            L10n.tr(
+                "drinkWaterNextActionFirstRecordDescriptionFormat",
+                L10n.tr("drinkWaterButtonTitle"),
+                L10n.tr("commonMilliliterFormat", HydrationServing.defaultGlassVolumeML)
+            )
+        )
+    }
+
+    @MainActor
+    @Test("첫 잔 기록 후에는 기존 다음 한 잔 안내로 돌아간다")
+    func firstRecordGuideEndsAfterFirstRecord() async {
+        let waterUseCase = MockDrinkWaterUseCase()
+        let guideUseCase = StubHydrationNextActionGuideUseCase()
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 2_000
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            nextActionGuideUseCase: guideUseCase,
+            widgetTimelineReloader: NoOpWidgetTimelineReloader()
+        )
+
+        await viewModel.loadInitialState()
+
+        #expect(viewModel.isFirstRecordGuideActive)
+
+        guideUseCase.guideValue = HydrationNextActionGuide.make(
+            currentIntakeML: Double(HydrationServing.defaultGlassVolumeML),
+            dailyGoalML: 2_000
+        )
+        await viewModel.drinkWater()
+
+        #expect(viewModel.isFirstRecordGuideActive == false)
+        #expect(
+            viewModel.nextActionHeadline ==
+            L10n.tr("drinkWaterNextActionReadyHeadline")
+        )
+        #expect(
+            viewModel.nextActionDescription ==
+            L10n.tr(
+                "drinkWaterNextActionRemainingDescriptionFormat",
+                L10n.tr("commonMilliliterFormat", 1_750),
+                7
+            )
+        )
+    }
+
+    @MainActor
+    @Test("목표가 없으면 첫 기록 안내 대신 목표 설정 안내를 유지한다")
+    func firstRecordGuideInactiveWhenGoalMissing() async {
+        let guideUseCase = StubHydrationNextActionGuideUseCase()
+        guideUseCase.guideValue = HydrationNextActionGuide.make(
+            currentIntakeML: 0,
+            dailyGoalML: 0
+        )
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: MockDrinkWaterUseCase(),
+            userPreferencesUseCase: MockUserPreferencesUseCase(),
+            nextActionGuideUseCase: guideUseCase,
+            widgetTimelineReloader: NoOpWidgetTimelineReloader()
+        )
+
+        await viewModel.refreshState()
+
+        #expect(viewModel.isFirstRecordGuideActive == false)
+        #expect(
+            viewModel.nextActionHeadline ==
+            L10n.tr("drinkWaterNextActionNeedsGoalHeadline")
+        )
+    }
+
+    @MainActor
+    @Test("루틴이 임박하면 기록이 0이어도 루틴 안내를 우선한다")
+    func firstRecordGuideYieldsToApproachingRoutine() async {
+        let guideUseCase = StubHydrationNextActionGuideUseCase()
+        guideUseCase.guideValue = HydrationNextActionGuide(
+            state: .approachingRoutine,
+            currentIntakeML: 0,
+            dailyGoalML: 2_000,
+            remainingML: 2_000,
+            remainingGlassCount: 8,
+            nextRoutine: HydrationNextRoutineContext(
+                id: "routine",
+                title: "오전 루틴",
+                hour: 10,
+                minute: 0,
+                minutesUntil: 30
+            )
+        )
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: MockDrinkWaterUseCase(),
+            userPreferencesUseCase: MockUserPreferencesUseCase(),
+            nextActionGuideUseCase: guideUseCase,
+            widgetTimelineReloader: NoOpWidgetTimelineReloader()
+        )
+
+        await viewModel.refreshState()
+
+        #expect(viewModel.isFirstRecordGuideActive == false)
+        #expect(
+            viewModel.nextActionHeadline ==
+            L10n.tr(
+                "drinkWaterNextActionApproachingRoutineHeadlineFormat",
+                L10n.tr("drinkWaterNextActionMinutesFormat", 30)
+            )
+        )
+    }
+
 }
 
 private final class SpyWidgetTimelineReloader: WidgetTimelineReloading, @unchecked Sendable {

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -1816,6 +1816,28 @@
         }
       }
     },
+    "drinkWaterNextActionFirstRecordDescriptionFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 버튼 한 번이면 %@ 한 잔이 건강 앱에 저장돼요."
+          }
+        }
+      }
+    },
+    "drinkWaterNextActionFirstRecordHeadline" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 첫 잔을 기록해 보세요"
+          }
+        }
+      }
+    },
     "drinkWaterNextActionGoalReachedDescription" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## 📝 Summary
HealthKit 권한 허용 직후(오늘 기록 0, `readyToDrink` 상태) 메인 기록 화면의 다음 한 잔 안내 카드를 첫 기록 유도 문구로 전환한다. 별도 배너 없이 기존 카드의 문구만 바꿔 기본 기록 CTA(`마시기`)와 건강 앱 저장을 안내하며, 온보딩 전환 실험 H4 기준과 정렬한다.

루트 흐름 점검 결과 `ContentView`는 권한 허용 후 항상 `selectedTab = .drink`로 진입하므로 탭 선택 관련 코드 변경은 없다.

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [x] 🧪 Test (테스트 추가/수정)
- [x] 📝 Documentation (문서 수정)

## 🔗 Related Issues
- Closes #261
- Related to #256

## 📋 Changes Made
### Added
- `DrinkWaterViewModel.isFirstRecordGuideActive`: `readyToDrink` && 오늘 섭취 0일 때 활성
- 첫 기록 안내 문구 키 2종: `drinkWaterNextActionFirstRecordHeadline`, `drinkWaterNextActionFirstRecordDescriptionFormat`
- `DrinkWaterViewModelTests` 4건: 활성 조건, 첫 기록 후 복귀, 목표 미설정 우선, 루틴 임박 우선

### Changed
- `Docs/product-specs/hydration-logging.md`: 첫 기록 안내 규칙과 H4 문서 링크 추가

## 🔍 Technical Details
- Presentation 전용 변경. Domain/Data, analytics(`water_logged`), Widget timeline 갱신 흐름은 그대로 사용한다.
- 안내 문구는 `drinkWaterButtonTitle`과 `HydrationServing.defaultGlassVolumeML`을 포맷 인자로 받아 CTA 문구/기본 잔 용량 변경 시 자동으로 동기화된다(하드코딩 250 없음).
- 우선순위: 루틴 임박(`approachingRoutine`), 목표 미설정(`needsGoal`) 안내가 첫 기록 안내보다 우선한다.
- 첫 기록 성공 후 기존 `refreshState` 흐름으로 섭취량이 갱신되면 자동으로 기존 안내로 복귀한다.
- 기존 카드 재사용으로 레이아웃 변화가 없어 #256 액션 영역 재정리와 충돌하지 않는다.

## 📸 Screenshots / Videos
- 첨부 없음: 기존 다음 한 잔 안내 카드의 문구 전환만 있고 레이아웃 변경이 없다. 재현: 오늘 기록 0 상태로 Drink 탭 진입.

## ✅ Testing
### 실행한 로컬 검증
- [x] `git diff --check` — clean
- [x] `make lint` — 257 files, 0 violations
- [x] `make arch-check` — passed
- [x] `tuist generate` — Success
- [x] `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,id=<iPhone 17 Pro>' -sdk iphonesimulator` — 93 tests / 11 suites passed (DrinkWaterViewModel Tests 23건 포함)

### 실행하지 않은 검증과 이유
- DomainLayer / DataLayer 테스트: 해당 레이어 변경 없음 (Presentation + Localization 리소스 + 문서만 변경)
- 앱 빌드: PresentationLayer 테스트 빌드에서 Localization 포함 컴파일 확인

### 자동화 결과
- GitHub Actions: PR 생성 후 lint workflow 결과 확인 예정
- Xcode Cloud: 해당 없음 (릴리스 빌드 아님)

### 검증 환경
- Xcode: 26.6 (17F113)
- iOS / Simulator / Device: iPhone 17 Pro, iOS 26.5 Simulator
- Tuist: 4.88.0

### 기존 경고와 새 경고
- Existing: 없음
- New: 없음

## 🚨 Breaking Changes
- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes
- WaterDrop 위치 고정과 되돌리기/초기화 overflow 메뉴 통합은 #256 범위에서 별도로 진행한다.
- 첫 기록 전환 효과는 `Docs/product-specs/onboarding-healthkit-conversion-experiments.md`의 H4 지표(first `water_logged` / `healthkit_permission_authorized`)로 평가한다. 새 이벤트/파라미터는 추가하지 않았다.

## 📝 Documentation
- `Docs/product-specs/hydration-logging.md` 갱신 (첫 기록 안내 규칙, Related Docs에 실험 문서 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)