### PR TITLE
온보딩 직후 알림 권한 프라이밍 게이트와 하루 3회 수분 리마인더 로컬 알림 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Mulimi에 새로 들어온 AI 에이전트를 위한 온보딩 문서다. 이 �
 
 - 앱 타깃: `iOS 26.0+`
 - 워치 타깃: `watchOS 26.0+`
-- 진입 흐름: `SignIn -> Onboarding -> HealthKitPermissionGate -> ContentView`
+- 진입 흐름: `SignIn -> Onboarding -> HydrationReminderPermissionGate -> HealthKitPermissionGate -> ContentView`
 - 루트 내비게이션: `Project/App/Sources/ContentView.swift`
 - 루트 세션 상태: `Project/Presentation/Sources/State/AppSession.swift`
 - 공용 라우팅: `Project/Presentation/Sources/Navigation/AppCoordinator.swift`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,6 +61,7 @@ Domain -> no UI dependency
 ```text
 SignIn
   -> Onboarding
+  -> HydrationReminderPermissionGate
   -> HealthKitPermissionGate
   -> ContentView
 ```

--- a/Docs/product-specs/analytics-events.md
+++ b/Docs/product-specs/analytics-events.md
@@ -30,7 +30,12 @@
 
 | Event | Required Parameters | Trigger |
 | --- | --- | --- |
-| `onboarding_completed` | `source` | 온보딩 마지막 CTA로 HealthKit 권한 게이트 진입 |
+| `onboarding_completed` | `source` | 온보딩 마지막 CTA로 권한 안내 흐름 진입 |
+| `hydration_reminder_priming_viewed` | `status` | 수분 리마인더 알림 권한 프라이밍 화면 노출 |
+| `hydration_reminder_request_tapped` | `status` | 알림 허용 CTA 탭 |
+| `hydration_reminder_permission_authorized` | `source`, `status` | 알림 권한 허용 확인 |
+| `hydration_reminder_permission_denied` | `source`, `status` | 알림 권한 거부 확인 |
+| `hydration_reminder_priming_skipped` | `status` | 프라이밍에서 나중에 할게요 탭 |
 | `healthkit_permission_gate_viewed` | `status` | HealthKit 권한 게이트 노출 |
 | `healthkit_permission_request_tapped` | `status` | 권한 요청 CTA 탭 |
 | `healthkit_permission_authorized` | `source`, `status` | 권한 허용 확인 |
@@ -52,6 +57,7 @@
 ### `source`
 
 - `onboarding`
+- `hydration_reminder_priming`
 - `healthkit_permission_gate`
 - `drink_water_main`
 - `app_intent`
@@ -96,6 +102,7 @@
 
 - HealthKit: `not_determined`, `denied`, `authorized`
 - Routine notification: `not_determined`, `denied`, `authorized`
+- Hydration reminder notification: `not_determined`, `denied`, `authorized`
 
 ## Validation
 

--- a/Docs/product-specs/hydration-reminder-priming.md
+++ b/Docs/product-specs/hydration-reminder-priming.md
@@ -1,0 +1,81 @@
+# Hydration Reminder Priming and Daily Nudges
+
+## Goal
+
+온보딩 직후 알림 권한을 맥락과 함께 요청하고, 허용한 사용자에게 하루 세 번 수분 입력을 유도하는 로컬 알림을 보낸다. 기존 루틴(AlarmKit) 알림과는 완전히 분리된 스택이다.
+
+## Current Flow
+
+```text
+Onboarding 완료
+  -> HydrationReminderPermissionGate (1회 노출, 스킵 가능)
+  -> HealthKitPermissionGate
+  -> ContentView
+```
+
+## Product Rules
+
+- 프라이밍 화면은 시스템 권한 팝업 전에 어떤 알림을 왜 보내는지 설명한다.
+- 시스템 권한 요청은 `알림 허용하기` CTA 탭에서만 실행한다. 자동 요청은 금지한다.
+- `나중에 할게요`로 언제든 건너뛸 수 있고, 거부해도 앱 진입을 막지 않는다.
+- 프라이밍은 기기당 1회만 노출한다. 허용/거부/스킵 어느 쪽이든 다시 보여주지 않는다.
+- 이미 온보딩을 마친 기존 사용자도 다음 실행 시 1회 프라이밍을 본다.
+- 권한이 허용된 상태에서는 앱 실행 시 리마인더 스케줄을 재동기화한다(문구 갱신 대응).
+- 사용자가 iOS 설정에서 권한을 회수하면 다음 실행 시 남은 리마인더를 정리한다.
+- 프라이밍 노출 전에 시스템 권한 상태를 먼저 확인한다. 확인이 끝나기 전에는 빈 화면을 유지해, 이미 권한이 결정된 사용자에게 프라이밍이 잠깐이라도 보이지 않게 한다.
+- 로그아웃해도 이미 스케줄된 리마인더는 유지한다. 재방문을 유도하는 의도된 동작이며, 알림을 탭하면 로그인 화면으로 진입한다.
+
+## Reminder Schedule
+
+- 슬롯 정책은 `HydrationReminderSlot`(Domain)이 SSOT다: 아침 9:00, 오후 14:00, 저녁 20:00.
+- 슬롯 3개 × 요일 7개 = 21개의 반복 `UNCalendarNotificationTrigger`로 스케줄한다.
+- 문구는 슬롯별 제목 + 요일에 따라 로테이션되는 본문 3종(듀오링고식 톤)이다. 토→일 주 경계를 포함해 같은 슬롯에서 같은 본문이 이틀 연속 반복되지 않는다.
+- 알림 식별자는 `hydrationReminder.<slot>.<weekday>`로 고정하고, 취소는 이 프리픽스만 대상으로 한다.
+- 재스케줄은 같은 식별자 `add()` 교체 방식으로 수행하고, 스케줄 성공 후에만 잔여 식별자를 정리한다. 중간 실패가 기존 스케줄을 지우지 않게 하기 위함이다.
+- `removeAllPendingNotificationRequests()`는 사용하지 않는다.
+
+## Routine Notifications와의 관계
+
+- 루틴 알림은 AlarmKit(`AlarmManager`) 기반이고 이 기능은 `UNUserNotificationCenter` 기반이다.
+- 두 권한은 서로 다른 시스템 권한이며 한쪽 허용이 다른 쪽에 영향을 주지 않는다.
+- 루틴 저장/삭제 시 AlarmKit 알람을 전체 리셋하는 기존 동작은 이 기능과 무관하다.
+
+## State Expectations
+
+- `프라이밍 미노출 + 권한 notDetermined`: 프라이밍 화면 노출
+- `허용`: 리마인더 21개 스케줄 후 다음 단계 진입
+- `거부 / 스킵`: 스케줄 없이 다음 단계 진입
+- `권한이 이미 결정된 상태(재설치 등)`: 프라이밍 없이 통과, 허용 상태면 재동기화
+
+## Measurement Plan
+
+이벤트 정의는 [Analytics Events](analytics-events.md)를 기준으로 한다.
+
+- `hydration_reminder_priming_viewed`: 프라이밍 화면 노출
+- `hydration_reminder_request_tapped`: 알림 허용 CTA 탭
+- `hydration_reminder_permission_authorized`: 권한 허용
+- `hydration_reminder_permission_denied`: 권한 거부
+- `hydration_reminder_priming_skipped`: 나중에 할게요 탭
+
+## Known Limitations
+
+- `UNUserNotificationCenterDelegate`가 없어 앱이 포그라운드일 때는 배너가 보이지 않는다. 포그라운드 표시와 알림 탭 딥링크는 후속 이슈로 다룬다(AppCoordinator 딥링크 이슈 #257과 연계).
+- 리마인더 시간과 문구는 아직 사용자 설정을 제공하지 않는다.
+- 회원 탈퇴 시 리마인더 자동 정리는 아직 없다. 후속 이슈로 다룬다.
+
+## Related Code
+
+- `Project/Domain/Interfaces/Entity/HydrationReminderSlot.swift`
+- `Project/Domain/Interfaces/UseCase/HydrationReminderUseCase.swift`
+- `Project/Domain/Sources/UseCase/HydrationReminderUseCaseImpl.swift`
+- `Project/Data/Sources/DataSource/HydrationReminderNotificationDataSource.swift`
+- `Project/Data/Sources/Repository/HydrationReminderRepositoryImpl.swift`
+- `Project/Presentation/Sources/ViewModel/HydrationReminderPermissionViewModel.swift`
+- `Project/Presentation/Sources/View/Authentication/HydrationReminderPermissionGateView.swift`
+- `Project/Presentation/Sources/View/RootView.swift`
+
+## Related Docs
+
+- `Docs/product-specs/sign-in-onboarding-healthkit.md`
+- `Docs/product-specs/routine-notifications.md`
+- `Docs/product-specs/analytics-events.md`

--- a/Docs/product-specs/index.md
+++ b/Docs/product-specs/index.md
@@ -5,6 +5,7 @@
 ## Specs
 
 - [SignIn, Onboarding, HealthKit Gate](sign-in-onboarding-healthkit.md)
+- [Hydration Reminder Priming and Daily Nudges](hydration-reminder-priming.md)
 - [Onboarding and HealthKit Conversion Experiments](onboarding-healthkit-conversion-experiments.md)
 - [Hydration Logging](hydration-logging.md)
 - [Routine Notifications](routine-notifications.md)

--- a/Docs/product-specs/sign-in-onboarding-healthkit.md
+++ b/Docs/product-specs/sign-in-onboarding-healthkit.md
@@ -9,9 +9,12 @@
 ```text
 SignIn
   -> Onboarding
+  -> HydrationReminderPermissionGate
   -> HealthKitPermissionGate
   -> ContentView
 ```
+
+수분 리마인더 알림 권한 프라이밍의 상세 규칙은 [Hydration Reminder Priming and Daily Nudges](hydration-reminder-priming.md)를 따른다.
 
 ## Product Rules
 
@@ -26,6 +29,7 @@ SignIn
 
 - `signedOut`: 로그인 화면
 - `signedIn + onboarding incomplete`: 온보딩
+- `signedIn + onboarding complete + 알림 프라이밍 미노출`: 수분 리마인더 알림 권한 프라이밍(1회, 스킵 가능)
 - `signedIn + onboarding complete + HealthKit unauthorized`: 권한 게이트
 - `signedIn + onboarding complete + HealthKit authorized`: 메인 진입
 
@@ -58,6 +62,7 @@ SignIn
 - `Project/App/Sources/ContentView.swift`
 - `Project/Presentation/Sources/View/RootView.swift`
 - `Project/Presentation/Sources/View/Authentication/OnboardingView.swift`
+- `Project/Presentation/Sources/View/Authentication/HydrationReminderPermissionGateView.swift`
 - `Project/Presentation/Sources/View/Authentication/HealthKitPermissionGateView.swift`
 
 ## Related Docs

--- a/Project/App/Sources/DrinkWaterApp.swift
+++ b/Project/App/Sources/DrinkWaterApp.swift
@@ -23,6 +23,9 @@ struct DrinkWaterApp: App {
                 appSession: DIContainer.shared.resolve(AppSession.self),
                 authenticationViewModel: DIContainer.shared.resolve(AuthenticationViewModel.self),
                 onboardingViewModel: DIContainer.shared.resolve(OnboardingViewModel.self),
+                hydrationReminderPermissionViewModel: DIContainer.shared.resolve(
+                    HydrationReminderPermissionViewModel.self
+                ),
                 healthKitPermissionViewModel: DIContainer.shared.resolve(HealthKitPermissionViewModel.self)
             ) {
                 ContentView()

--- a/Project/Data/Sources/DataSource/HydrationReminderNotificationDataSource.swift
+++ b/Project/Data/Sources/DataSource/HydrationReminderNotificationDataSource.swift
@@ -1,0 +1,150 @@
+import DomainLayerInterface
+import Foundation
+import Localization
+import UserNotifications
+
+public protocol HydrationReminderNotificationDataSource: Sendable {
+    func authorizationStatus() async -> HydrationReminderAuthorizationStatus
+    func requestAuthorization() async throws -> HydrationReminderAuthorizationStatus
+    func scheduleDailyReminders(for slots: [HydrationReminderSlot]) async throws
+    func cancelDailyReminders() async
+}
+
+public final class HydrationReminderNotificationDataSourceImpl: HydrationReminderNotificationDataSource,
+                                                                @unchecked Sendable {
+    private enum Constant {
+        static let identifierPrefix = "hydrationReminder"
+        static let scheduledWeekdays = 1...7
+        // 본문 3종을 7일에 단순 나머지로 배치하면 토요일(7)과 일요일(1)이 같은
+        // 인덱스가 되어 주 경계에서 같은 문구가 이틀 연속 반복된다. 주 경계를
+        // 포함해 연속 반복이 없도록 요일별 회전 테이블을 고정한다.
+        static let weekdayVariantIndices = [0, 1, 2, 0, 1, 2, 1]
+    }
+
+    private var notificationCenter: UNUserNotificationCenter {
+        .current()
+    }
+
+    public init() {}
+
+    public func authorizationStatus() async -> HydrationReminderAuthorizationStatus {
+        let settings = await notificationCenter.notificationSettings()
+        return mapAuthorizationStatus(settings.authorizationStatus)
+    }
+
+    public func requestAuthorization() async throws -> HydrationReminderAuthorizationStatus {
+        _ = try await notificationCenter.requestAuthorization(options: [.alert, .sound])
+        return await authorizationStatus()
+    }
+
+    public func scheduleDailyReminders(for slots: [HydrationReminderSlot]) async throws {
+        var scheduledIdentifiers = Set<String>()
+
+        // 같은 식별자로 add()하면 기존 요청이 교체되므로 먼저 취소하지 않는다.
+        // 덕분에 중간에 실패해도 이전 스케줄이 지워진 채 남지 않는다.
+        for slot in slots {
+            for weekday in Constant.scheduledWeekdays {
+                let content = UNMutableNotificationContent()
+                content.title = notificationTitle(for: slot)
+                content.body = notificationBody(for: slot, weekday: weekday)
+                content.sound = .default
+
+                var dateComponents = DateComponents()
+                dateComponents.weekday = weekday
+                dateComponents.hour = slot.hour
+                dateComponents.minute = slot.minute
+
+                let identifier = reminderIdentifier(for: slot, weekday: weekday)
+                let request = UNNotificationRequest(
+                    identifier: identifier,
+                    content: content,
+                    trigger: UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+                )
+
+                try await notificationCenter.add(request)
+                scheduledIdentifiers.insert(identifier)
+            }
+        }
+
+        await cancelReminders(excluding: scheduledIdentifiers)
+    }
+
+    public func cancelDailyReminders() async {
+        await cancelReminders(excluding: [])
+    }
+
+    private func cancelReminders(excluding scheduledIdentifiers: Set<String>) async {
+        let reminderIdentifiers = await notificationCenter.pendingNotificationRequests()
+            .map(\.identifier)
+            .filter { $0.hasPrefix(Constant.identifierPrefix) && !scheduledIdentifiers.contains($0) }
+
+        guard !reminderIdentifiers.isEmpty else {
+            return
+        }
+
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: reminderIdentifiers)
+    }
+
+    private func reminderIdentifier(for slot: HydrationReminderSlot, weekday: Int) -> String {
+        "\(Constant.identifierPrefix).\(slot.rawValue).\(weekday)"
+    }
+
+    private func notificationTitle(for slot: HydrationReminderSlot) -> String {
+        switch slot {
+        case .morning:
+            return L10n.tr("hydrationReminderMorningTitle")
+        case .afternoon:
+            return L10n.tr("hydrationReminderAfternoonTitle")
+        case .evening:
+            return L10n.tr("hydrationReminderEveningTitle")
+        }
+    }
+
+    private func notificationBody(for slot: HydrationReminderSlot, weekday: Int) -> String {
+        let bodyKeys = bodyKeys(for: slot)
+        let slotOffset = HydrationReminderSlot.allCases.firstIndex(of: slot) ?? 0
+        let variantIndices = Constant.weekdayVariantIndices
+        let weekdayIndex = variantIndices[(weekday - 1) % variantIndices.count]
+        let bodyKey = bodyKeys[(weekdayIndex + slotOffset) % bodyKeys.count]
+
+        return L10n.tr(bodyKey)
+    }
+
+    private func bodyKeys(for slot: HydrationReminderSlot) -> [String] {
+        switch slot {
+        case .morning:
+            return [
+                "hydrationReminderMorningBodyVariant1",
+                "hydrationReminderMorningBodyVariant2",
+                "hydrationReminderMorningBodyVariant3"
+            ]
+        case .afternoon:
+            return [
+                "hydrationReminderAfternoonBodyVariant1",
+                "hydrationReminderAfternoonBodyVariant2",
+                "hydrationReminderAfternoonBodyVariant3"
+            ]
+        case .evening:
+            return [
+                "hydrationReminderEveningBodyVariant1",
+                "hydrationReminderEveningBodyVariant2",
+                "hydrationReminderEveningBodyVariant3"
+            ]
+        }
+    }
+
+    private func mapAuthorizationStatus(
+        _ status: UNAuthorizationStatus
+    ) -> HydrationReminderAuthorizationStatus {
+        switch status {
+        case .notDetermined:
+            return .notDetermined
+        case .denied:
+            return .denied
+        case .authorized, .provisional, .ephemeral:
+            return .authorized
+        @unknown default:
+            return .notDetermined
+        }
+    }
+}

--- a/Project/Data/Sources/DataSource/HydrationReminderStorageDataSource.swift
+++ b/Project/Data/Sources/DataSource/HydrationReminderStorageDataSource.swift
@@ -1,0 +1,26 @@
+import DomainLayerInterface
+import Foundation
+import Utils
+
+public protocol HydrationReminderStorageDataSource: Sendable {
+    func hasSeenPermissionPriming() -> Bool
+    func setHasSeenPermissionPriming(_ seen: Bool)
+}
+
+public final class HydrationReminderStorageDataSourceImpl: HydrationReminderStorageDataSource,
+                                                           @unchecked Sendable {
+    private let userDefaults: UserDefaults
+
+    public init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+    }
+
+    public func hasSeenPermissionPriming() -> Bool {
+        userDefaults.bool(forKey: .hasSeenHydrationReminderPriming)
+    }
+
+    public func setHasSeenPermissionPriming(_ seen: Bool) {
+        userDefaults.set(seen, forKey: .hasSeenHydrationReminderPriming)
+        userDefaults.synchronize()
+    }
+}

--- a/Project/Data/Sources/Repository/HydrationReminderRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/HydrationReminderRepositoryImpl.swift
@@ -1,0 +1,39 @@
+import DomainLayerInterface
+import Foundation
+
+public struct HydrationReminderRepositoryImpl: HydrationReminderRepository {
+    private let notificationDataSource: HydrationReminderNotificationDataSource
+    private let storageDataSource: HydrationReminderStorageDataSource
+
+    public init(
+        notificationDataSource: HydrationReminderNotificationDataSource,
+        storageDataSource: HydrationReminderStorageDataSource
+    ) {
+        self.notificationDataSource = notificationDataSource
+        self.storageDataSource = storageDataSource
+    }
+
+    public func authorizationStatus() async -> HydrationReminderAuthorizationStatus {
+        await notificationDataSource.authorizationStatus()
+    }
+
+    public func requestAuthorization() async throws -> HydrationReminderAuthorizationStatus {
+        try await notificationDataSource.requestAuthorization()
+    }
+
+    public func scheduleDailyReminders(for slots: [HydrationReminderSlot]) async throws {
+        try await notificationDataSource.scheduleDailyReminders(for: slots)
+    }
+
+    public func cancelDailyReminders() async {
+        await notificationDataSource.cancelDailyReminders()
+    }
+
+    public func hasSeenPermissionPriming() -> Bool {
+        storageDataSource.hasSeenPermissionPriming()
+    }
+
+    public func setHasSeenPermissionPriming(_ seen: Bool) {
+        storageDataSource.setHasSeenPermissionPriming(seen)
+    }
+}

--- a/Project/Data/Tests/HydrationReminderRepositoryImplTests.swift
+++ b/Project/Data/Tests/HydrationReminderRepositoryImplTests.swift
@@ -1,0 +1,146 @@
+import DataLayer
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@Suite("HydrationReminderRepositoryImpl Tests")
+struct HydrationReminderRepositoryImplTests {
+    private enum TestError: Error {
+        case scheduleFailed
+    }
+
+    private final class SpyHydrationReminderNotificationDataSource: HydrationReminderNotificationDataSource,
+                                                                    @unchecked Sendable {
+        var authorizationStatusValue: HydrationReminderAuthorizationStatus = .notDetermined
+        var requestAuthorizationResult: Result<HydrationReminderAuthorizationStatus, Error> = .success(.authorized)
+        var scheduleError: Error?
+        private(set) var scheduledSlots: [HydrationReminderSlot] = []
+        private(set) var scheduleCallCount = 0
+        private(set) var cancelCallCount = 0
+
+        func authorizationStatus() async -> HydrationReminderAuthorizationStatus {
+            authorizationStatusValue
+        }
+
+        func requestAuthorization() async throws -> HydrationReminderAuthorizationStatus {
+            switch requestAuthorizationResult {
+            case .success(let status):
+                authorizationStatusValue = status
+                return status
+            case .failure(let error):
+                throw error
+            }
+        }
+
+        func scheduleDailyReminders(for slots: [HydrationReminderSlot]) async throws {
+            if let scheduleError {
+                throw scheduleError
+            }
+
+            scheduleCallCount += 1
+            scheduledSlots = slots
+        }
+
+        func cancelDailyReminders() async {
+            cancelCallCount += 1
+        }
+    }
+
+    private final class SpyHydrationReminderStorageDataSource: HydrationReminderStorageDataSource,
+                                                               @unchecked Sendable {
+        var hasSeenPermissionPrimingValue = false
+
+        func hasSeenPermissionPriming() -> Bool {
+            hasSeenPermissionPrimingValue
+        }
+
+        func setHasSeenPermissionPriming(_ seen: Bool) {
+            hasSeenPermissionPrimingValue = seen
+        }
+    }
+
+    @Test("authorizationStatus는 알림 데이터소스 상태를 반환한다")
+    func authorizationStatus() async {
+        let notification = SpyHydrationReminderNotificationDataSource()
+        notification.authorizationStatusValue = .authorized
+        let repository = HydrationReminderRepositoryImpl(
+            notificationDataSource: notification,
+            storageDataSource: SpyHydrationReminderStorageDataSource()
+        )
+
+        let status = await repository.authorizationStatus()
+
+        #expect(status == .authorized)
+    }
+
+    @Test("requestAuthorization는 알림 데이터소스에 위임한다")
+    func requestAuthorization() async throws {
+        let notification = SpyHydrationReminderNotificationDataSource()
+        notification.requestAuthorizationResult = .success(.denied)
+        let repository = HydrationReminderRepositoryImpl(
+            notificationDataSource: notification,
+            storageDataSource: SpyHydrationReminderStorageDataSource()
+        )
+
+        let status = try await repository.requestAuthorization()
+
+        #expect(status == .denied)
+    }
+
+    @Test("scheduleDailyReminders는 슬롯을 그대로 전달한다")
+    func scheduleDailyReminders() async throws {
+        let notification = SpyHydrationReminderNotificationDataSource()
+        let repository = HydrationReminderRepositoryImpl(
+            notificationDataSource: notification,
+            storageDataSource: SpyHydrationReminderStorageDataSource()
+        )
+
+        try await repository.scheduleDailyReminders(for: HydrationReminderSlot.allCases)
+
+        #expect(notification.scheduleCallCount == 1)
+        #expect(notification.scheduledSlots == HydrationReminderSlot.allCases)
+    }
+
+    @Test("scheduleDailyReminders는 스케줄 실패를 전파한다")
+    func scheduleDailyRemindersPropagatesError() async {
+        let notification = SpyHydrationReminderNotificationDataSource()
+        notification.scheduleError = TestError.scheduleFailed
+        let repository = HydrationReminderRepositoryImpl(
+            notificationDataSource: notification,
+            storageDataSource: SpyHydrationReminderStorageDataSource()
+        )
+
+        await #expect(throws: TestError.scheduleFailed) {
+            try await repository.scheduleDailyReminders(for: HydrationReminderSlot.allCases)
+        }
+    }
+
+    @Test("cancelDailyReminders는 알림 데이터소스에 위임한다")
+    func cancelDailyReminders() async {
+        let notification = SpyHydrationReminderNotificationDataSource()
+        let repository = HydrationReminderRepositoryImpl(
+            notificationDataSource: notification,
+            storageDataSource: SpyHydrationReminderStorageDataSource()
+        )
+
+        await repository.cancelDailyReminders()
+
+        #expect(notification.cancelCallCount == 1)
+    }
+
+    @Test("프라이밍 플래그는 스토리지 데이터소스에 위임한다")
+    func primingFlagDelegatesToStorage() {
+        let storage = SpyHydrationReminderStorageDataSource()
+        let repository = HydrationReminderRepositoryImpl(
+            notificationDataSource: SpyHydrationReminderNotificationDataSource(),
+            storageDataSource: storage
+        )
+
+        #expect(repository.hasSeenPermissionPriming() == false)
+
+        repository.setHasSeenPermissionPriming(true)
+
+        #expect(storage.hasSeenPermissionPrimingValue)
+        #expect(repository.hasSeenPermissionPriming())
+    }
+}

--- a/Project/Domain/Interfaces/Entity/HydrationReminderAuthorizationStatus.swift
+++ b/Project/Domain/Interfaces/Entity/HydrationReminderAuthorizationStatus.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum HydrationReminderAuthorizationStatus: Int, Codable, Sendable {
+    case notDetermined
+    case denied
+    case authorized
+}

--- a/Project/Domain/Interfaces/Entity/HydrationReminderSlot.swift
+++ b/Project/Domain/Interfaces/Entity/HydrationReminderSlot.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public enum HydrationReminderSlot: String, CaseIterable, Codable, Sendable {
+    case morning
+    case afternoon
+    case evening
+
+    public var hour: Int {
+        switch self {
+        case .morning:
+            return 9
+        case .afternoon:
+            return 14
+        case .evening:
+            return 20
+        }
+    }
+
+    public var minute: Int {
+        0
+    }
+}

--- a/Project/Domain/Interfaces/Entity/ProductAnalyticsEvent.swift
+++ b/Project/Domain/Interfaces/Entity/ProductAnalyticsEvent.swift
@@ -47,6 +47,65 @@ public extension ProductAnalyticsEvent {
         )
     }
 
+    static func hydrationReminderPrimingViewed(
+        status: HydrationReminderAuthorizationStatus
+    ) -> ProductAnalyticsEvent {
+        ProductAnalyticsEvent(
+            name: "hydration_reminder_priming_viewed",
+            parameters: [
+                AnalyticsParameterName.status: .string(status.analyticsValue)
+            ]
+        )
+    }
+
+    static func hydrationReminderPermissionRequestTapped(
+        status: HydrationReminderAuthorizationStatus
+    ) -> ProductAnalyticsEvent {
+        ProductAnalyticsEvent(
+            name: "hydration_reminder_request_tapped",
+            parameters: [
+                AnalyticsParameterName.status: .string(status.analyticsValue)
+            ]
+        )
+    }
+
+    static func hydrationReminderPermissionAuthorized(
+        source: String,
+        status: HydrationReminderAuthorizationStatus
+    ) -> ProductAnalyticsEvent {
+        ProductAnalyticsEvent(
+            name: "hydration_reminder_permission_authorized",
+            parameters: [
+                AnalyticsParameterName.source: .string(source),
+                AnalyticsParameterName.status: .string(status.analyticsValue)
+            ]
+        )
+    }
+
+    static func hydrationReminderPermissionDenied(
+        source: String,
+        status: HydrationReminderAuthorizationStatus
+    ) -> ProductAnalyticsEvent {
+        ProductAnalyticsEvent(
+            name: "hydration_reminder_permission_denied",
+            parameters: [
+                AnalyticsParameterName.source: .string(source),
+                AnalyticsParameterName.status: .string(status.analyticsValue)
+            ]
+        )
+    }
+
+    static func hydrationReminderPrimingSkipped(
+        status: HydrationReminderAuthorizationStatus
+    ) -> ProductAnalyticsEvent {
+        ProductAnalyticsEvent(
+            name: "hydration_reminder_priming_skipped",
+            parameters: [
+                AnalyticsParameterName.status: .string(status.analyticsValue)
+            ]
+        )
+    }
+
     static func healthKitPermissionGateViewed(
         status: HealthKitAuthorizationStatus
     ) -> ProductAnalyticsEvent {
@@ -285,6 +344,19 @@ private extension HealthKitAuthorizationStatus {
         case .sharingDenied:
             return "denied"
         case .sharingAuthorized:
+            return "authorized"
+        }
+    }
+}
+
+private extension HydrationReminderAuthorizationStatus {
+    var analyticsValue: String {
+        switch self {
+        case .notDetermined:
+            return "not_determined"
+        case .denied:
+            return "denied"
+        case .authorized:
             return "authorized"
         }
     }

--- a/Project/Domain/Interfaces/Repository/HydrationReminderRepository.swift
+++ b/Project/Domain/Interfaces/Repository/HydrationReminderRepository.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public protocol HydrationReminderRepository: Sendable {
+    func authorizationStatus() async -> HydrationReminderAuthorizationStatus
+    func requestAuthorization() async throws -> HydrationReminderAuthorizationStatus
+    func scheduleDailyReminders(for slots: [HydrationReminderSlot]) async throws
+    func cancelDailyReminders() async
+    func hasSeenPermissionPriming() -> Bool
+    func setHasSeenPermissionPriming(_ seen: Bool)
+}

--- a/Project/Domain/Interfaces/UseCase/HydrationReminderUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/HydrationReminderUseCase.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol HydrationReminderUseCase: Sendable {
+    func authorizationStatus() async -> HydrationReminderAuthorizationStatus
+    func requestAuthorizationAndSyncReminders() async throws -> HydrationReminderAuthorizationStatus
+    func syncReminders() async
+    func hasSeenPermissionPriming() -> Bool
+    func markPermissionPrimingSeen()
+}

--- a/Project/Domain/Sources/UseCase/HydrationReminderUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/HydrationReminderUseCaseImpl.swift
@@ -1,0 +1,45 @@
+import DomainLayerInterface
+import Foundation
+
+public struct HydrationReminderUseCaseImpl: HydrationReminderUseCase {
+    private let repository: HydrationReminderRepository
+
+    public init(repository: HydrationReminderRepository) {
+        self.repository = repository
+    }
+
+    public func authorizationStatus() async -> HydrationReminderAuthorizationStatus {
+        await repository.authorizationStatus()
+    }
+
+    public func requestAuthorizationAndSyncReminders() async throws -> HydrationReminderAuthorizationStatus {
+        let status = try await repository.requestAuthorization()
+
+        if status == .authorized {
+            try await repository.scheduleDailyReminders(for: HydrationReminderSlot.allCases)
+        } else {
+            await repository.cancelDailyReminders()
+        }
+
+        return status
+    }
+
+    public func syncReminders() async {
+        let status = await repository.authorizationStatus()
+
+        guard status == .authorized else {
+            await repository.cancelDailyReminders()
+            return
+        }
+
+        try? await repository.scheduleDailyReminders(for: HydrationReminderSlot.allCases)
+    }
+
+    public func hasSeenPermissionPriming() -> Bool {
+        repository.hasSeenPermissionPriming()
+    }
+
+    public func markPermissionPrimingSeen() {
+        repository.setHasSeenPermissionPriming(true)
+    }
+}

--- a/Project/Domain/Tests/HydrationReminderUseCaseTests.swift
+++ b/Project/Domain/Tests/HydrationReminderUseCaseTests.swift
@@ -1,0 +1,123 @@
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import DomainLayer
+
+@Suite("HydrationReminderUseCase Tests")
+struct HydrationReminderUseCaseTests {
+    @Test("authorizationStatus는 Repository 상태를 반환한다")
+    func authorizationStatus() async {
+        let repository = MockHydrationReminderRepository()
+        repository.authorizationStatusValue = .denied
+        let useCase = HydrationReminderUseCaseImpl(repository: repository)
+
+        let status = await useCase.authorizationStatus()
+
+        #expect(status == .denied)
+    }
+
+    @Test("권한이 허용되면 모든 슬롯의 리마인더를 스케줄한다")
+    func requestAuthorizationSchedulesWhenAuthorized() async throws {
+        let repository = MockHydrationReminderRepository()
+        repository.requestAuthorizationResult = .success(.authorized)
+        let useCase = HydrationReminderUseCaseImpl(repository: repository)
+
+        let status = try await useCase.requestAuthorizationAndSyncReminders()
+
+        #expect(status == .authorized)
+        #expect(repository.scheduleDailyRemindersCallCount == 1)
+        #expect(repository.capturedSlots == HydrationReminderSlot.allCases)
+        #expect(repository.cancelDailyRemindersCallCount == 0)
+    }
+
+    @Test("권한이 거부되면 리마인더를 취소한다")
+    func requestAuthorizationCancelsWhenDenied() async throws {
+        let repository = MockHydrationReminderRepository()
+        repository.requestAuthorizationResult = .success(.denied)
+        let useCase = HydrationReminderUseCaseImpl(repository: repository)
+
+        let status = try await useCase.requestAuthorizationAndSyncReminders()
+
+        #expect(status == .denied)
+        #expect(repository.scheduleDailyRemindersCallCount == 0)
+        #expect(repository.cancelDailyRemindersCallCount == 1)
+    }
+
+    @Test("권한 요청 실패는 그대로 전파한다")
+    func requestAuthorizationPropagatesError() async {
+        struct RequestError: Error {}
+        let repository = MockHydrationReminderRepository()
+        repository.requestAuthorizationResult = .failure(RequestError())
+        let useCase = HydrationReminderUseCaseImpl(repository: repository)
+
+        await #expect(throws: RequestError.self) {
+            try await useCase.requestAuthorizationAndSyncReminders()
+        }
+        #expect(repository.scheduleDailyRemindersCallCount == 0)
+    }
+
+    @Test("권한 허용 후 스케줄 실패는 에러를 전파한다")
+    func requestAuthorizationPropagatesScheduleError() async {
+        struct ScheduleError: Error {}
+        let repository = MockHydrationReminderRepository()
+        repository.requestAuthorizationResult = .success(.authorized)
+        repository.scheduleDailyRemindersError = ScheduleError()
+        let useCase = HydrationReminderUseCaseImpl(repository: repository)
+
+        await #expect(throws: ScheduleError.self) {
+            try await useCase.requestAuthorizationAndSyncReminders()
+        }
+    }
+
+    @Test("syncReminders는 스케줄 실패를 삼키고 조용히 종료한다")
+    func syncRemindersSwallowsScheduleError() async {
+        struct ScheduleError: Error {}
+        let repository = MockHydrationReminderRepository()
+        repository.authorizationStatusValue = .authorized
+        repository.scheduleDailyRemindersError = ScheduleError()
+        let useCase = HydrationReminderUseCaseImpl(repository: repository)
+
+        await useCase.syncReminders()
+
+        #expect(repository.scheduleDailyRemindersCallCount == 0)
+        #expect(repository.cancelDailyRemindersCallCount == 0)
+    }
+
+    @Test("syncReminders는 허용 상태에서 다시 스케줄한다")
+    func syncRemindersSchedulesWhenAuthorized() async {
+        let repository = MockHydrationReminderRepository()
+        repository.authorizationStatusValue = .authorized
+        let useCase = HydrationReminderUseCaseImpl(repository: repository)
+
+        await useCase.syncReminders()
+
+        #expect(repository.scheduleDailyRemindersCallCount == 1)
+        #expect(repository.capturedSlots == HydrationReminderSlot.allCases)
+    }
+
+    @Test("syncReminders는 미허용 상태에서 리마인더를 취소한다")
+    func syncRemindersCancelsWhenNotAuthorized() async {
+        let repository = MockHydrationReminderRepository()
+        repository.authorizationStatusValue = .denied
+        let useCase = HydrationReminderUseCaseImpl(repository: repository)
+
+        await useCase.syncReminders()
+
+        #expect(repository.scheduleDailyRemindersCallCount == 0)
+        #expect(repository.cancelDailyRemindersCallCount == 1)
+    }
+
+    @Test("프라이밍 노출 여부를 Repository에 위임한다")
+    func primingFlagDelegatesToRepository() {
+        let repository = MockHydrationReminderRepository()
+        let useCase = HydrationReminderUseCaseImpl(repository: repository)
+
+        #expect(useCase.hasSeenPermissionPriming() == false)
+
+        useCase.markPermissionPrimingSeen()
+
+        #expect(repository.hasSeenPermissionPrimingValue)
+        #expect(useCase.hasSeenPermissionPriming())
+    }
+}

--- a/Project/Domain/Tests/Mock/MockHydrationReminderRepository.swift
+++ b/Project/Domain/Tests/Mock/MockHydrationReminderRepository.swift
@@ -1,0 +1,47 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockHydrationReminderRepository: HydrationReminderRepository, @unchecked Sendable {
+    var authorizationStatusValue: HydrationReminderAuthorizationStatus = .notDetermined
+    var requestAuthorizationResult: Result<HydrationReminderAuthorizationStatus, Error> = .success(.authorized)
+    var scheduleDailyRemindersError: Error?
+    var scheduleDailyRemindersCallCount = 0
+    var cancelDailyRemindersCallCount = 0
+    var capturedSlots: [HydrationReminderSlot] = []
+    var hasSeenPermissionPrimingValue = false
+
+    func authorizationStatus() async -> HydrationReminderAuthorizationStatus {
+        authorizationStatusValue
+    }
+
+    func requestAuthorization() async throws -> HydrationReminderAuthorizationStatus {
+        switch requestAuthorizationResult {
+        case .success(let status):
+            authorizationStatusValue = status
+            return status
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func scheduleDailyReminders(for slots: [HydrationReminderSlot]) async throws {
+        if let scheduleDailyRemindersError {
+            throw scheduleDailyRemindersError
+        }
+
+        scheduleDailyRemindersCallCount += 1
+        capturedSlots = slots
+    }
+
+    func cancelDailyReminders() async {
+        cancelDailyRemindersCallCount += 1
+    }
+
+    func hasSeenPermissionPriming() -> Bool {
+        hasSeenPermissionPrimingValue
+    }
+
+    func setHasSeenPermissionPriming(_ seen: Bool) {
+        hasSeenPermissionPrimingValue = seen
+    }
+}

--- a/Project/Presentation/Sources/View/Authentication/HydrationReminderPermissionGateView.swift
+++ b/Project/Presentation/Sources/View/Authentication/HydrationReminderPermissionGateView.swift
@@ -1,0 +1,199 @@
+//
+//  HydrationReminderPermissionGateView.swift
+//  PresentationLayer
+//
+//  Created by Claude on 7/25/26.
+//
+
+import DomainLayerInterface
+import Localization
+import SwiftUI
+
+public struct HydrationReminderPermissionGateView<Content: View>: View {
+    @Bindable private var viewModel: HydrationReminderPermissionViewModel
+    private let content: () -> Content
+
+    public init(
+        viewModel: HydrationReminderPermissionViewModel,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.viewModel = viewModel
+        self.content = content
+    }
+
+    public var body: some View {
+        Group {
+            if viewModel.isFinished {
+                content()
+            } else if viewModel.isPrepared {
+                primingView
+            } else {
+                // 권한이 이미 결정된 사용자(재설치 등)에게 프라이밍이 잠깐
+                // 노출되지 않도록 시스템 상태 확인 전에는 빈 화면을 유지한다.
+                Color.clear
+            }
+        }
+        .task {
+            await viewModel.prepareIfNeeded()
+        }
+    }
+
+    private var primingView: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                Spacer(minLength: 24)
+
+                headerSection
+                benefitCard
+
+                if let errorMessage = viewModel.errorMessage, !errorMessage.isEmpty {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color.red.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .padding(.horizontal, 24)
+                }
+
+                VStack(spacing: 12) {
+                    Button {
+                        Task {
+                            await viewModel.requestPermission()
+                        }
+                    } label: {
+                        allowButtonLabel
+                    }
+                    .disabled(viewModel.isLoading)
+                    .accessibilityLabel(L10n.tr("hydrationReminderPrimingAllowTitle"))
+                    .accessibilityHint(L10n.tr("hydrationReminderPrimingAllowAccessibilityHint"))
+
+                    Button {
+                        viewModel.skipPriming()
+                    } label: {
+                        Text(L10n.tr("hydrationReminderPrimingSkipTitle"))
+                            .font(.headline)
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                            .frame(minHeight: 52)
+                            .foregroundColor(.primary)
+                            .background(Color.secondary.opacity(0.12))
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    }
+                    .disabled(viewModel.isLoading)
+                    .accessibilityHint(L10n.tr("hydrationReminderPrimingSkipAccessibilityHint"))
+                }
+                .padding(.horizontal, 24)
+
+                Text(L10n.tr("hydrationReminderPrimingFootnote"))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+
+                Spacer(minLength: 24)
+            }
+            .padding(.vertical, 24)
+        }
+    }
+
+    private var headerSection: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "bell.badge.fill")
+                .font(.system(size: 72))
+                .foregroundStyle(.teal)
+                .accessibilityHidden(true)
+
+            Text(L10n.tr("hydrationReminderPrimingTitle"))
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .multilineTextAlignment(.center)
+
+            Text(L10n.tr("hydrationReminderPrimingDescription"))
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+        }
+    }
+
+    private var benefitCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(L10n.tr("hydrationReminderPrimingBenefitSectionTitle"))
+                .font(.headline)
+
+            benefitRow(
+                title: L10n.tr("hydrationReminderPrimingScheduleTitle"),
+                description: L10n.tr("hydrationReminderPrimingScheduleDescription"),
+                systemImage: "bell.fill",
+                tint: .teal
+            )
+
+            benefitRow(
+                title: L10n.tr("hydrationReminderPrimingHabitTitle"),
+                description: L10n.tr("hydrationReminderPrimingHabitDescription"),
+                systemImage: "flame.fill",
+                tint: .orange
+            )
+
+            benefitRow(
+                title: L10n.tr("hydrationReminderPrimingControlTitle"),
+                description: L10n.tr("hydrationReminderPrimingControlDescription"),
+                systemImage: "slider.horizontal.3",
+                tint: .blue
+            )
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.secondary.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .padding(.horizontal, 24)
+    }
+
+    private var allowButtonLabel: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .tint(.white)
+            } else {
+                Text(L10n.tr("hydrationReminderPrimingAllowTitle"))
+                    .font(.headline)
+                    .fontWeight(.semibold)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(minHeight: 52)
+        .foregroundColor(.white)
+        .background(Color.black)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func benefitRow(
+        title: String,
+        description: String,
+        systemImage: String,
+        tint: Color
+    ) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: systemImage)
+                .font(.headline)
+                .foregroundStyle(tint)
+                .frame(width: 24)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(.primary)
+
+                Text(description)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/Project/Presentation/Sources/View/Authentication/OnboardingView.swift
+++ b/Project/Presentation/Sources/View/Authentication/OnboardingView.swift
@@ -168,7 +168,7 @@ public struct OnboardingView: View {
     private var footer: some View {
         VStack(spacing: 14) {
             if viewModel.isLastPage {
-                Text(L10n.tr("onboardingHealthKitPermissionFootnote"))
+                Text(L10n.tr("onboardingPermissionFlowFootnote"))
                     .font(.footnote)
                     .foregroundStyle(.white.opacity(0.62))
                     .multilineTextAlignment(.center)
@@ -225,7 +225,7 @@ public struct OnboardingView: View {
         } label: {
             Text(
                 viewModel.isLastPage ?
-                L10n.tr("onboardingHealthKitContinueTitle") :
+                L10n.tr("onboardingPermissionContinueTitle") :
                 L10n.tr("onboardingNextTitle")
             )
                 .font(.headline.weight(.semibold))

--- a/Project/Presentation/Sources/View/RootView.swift
+++ b/Project/Presentation/Sources/View/RootView.swift
@@ -12,6 +12,7 @@ public struct RootView<Content: View>: View {
     @State private var appSession: AppSession
     @State private var authenticationViewModel: AuthenticationViewModel
     @State private var onboardingViewModel: OnboardingViewModel
+    @State private var hydrationReminderPermissionViewModel: HydrationReminderPermissionViewModel
     @State private var healthKitPermissionViewModel: HealthKitPermissionViewModel
     private let content: () -> Content
 
@@ -19,12 +20,16 @@ public struct RootView<Content: View>: View {
         appSession: @autoclosure @escaping () -> AppSession,
         authenticationViewModel: @autoclosure @escaping () -> AuthenticationViewModel,
         onboardingViewModel: @autoclosure @escaping () -> OnboardingViewModel,
+        hydrationReminderPermissionViewModel: @autoclosure @escaping () -> HydrationReminderPermissionViewModel,
         healthKitPermissionViewModel: @autoclosure @escaping () -> HealthKitPermissionViewModel,
         @ViewBuilder content: @escaping () -> Content
     ) {
         self._appSession = State(wrappedValue: appSession())
         self._authenticationViewModel = State(wrappedValue: authenticationViewModel())
         self._onboardingViewModel = State(wrappedValue: onboardingViewModel())
+        self._hydrationReminderPermissionViewModel = State(
+            wrappedValue: hydrationReminderPermissionViewModel()
+        )
         self._healthKitPermissionViewModel = State(wrappedValue: healthKitPermissionViewModel())
         self.content = content
     }
@@ -33,8 +38,10 @@ public struct RootView<Content: View>: View {
         Group {
             if appSession.isAuthenticated {
                 if onboardingViewModel.hasCompletedOnboarding {
-                    HealthKitPermissionGateView(viewModel: healthKitPermissionViewModel) {
-                        content()
+                    HydrationReminderPermissionGateView(viewModel: hydrationReminderPermissionViewModel) {
+                        HealthKitPermissionGateView(viewModel: healthKitPermissionViewModel) {
+                            content()
+                        }
                     }
                 } else {
                     OnboardingView(viewModel: onboardingViewModel)
@@ -43,6 +50,7 @@ public struct RootView<Content: View>: View {
                 SignInView(viewModel: authenticationViewModel)
                     .onAppear {
                         onboardingViewModel.prepareForSignedOutState()
+                        hydrationReminderPermissionViewModel.markSignedOut()
                         healthKitPermissionViewModel.markSignedOut()
                     }
             }

--- a/Project/Presentation/Sources/ViewModel/HydrationReminderPermissionViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HydrationReminderPermissionViewModel.swift
@@ -1,0 +1,127 @@
+//
+//  HydrationReminderPermissionViewModel.swift
+//  PresentationLayer
+//
+//  Created by Claude on 7/25/26.
+//
+
+import DomainLayerInterface
+import Foundation
+import Localization
+import Observation
+
+@Observable
+@MainActor
+public final class HydrationReminderPermissionViewModel {
+    private enum Constant {
+        static let analyticsSource = "hydration_reminder_priming"
+    }
+
+    public private(set) var authorizationStatus: HydrationReminderAuthorizationStatus = .notDetermined
+    public private(set) var isFinished: Bool
+    public private(set) var isPrepared = false
+    public var isLoading = false
+    public var errorMessage: String?
+
+    private let hydrationReminderUseCase: HydrationReminderUseCase
+    private let analyticsUseCase: AnalyticsUseCase
+    private var didTrackPrimingViewed = false
+    private var didSyncReminders = false
+
+    public init(
+        hydrationReminderUseCase: HydrationReminderUseCase,
+        analyticsUseCase: AnalyticsUseCase = NoOpAnalyticsUseCase()
+    ) {
+        self.hydrationReminderUseCase = hydrationReminderUseCase
+        self.analyticsUseCase = analyticsUseCase
+        self.isFinished = hydrationReminderUseCase.hasSeenPermissionPriming()
+    }
+
+    public func prepareIfNeeded() async {
+        authorizationStatus = await hydrationReminderUseCase.authorizationStatus()
+
+        if isFinished || authorizationStatus != .notDetermined {
+            finishPriming()
+            isPrepared = true
+            await syncRemindersIfNeeded()
+            return
+        }
+
+        isPrepared = true
+
+        if !didTrackPrimingViewed {
+            analyticsUseCase.track(.hydrationReminderPrimingViewed(status: authorizationStatus))
+            didTrackPrimingViewed = true
+        }
+    }
+
+    public func requestPermission() async {
+        isLoading = true
+        errorMessage = nil
+        analyticsUseCase.track(.hydrationReminderPermissionRequestTapped(status: authorizationStatus))
+
+        do {
+            authorizationStatus = try await hydrationReminderUseCase.requestAuthorizationAndSyncReminders()
+        } catch {
+            errorMessage = L10n.tr("hydrationReminderPrimingRequestFailureDescription")
+            isLoading = false
+            return
+        }
+
+        trackPermissionOutcome()
+        didSyncReminders = true
+        finishPriming()
+        isLoading = false
+    }
+
+    public func skipPriming() {
+        analyticsUseCase.track(.hydrationReminderPrimingSkipped(status: authorizationStatus))
+        finishPriming()
+    }
+
+    public func markSignedOut() {
+        errorMessage = nil
+        isLoading = false
+        isPrepared = false
+        isFinished = hydrationReminderUseCase.hasSeenPermissionPriming()
+    }
+
+    private func finishPriming() {
+        if !hydrationReminderUseCase.hasSeenPermissionPriming() {
+            hydrationReminderUseCase.markPermissionPrimingSeen()
+        }
+
+        errorMessage = nil
+        isFinished = true
+    }
+
+    private func syncRemindersIfNeeded() async {
+        guard !didSyncReminders else {
+            return
+        }
+
+        didSyncReminders = true
+        await hydrationReminderUseCase.syncReminders()
+    }
+
+    private func trackPermissionOutcome() {
+        switch authorizationStatus {
+        case .authorized:
+            analyticsUseCase.track(
+                .hydrationReminderPermissionAuthorized(
+                    source: Constant.analyticsSource,
+                    status: authorizationStatus
+                )
+            )
+        case .denied:
+            analyticsUseCase.track(
+                .hydrationReminderPermissionDenied(
+                    source: Constant.analyticsSource,
+                    status: authorizationStatus
+                )
+            )
+        case .notDetermined:
+            return
+        }
+    }
+}

--- a/Project/Presentation/Tests/HydrationReminderPermissionViewModelTests.swift
+++ b/Project/Presentation/Tests/HydrationReminderPermissionViewModelTests.swift
@@ -1,0 +1,189 @@
+import DomainLayerInterface
+import Foundation
+import Localization
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("HydrationReminderPermissionViewModel Tests")
+struct HydrationReminderPermissionViewModelTests {
+    private enum MockError: Error {
+        case failed
+    }
+
+    @MainActor
+    @Test("프라이밍을 본 적 없으면 초기 상태는 미완료·미준비다")
+    func initialStateShowsPriming() {
+        let useCase = MockHydrationReminderUseCase()
+
+        let viewModel = HydrationReminderPermissionViewModel(hydrationReminderUseCase: useCase)
+
+        #expect(viewModel.isFinished == false)
+        #expect(viewModel.isPrepared == false)
+    }
+
+    @MainActor
+    @Test("프라이밍을 이미 봤으면 초기 상태부터 완료다")
+    func initialStateSkipsPrimingWhenAlreadySeen() {
+        let useCase = MockHydrationReminderUseCase()
+        useCase.hasSeenPermissionPrimingValue = true
+
+        let viewModel = HydrationReminderPermissionViewModel(hydrationReminderUseCase: useCase)
+
+        #expect(viewModel.isFinished)
+    }
+
+    @MainActor
+    @Test("prepareIfNeeded는 notDetermined 상태에서 자동으로 권한을 요청하지 않는다")
+    func prepareIfNeededDoesNotRequestAuthorizationAutomatically() async {
+        let useCase = MockHydrationReminderUseCase()
+        let analyticsUseCase = MockAnalyticsUseCase()
+
+        let viewModel = HydrationReminderPermissionViewModel(
+            hydrationReminderUseCase: useCase,
+            analyticsUseCase: analyticsUseCase
+        )
+
+        await viewModel.prepareIfNeeded()
+
+        #expect(useCase.requestAuthorizationCallCount == 0)
+        #expect(viewModel.isFinished == false)
+        #expect(viewModel.isPrepared)
+        #expect(analyticsUseCase.trackedEvents.map(\.name) == ["hydration_reminder_priming_viewed"])
+    }
+
+    @MainActor
+    @Test("prepareIfNeeded는 이미 결정된 권한 상태면 프라이밍을 건너뛰고 동기화한다")
+    func prepareIfNeededFinishesWhenStatusAlreadyDetermined() async {
+        let useCase = MockHydrationReminderUseCase()
+        useCase.authorizationStatusValue = .authorized
+
+        let viewModel = HydrationReminderPermissionViewModel(hydrationReminderUseCase: useCase)
+
+        await viewModel.prepareIfNeeded()
+
+        #expect(viewModel.isFinished)
+        #expect(viewModel.isPrepared)
+        #expect(useCase.markPermissionPrimingSeenCallCount == 1)
+        #expect(useCase.syncRemindersCallCount == 1)
+        #expect(useCase.requestAuthorizationCallCount == 0)
+    }
+
+    @MainActor
+    @Test("prepareIfNeeded는 프라이밍을 본 사용자의 리마인더를 한 번만 동기화한다")
+    func prepareIfNeededSyncsOnceForReturningUser() async {
+        let useCase = MockHydrationReminderUseCase()
+        useCase.hasSeenPermissionPrimingValue = true
+        useCase.authorizationStatusValue = .authorized
+
+        let viewModel = HydrationReminderPermissionViewModel(hydrationReminderUseCase: useCase)
+
+        await viewModel.prepareIfNeeded()
+        await viewModel.prepareIfNeeded()
+
+        #expect(useCase.syncRemindersCallCount == 1)
+    }
+
+    @MainActor
+    @Test("requestPermission 허용 시 완료 처리하고 허용 이벤트를 남긴다")
+    func requestPermissionAuthorized() async {
+        let useCase = MockHydrationReminderUseCase()
+        useCase.requestAuthorizationResult = .success(.authorized)
+        let analyticsUseCase = MockAnalyticsUseCase()
+
+        let viewModel = HydrationReminderPermissionViewModel(
+            hydrationReminderUseCase: useCase,
+            analyticsUseCase: analyticsUseCase
+        )
+
+        await viewModel.requestPermission()
+
+        #expect(useCase.requestAuthorizationCallCount == 1)
+        #expect(viewModel.authorizationStatus == .authorized)
+        #expect(viewModel.isFinished)
+        #expect(viewModel.errorMessage == nil)
+        #expect(useCase.markPermissionPrimingSeenCallCount == 1)
+        #expect(analyticsUseCase.trackedEvents.map(\.name) == [
+            "hydration_reminder_request_tapped",
+            "hydration_reminder_permission_authorized"
+        ])
+    }
+
+    @MainActor
+    @Test("requestPermission 거부 시에도 완료 처리하고 거부 이벤트를 남긴다")
+    func requestPermissionDenied() async {
+        let useCase = MockHydrationReminderUseCase()
+        useCase.requestAuthorizationResult = .success(.denied)
+        let analyticsUseCase = MockAnalyticsUseCase()
+
+        let viewModel = HydrationReminderPermissionViewModel(
+            hydrationReminderUseCase: useCase,
+            analyticsUseCase: analyticsUseCase
+        )
+
+        await viewModel.requestPermission()
+
+        #expect(viewModel.authorizationStatus == .denied)
+        #expect(viewModel.isFinished)
+        #expect(analyticsUseCase.trackedEvents.map(\.name) == [
+            "hydration_reminder_request_tapped",
+            "hydration_reminder_permission_denied"
+        ])
+    }
+
+    @MainActor
+    @Test("requestPermission 실패 시 에러 메시지를 남기고 프라이밍에 머문다")
+    func requestPermissionFailure() async {
+        let useCase = MockHydrationReminderUseCase()
+        useCase.requestAuthorizationResult = .failure(MockError.failed)
+
+        let viewModel = HydrationReminderPermissionViewModel(hydrationReminderUseCase: useCase)
+
+        await viewModel.requestPermission()
+
+        #expect(viewModel.isFinished == false)
+        #expect(viewModel.errorMessage == L10n.tr("hydrationReminderPrimingRequestFailureDescription"))
+        #expect(useCase.markPermissionPrimingSeenCallCount == 0)
+    }
+
+    @MainActor
+    @Test("skipPriming은 프라이밍 노출 완료를 저장하고 스킵 이벤트를 남긴다")
+    func skipPriming() {
+        let useCase = MockHydrationReminderUseCase()
+        let analyticsUseCase = MockAnalyticsUseCase()
+
+        let viewModel = HydrationReminderPermissionViewModel(
+            hydrationReminderUseCase: useCase,
+            analyticsUseCase: analyticsUseCase
+        )
+
+        viewModel.skipPriming()
+
+        #expect(viewModel.isFinished)
+        #expect(useCase.markPermissionPrimingSeenCallCount == 1)
+        #expect(useCase.requestAuthorizationCallCount == 0)
+        #expect(analyticsUseCase.trackedEvents.map(\.name) == ["hydration_reminder_priming_skipped"])
+    }
+
+    @MainActor
+    @Test("markSignedOut는 에러를 초기화하고 저장된 프라이밍 상태를 유지한다")
+    func markSignedOutKeepsPersistedPrimingState() async {
+        let useCase = MockHydrationReminderUseCase()
+        useCase.requestAuthorizationResult = .failure(MockError.failed)
+
+        let viewModel = HydrationReminderPermissionViewModel(hydrationReminderUseCase: useCase)
+
+        await viewModel.prepareIfNeeded()
+        await viewModel.requestPermission()
+        viewModel.markSignedOut()
+
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.isFinished == false)
+        #expect(viewModel.isPrepared == false)
+
+        useCase.hasSeenPermissionPrimingValue = true
+        viewModel.markSignedOut()
+
+        #expect(viewModel.isFinished)
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockHydrationReminderUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockHydrationReminderUseCase.swift
@@ -1,0 +1,40 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockHydrationReminderUseCase: HydrationReminderUseCase, @unchecked Sendable {
+    var authorizationStatusValue: HydrationReminderAuthorizationStatus = .notDetermined
+    var requestAuthorizationResult: Result<HydrationReminderAuthorizationStatus, Error> = .success(.authorized)
+    var hasSeenPermissionPrimingValue = false
+    private(set) var requestAuthorizationCallCount = 0
+    private(set) var syncRemindersCallCount = 0
+    private(set) var markPermissionPrimingSeenCallCount = 0
+
+    func authorizationStatus() async -> HydrationReminderAuthorizationStatus {
+        authorizationStatusValue
+    }
+
+    func requestAuthorizationAndSyncReminders() async throws -> HydrationReminderAuthorizationStatus {
+        requestAuthorizationCallCount += 1
+
+        switch requestAuthorizationResult {
+        case .success(let status):
+            authorizationStatusValue = status
+            return status
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func syncReminders() async {
+        syncRemindersCallCount += 1
+    }
+
+    func hasSeenPermissionPriming() -> Bool {
+        hasSeenPermissionPrimingValue
+    }
+
+    func markPermissionPrimingSeen() {
+        markPermissionPrimingSeenCallCount += 1
+        hasSeenPermissionPrimingValue = true
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockHydrationReminderUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockHydrationReminderUseCase.swift
@@ -1,0 +1,40 @@
+import DomainLayerInterface
+import Foundation
+
+public final class MockHydrationReminderUseCase: HydrationReminderUseCase, @unchecked Sendable {
+    public var authorizationStatusValue: HydrationReminderAuthorizationStatus
+    public var requestAuthorizationResult: Result<HydrationReminderAuthorizationStatus, Error> = .success(.authorized)
+    public var hasSeenPriming: Bool
+
+    public init(
+        authorizationStatus: HydrationReminderAuthorizationStatus = .notDetermined,
+        hasSeenPriming: Bool = false
+    ) {
+        self.authorizationStatusValue = authorizationStatus
+        self.hasSeenPriming = hasSeenPriming
+    }
+
+    public func authorizationStatus() async -> HydrationReminderAuthorizationStatus {
+        authorizationStatusValue
+    }
+
+    public func requestAuthorizationAndSyncReminders() async throws -> HydrationReminderAuthorizationStatus {
+        switch requestAuthorizationResult {
+        case .success(let status):
+            authorizationStatusValue = status
+            return status
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    public func syncReminders() async {}
+
+    public func hasSeenPermissionPriming() -> Bool {
+        hasSeenPriming
+    }
+
+    public func markPermissionPrimingSeen() {
+        hasSeenPriming = true
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -65,6 +65,10 @@ public final class PreviewAssembly: Assembly {
             MockRoutineUseCase()
         }
 
+        container.register(HydrationReminderUseCase.self) { _ in
+            MockHydrationReminderUseCase()
+        }
+
         container.register((any WidgetTimelineReloading).self) { _ in
             NoOpWidgetTimelineReloader()
         }
@@ -152,6 +156,17 @@ public final class PreviewAssembly: Assembly {
                 OnboardingViewModel(userPreferencesUseCase: userPreferencesUseCase)
             }
         }
+
+        container.register(HydrationReminderPermissionViewModel.self) { resolver in
+            let hydrationReminderUseCase = resolver.resolve(HydrationReminderUseCase.self)!
+
+            return MainActor.assumeIsolated {
+                HydrationReminderPermissionViewModel(
+                    hydrationReminderUseCase: hydrationReminderUseCase
+                )
+            }
+        }
+        .inObjectScope(.container)
 
         container.register(HealthKitPermissionViewModel.self) { resolver in
             let healthKitUseCase = resolver.resolve(HealthKitUseCase.self)!

--- a/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
@@ -79,6 +79,22 @@ public final class DataAssembly: Assembly {
             )
         }
 
+        // MARK: - HydrationReminder
+        container.register(HydrationReminderNotificationDataSource.self) { _ in
+            HydrationReminderNotificationDataSourceImpl()
+        }
+
+        container.register(HydrationReminderStorageDataSource.self) { _ in
+            HydrationReminderStorageDataSourceImpl(userDefaults: .appGroup)
+        }
+
+        container.register(HydrationReminderRepository.self) { resolver in
+            HydrationReminderRepositoryImpl(
+                notificationDataSource: resolver.resolve(HydrationReminderNotificationDataSource.self)!,
+                storageDataSource: resolver.resolve(HydrationReminderStorageDataSource.self)!
+            )
+        }
+
         // MARK: - Challenge
         container.register(ChallengeStorageDataSource.self) { _ in
             ChallengeStorageDataSourceImpl(userDefaults: .appGroup)

--- a/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
@@ -99,6 +99,13 @@ public final class DomainAssembly: Assembly {
             )
         }
 
+        // MARK: - HydrationReminder
+        container.register(HydrationReminderUseCase.self) { resolver in
+            HydrationReminderUseCaseImpl(
+                repository: resolver.resolve(HydrationReminderRepository.self)!
+            )
+        }
+
         // MARK: - Authentication
         container.register(SignInUseCase.self) { resolver in
             SignInUseCaseImpl(

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -136,6 +136,19 @@ public final class PresentationAssembly: Assembly {
             }
         }
 
+        container.register(HydrationReminderPermissionViewModel.self) { resolver in
+            let hydrationReminderUseCase = resolver.resolve(HydrationReminderUseCase.self)!
+            let analyticsUseCase = resolver.resolve(AnalyticsUseCase.self)!
+
+            return MainActor.assumeIsolated {
+                HydrationReminderPermissionViewModel(
+                    hydrationReminderUseCase: hydrationReminderUseCase,
+                    analyticsUseCase: analyticsUseCase
+                )
+            }
+        }
+        .inObjectScope(.container)
+
         container.register(HealthKitPermissionViewModel.self) { resolver in
             let healthKitUseCase = resolver.resolve(HealthKitUseCase.self)!
             let analyticsUseCase = resolver.resolve(AnalyticsUseCase.self)!

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockHydrationReminderUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockHydrationReminderUseCaseForTesting.swift
@@ -1,0 +1,28 @@
+import DomainLayerInterface
+import Foundation
+
+public final class MockHydrationReminderUseCaseForTesting: HydrationReminderUseCase, @unchecked Sendable {
+    public var authorizationStatusValue: HydrationReminderAuthorizationStatus = .notDetermined
+    public var hasSeenPriming = false
+
+    public init() {}
+
+    public func authorizationStatus() async -> HydrationReminderAuthorizationStatus {
+        authorizationStatusValue
+    }
+
+    public func requestAuthorizationAndSyncReminders() async throws -> HydrationReminderAuthorizationStatus {
+        authorizationStatusValue = .authorized
+        return authorizationStatusValue
+    }
+
+    public func syncReminders() async {}
+
+    public func hasSeenPermissionPriming() -> Bool {
+        hasSeenPriming
+    }
+
+    public func markPermissionPrimingSeen() {
+        hasSeenPriming = true
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Testing/TestingAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/TestingAssembly.swift
@@ -46,5 +46,9 @@ public final class TestingAssembly: Assembly {
         container.register(RoutineUseCase.self) { _ in
             MockRoutineUseCaseForTesting()
         }
+
+        container.register(HydrationReminderUseCase.self) { _ in
+            MockHydrationReminderUseCaseForTesting()
+        }
     }
 }

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -4302,28 +4302,6 @@
         }
       }
     },
-    "onboardingHealthKitContinueTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "건강 앱 권한 확인하기"
-          }
-        }
-      }
-    },
-    "onboardingHealthKitPermissionFootnote" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다음 단계에서 건강 앱에 저장할 수분 기록과 목표 추천에 쓸 신체 정보를 안내해요."
-          }
-        }
-      }
-    },
     "onboardingPageProgressAccessibilityLabelFormat" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -6355,6 +6333,325 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "탈퇴 처리 중..."
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "물 마실 시간을 알려드릴게요"
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림을 켜면 하루 세 번, 수분 기록을 잊지 않게 뮬리미가 챙겨드려요."
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingBenefitSectionTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이런 알림을 보내드려요"
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingScheduleTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하루 세 번 리마인드"
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingScheduleDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아침 9시, 오후 2시, 저녁 8시에 맞춰 알려드려요."
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingHabitTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "물 마시는 습관 만들기"
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingHabitDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제때 기록할수록 목표 달성이 쉬워져요."
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingControlTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "언제든 바꿀 수 있어요"
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingControlDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS 설정에서 알림을 자유롭게 켜고 끌 수 있어요."
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingAllowTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림 허용하기"
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingSkipTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "나중에 할게요"
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingFootnote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림은 수분 기록 리마인드에만 사용해요."
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingRequestFailureDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림 권한 요청에 실패했어요. 잠시 후 다시 시도해주세요."
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingAllowAccessibilityHint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템 알림 권한 요청 창을 엽니다."
+          }
+        }
+      }
+    },
+    "hydrationReminderPrimingSkipAccessibilityHint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림 없이 다음 단계로 이동합니다."
+          }
+        }
+      }
+    },
+    "hydrationReminderMorningTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "좋은 아침이에요 ☀️"
+          }
+        }
+      }
+    },
+    "hydrationReminderMorningBodyVariant1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "물 한 잔으로 하루를 시작해볼까요? 첫 잔을 기록해보세요."
+          }
+        }
+      }
+    },
+    "hydrationReminderMorningBodyVariant2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자는 동안 목말랐던 몸이 물을 기다리고 있어요. 💧"
+          }
+        }
+      }
+    },
+    "hydrationReminderMorningBodyVariant3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아침 물 한 잔이 오늘의 컨디션을 바꿔요. 지금 기록해보세요."
+          }
+        }
+      }
+    },
+    "hydrationReminderAfternoonTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잠깐, 수분 충전 시간!"
+          }
+        }
+      }
+    },
+    "hydrationReminderAfternoonBodyVariant1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오후엔 수분이 훅 떨어져요. 물 한 잔 마시고 기록해볼까요?"
+          }
+        }
+      }
+    },
+    "hydrationReminderAfternoonBodyVariant2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "집중이 안 될 땐 물 한 잔이 답이에요. 잊기 전에 기록!"
+          }
+        }
+      }
+    },
+    "hydrationReminderAfternoonBodyVariant3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커피 말고 물도 한 잔! 뮬리미가 기다리고 있어요."
+          }
+        }
+      }
+    },
+    "hydrationReminderEveningTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 목표, 다 채웠나요?"
+          }
+        }
+      }
+    },
+    "hydrationReminderEveningBodyVariant1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 마신 물, 다 기록했나요? 자기 전에 확인해보세요."
+          }
+        }
+      }
+    },
+    "hydrationReminderEveningBodyVariant2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저녁 물 한 잔이면 오늘 목표에 한 걸음 더 가까워져요."
+          }
+        }
+      }
+    },
+    "hydrationReminderEveningBodyVariant3" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하루를 마무리하며 물 한 잔 어때요? 기록도 잊지 마세요!"
+          }
+        }
+      }
+    },
+    "onboardingPermissionContinueTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "권한 설정하고 시작하기"
+          }
+        }
+      }
+    },
+    "onboardingPermissionFlowFootnote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음 단계에서 수분 리마인드 알림과 건강 앱 연동 권한을 차례로 안내해요."
           }
         }
       }

--- a/Project/Shared/Utils/Sources/String+Extensions.swift
+++ b/Project/Shared/Utils/Sources/String+Extensions.swift
@@ -28,6 +28,7 @@ public extension String {
     static let manualBodyHeightCM: String = "manualBodyHeightCM"
     static let manualBodyWeightKG: String = "manualBodyWeightKG"
     static let hydrationRoutines: String = "hydrationRoutines"
+    static let hasSeenHydrationReminderPriming: String = "hasSeenHydrationReminderPriming"
     static let hydrationChallengeStates: String = "hydrationChallengeStates"
     static let hydrationChallengeBadgeHistories: String = "hydrationChallengeBadgeHistories"
 }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 ```text
 SignIn
   -> Onboarding
+  -> HydrationReminderPermissionGate
   -> HealthKitPermissionGate
   -> ContentView
 ```


### PR DESCRIPTION
## 📝 Summary
온보딩 완료 직후 알림 권한을 요청하기 전에 이유를 설명하는 프라이밍 화면을 추가하고, 권한 허용 시 하루 3번(9시/14시/20시) 수분 입력을 유도하는 듀오링고식 로컬 알림을 스케줄합니다. 기존 루틴(AlarmKit) 알림 스택은 변경하지 않고 `UNUserNotificationCenter` 기반 별도 스택으로 구현했습니다.

새 진입 흐름: `SignIn -> Onboarding -> HydrationReminderPermissionGate -> HealthKitPermissionGate -> ContentView`

## 🎯 Type of Change
- [x] ✨ New feature (새로운 기능 추가)
- [x] 🎨 UI/UX (디자인 변경)
- [x] 🧪 Test (테스트 추가/수정)
- [x] 📝 Documentation (문서 수정)

## 🔗 Related Issues
- Closes #271
- Related to #257, #272

## 📋 Changes Made
### Added
- Domain: `HydrationReminderSlot`(아침 9시/오후 14시/저녁 20시 정책 SSOT), `HydrationReminderAuthorizationStatus`, `HydrationReminderUseCase`/`Repository` 인터페이스와 `HydrationReminderUseCaseImpl`
- Data: `HydrationReminderNotificationDataSource`(UNUserNotificationCenter 래퍼, 슬롯 3개 × 요일 7개 = 21개 반복 알림), `HydrationReminderStorageDataSource`(프라이밍 노출 플래그), `HydrationReminderRepositoryImpl`
- Presentation: `HydrationReminderPermissionGateView`(1회 노출, 스킵 가능, 앱 진입을 막지 않음) + `HydrationReminderPermissionViewModel`
- 알림 문구: 슬롯별 제목 + 요일 로테이션 본문 3종 (토→일 주 경계 포함 이틀 연속 같은 문구 반복 없음)
- 분석 이벤트 5종: `hydration_reminder_priming_viewed`, `hydration_reminder_request_tapped`, `hydration_reminder_permission_authorized/denied`, `hydration_reminder_priming_skipped`
- 테스트: Domain 9건, Data 6건, Presentation 10건 + 목 4종
- 제품 스펙: `Docs/product-specs/hydration-reminder-priming.md`

### Changed
- `RootView`: 온보딩 완료 분기에 리마인더 프라이밍 게이트 삽입, 로그아웃 시 `markSignedOut()` 리셋 추가
- `OnboardingView` 마지막 페이지 CTA/각주: HealthKit 전용 카피 → 권한 안내 흐름 중립 카피 (`onboardingPermissionContinueTitle`, `onboardingPermissionFlowFootnote`)
- DI 어셈블리 4곳(Production Data/Domain/Presentation, Preview, Testing)에 신규 체인 등록
- `AGENTS.md`/`README.md`/`ARCHITECTURE.md` 진입 흐름 및 `analytics-events.md`, `sign-in-onboarding-healthkit.md` 갱신

### Removed
- 미사용 로컬라이제이션 키 2개(`onboardingHealthKitContinueTitle`, `onboardingHealthKitPermissionFootnote`)

## 🔍 Technical Details
- **루틴과의 분리**: 루틴 알림은 AlarmKit, 이 기능은 UNUserNotificationCenter로 시스템 권한 자체가 다릅니다. 식별자는 `hydrationReminder.<slot>.<weekday>` 프리픽스로 네임스페이스하고 취소도 이 프리픽스만 대상입니다(`removeAllPendingNotificationRequests()` 미사용).
- **안전한 재스케줄**: 같은 식별자 `add()`는 기존 요청을 교체하므로 선-취소 없이 추가 후 잔여분만 정리합니다. 중간 실패가 기존 스케줄을 지우지 않습니다.
- **프라이밍 플래시 방지**: 시스템 권한 상태 확인 전에는 빈 화면을 유지해, 재설치 등으로 권한이 이미 결정된 사용자에게 프라이밍이 잠깐 노출되지 않게 했습니다.
- **정책 결정**: 로그아웃 후에도 스케줄된 리마인더는 유지합니다(재방문 유도, 스펙에 명시). 회원 탈퇴 시 정리와 포그라운드 배너/딥링크는 #272에서 다룹니다.
- 멀티에이전트 적대적 리뷰(4개 관점 리뷰 + 발견 건별 검증)로 확인된 6건(모두 minor)을 반영 또는 스펙 명시/후속 이슈로 처리했습니다.

## 📸 Screenshots / Videos
- 첨부 없음 (시뮬레이터 스크린샷 미채취, 신규 화면은 HealthKit 권한 게이트와 동일한 레이아웃 패턴)

## ✅ Testing
### 실행한 로컬 검증
- [x] `git diff --check`
- [x] `make lint` — 0 violations
- [x] `make arch-check` — passed
- [x] `tuist generate`
- [x] `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer ...` — 106 tests passed
- [x] `xcodebuild test -workspace Mulimi.xcworkspace -scheme DataLayer ...` — 17 tests passed
- [x] `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer ...` — 117 tests passed
- [x] `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi ...` — BUILD SUCCEEDED

### 실행하지 않은 검증과 이유
- Watch 타깃 테스트: Watch 변경 없음
- 실기기 알림 발화 확인: 로컬 시뮬레이터 검증 범위 밖, 반복 트리거는 UNCalendarNotificationTrigger 표준 동작

### 자동화 결과
- GitHub Actions: PR 생성 후 lint workflow 확인 예정
- Xcode Cloud: 해당 없음

### 검증 환경
- Xcode: 26.6 (17F113)
- iOS / Simulator / Device: iPhone 17 Pro Simulator
- Tuist: 4.88.0

### 기존 경고와 새 경고
- Existing: appintentsmetadataprocessor 메타데이터 경고(기존)
- New: 없음

## 🚨 Breaking Changes
- [x] No

## 📌 Additional Notes
- 이미 온보딩을 마친 기존 사용자도 업데이트 후 첫 실행 시 프라이밍을 1회 보게 됩니다(의도된 동작).
- 알림 권한이 이미 결정된 상태(재설치 등)에서는 프라이밍 없이 통과하며, 허용 상태면 실행 시 스케줄을 재동기화합니다.

## 📝 Documentation
- `Docs/product-specs/hydration-reminder-priming.md` (신규)
- `Docs/product-specs/sign-in-onboarding-healthkit.md`, `analytics-events.md`, `index.md`
- `AGENTS.md`, `README.md`, `ARCHITECTURE.md` 진입 흐름

🤖 Generated with [Claude Code](https://claude.com/claude-code)