### PR TITLE
Firebase Crashlytics 제거 및 PostHog 오류 추적 통합

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ XCConfig/Secrets.xcconfig
 .env
 .env.example
 .posthog-wizard-cache/
+
+### Local agent configuration ###
+.claude/

--- a/Docs/security-privacy.md
+++ b/Docs/security-privacy.md
@@ -4,7 +4,7 @@ Mulimi의 보안/개인정보 운영 기준이다. 이 문서는 법률 검토 �
 
 ## Goals
 
-- HealthKit, Apple Sign In, Firebase, PostHog, App Group, iCloud KVS의 데이터 경계를 한 곳에서 확인한다.
+- HealthKit, Apple Sign In, Firebase Analytics, PostHog, App Group, iCloud KVS의 데이터 경계를 한 곳에서 확인한다.
 - 이벤트 파라미터와 로컬 저장소에 넣으면 안 되는 데이터를 명확히 한다.
 - AdMob, IAP, 서버 연동을 추가하기 전에 개인정보 영향 검토를 먼저 수행한다.
 
@@ -29,7 +29,7 @@ Mulimi의 보안/개인정보 운영 기준이다. 이 문서는 법률 검토 �
 | Apple account credential | Apple user identifier, optional email/name | Keychain | 로그인 상태 판단용이다. identity token, authorization code는 현재 저장하지 않는다. |
 | Firebase Analytics | allowlist 이벤트와 파라미터 | Firebase/Google Analytics | 제품 행동 측정만 허용한다. 개인정보, 건강 원본 값, 자유 입력 텍스트는 금지한다. |
 | PostHog Analytics | allowlist 이벤트와 Apple user identifier 기반 distinct ID | PostHog US Cloud | Firebase와 같은 이벤트 계약만 전송한다. 이메일/이름은 person property로 보내지 않는다. |
-| Crashlytics | SDK dependency only | Firebase Crashlytics | 커스텀 key/log를 추가할 때 HealthKit 값, 계정 식별자, 이메일, 루틴 제목을 넣지 않는다. |
+| PostHog Error Tracking | native error, stack trace, 진단 속성 | PostHog US Cloud | 오류·로그 속성에 개인정보, 건강 원본 값, 자유 입력 텍스트를 넣지 않는다. |
 
 ## HealthKit
 
@@ -71,9 +71,9 @@ HealthKit 변경 전 체크:
 - Apple Sign In token revocation이 필요한 서버 구조인지
 - 삭제 요청 후 보관해야 하는 결제/영수증/분쟁 대응 데이터가 있는지
 
-## Firebase, PostHog Analytics And Crashlytics
+## Firebase Analytics And PostHog
 
-Analytics 이벤트 계약은 `Docs/product-specs/analytics-events.md`가 기준이다. Firebase/PostHog SDK 직접 의존은 앱 초기화와 repository 구현으로 제한한다. PostHog `identify`는 안정적인 Apple user identifier만 사용하고 이메일과 이름은 전송하지 않는다. 로그아웃과 회원 탈퇴 성공 시 `reset`한다.
+Analytics 이벤트 계약은 `Docs/product-specs/analytics-events.md`가 기준이다. Firebase/PostHog SDK 직접 의존은 앱 초기화와 repository 구현으로 제한한다. PostHog `identify`는 안정적인 Apple user identifier만 사용하고 이메일과 이름은 전송하지 않는다. 로그아웃과 회원 탈퇴 성공 시 `reset`한다. 오류 수집은 PostHog Error Tracking만 사용하고 Release dSYM 업로드용 개인 API 키는 Xcode Cloud secret에만 저장한다.
 
 허용:
 
@@ -88,7 +88,7 @@ Analytics 이벤트 계약은 `Docs/product-specs/analytics-events.md`가 기준
 - 루틴 제목, 자유 입력 텍스트, 알림 본문, 사용자 메모
 - 정확한 위치, 연락처, 사진, 캘린더, 파일 경로
 - 기기 식별자, 광고 식별자, fingerprinting 목적 값
-- Crashlytics custom key/log에 개인정보나 건강 데이터를 넣는 것
+- PostHog 오류 이벤트나 로그 속성에 개인정보, 건강 데이터, 자유 입력 텍스트를 넣는 것
 
 이벤트 추가 전 체크:
 
@@ -160,7 +160,7 @@ StoreKit, 구독, 결제 서버, 영수증 검증을 추가하기 전에 아래�
 - 개인정보 처리방침 또는 앱 내 고지 문구 변경이 필요한가?
 - Analytics 이벤트 파라미터가 allowlist 기준을 따르는가?
 - App Group/iCloud KVS에 민감 데이터가 추가되지 않았는가?
-- 로그, OSLog, Crashlytics custom key에 개인정보/건강 데이터가 들어가지 않는가?
+- 로그, OSLog, PostHog 오류·로그 속성에 개인정보/건강 데이터가 들어가지 않는가?
 - 회원 탈퇴/로그아웃/동의 철회 시 데이터 삭제 또는 수집 중단 범위가 명확한가?
 - 법률 검토가 필요한 항목을 PR과 이슈에 남겼는가?
 

--- a/Project/App/Project.swift
+++ b/Project/App/Project.swift
@@ -86,7 +86,6 @@ let project = Project(
                     path: .relativeToRoot("Project/Shared/Utils")
                 ),
                 .external(name: "FirebaseAnalytics"),
-                .external(name: "FirebaseCrashlytics"),
                 .external(name: "PostHog")
             ],
             settings: .settings(

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 <p align="center">
   <img src="https://img.shields.io/badge/WidgetKit-Home_%26_Lock_Screen-0F766E?style=for-the-badge" alt="WidgetKit">
   <img src="https://img.shields.io/badge/Watch_App-MulimiWatch-374151?style=for-the-badge" alt="Watch App">
-  <img src="https://img.shields.io/badge/Firebase-Analytics_%26_Crashlytics-FF6F00?style=for-the-badge&logo=firebase&logoColor=white" alt="Firebase">
+  <img src="https://img.shields.io/badge/Firebase-Analytics-FF6F00?style=for-the-badge&logo=firebase&logoColor=white" alt="Firebase Analytics">
+  <img src="https://img.shields.io/badge/PostHog-Analytics_%26_Error_Tracking-F54E00?style=for-the-badge&logo=posthog&logoColor=white" alt="PostHog">
 </p>
 
 ## 물리미 (Mulimi)
@@ -37,7 +38,7 @@
 - `Swift 6.0`, `SwiftUI`, `Swift Concurrency`
 - `Tuist` 기반 모듈형 프로젝트
 - `HealthKit`, `WidgetKit`, `AppIntents`
-- `Firebase Analytics`, `Firebase Crashlytics`
+- `Firebase Analytics`, `PostHog Analytics`, `PostHog Error Tracking`
 - `Swinject` 기반 의존성 주입
 
 ## 🏗️ 아키텍처


### PR DESCRIPTION
## 📝 Summary

- PostHog Error Tracking 검증 이후 오류 수집 주체를 하나로 통합할 수 있도록 Firebase Crashlytics 앱 타깃 의존성을 제거합니다.
- Firebase Analytics와 PostHog Analytics dual-write는 그대로 유지합니다.
- 로컬 PostHog Wizard/Claude 설정인 `.claude/`가 저장소에 포함되지 않도록 ignore합니다.

## 🎯 Type of Change

- [ ] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [x] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [x] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [x] 🛡️ Security (보안 강화)
- [ ] 🧪 Test (테스트 추가/수정)
- [x] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues

- Closes #277
- Depends on #276 (merged)

## 📋 Changes Made

### Added

- `.claude/` 로컬 에이전트 설정 ignore 규칙

### Changed

- README 기술 스택을 Firebase Analytics와 PostHog Analytics/Error Tracking 기준으로 갱신
- 보안·개인정보 문서를 PostHog 단일 오류 수집 정책으로 갱신

### Fixed

- Crashlytics와 PostHog가 진단 데이터를 중복 수집할 수 있는 앱 타깃 구성 제거

### Removed

- Mulimi 앱 타깃의 `FirebaseCrashlytics` 의존성

## 🔍 Technical Details

- `firebase-ios-sdk` 패키지는 `FirebaseAnalytics`가 계속 사용하므로 유지합니다.
- 생성된 Mulimi 프로젝트에서 `FirebaseCrashlytics` 링크가 사라지고 Firebase Analytics 및 PostHog 링크는 유지되는 것을 확인했습니다.
- 생성 프로젝트에 남는 `PHPLCrashReporter`는 PostHog native error 수집 구현이므로 제거 대상이 아닙니다.

## 📸 Screenshots / Videos

- UI 변경 없음

## ✅ Testing

### 실행한 로컬 검증

- [x] `git diff --check`
- [x] `make lint`
- [x] `make arch-check`
- [x] `tuist generate`
- [ ] `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer ...`
- [ ] `xcodebuild test -workspace Mulimi.xcworkspace -scheme DataLayer ...`
- [ ] `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer ...`
- [ ] `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi ...`

### 실행하지 않은 검증과 이유

- Swift 동작·Domain/Data/Presentation 로직 변경이 없어 unit test는 생략했습니다.
- 앱 빌드는 작성자가 실행 예정이라 생략했습니다.
- PostHog native error 수신과 Release dSYM symbolication은 Xcode Cloud secret과 비프로덕션 Release 환경이 필요한 수동 검증으로, Ready for review 전 확인이 필요합니다.

### 자동화 결과

- GitHub Actions: PR 생성 후 확인
- Xcode Cloud: PR 생성 후 확인

### 검증 환경

- Xcode: 사용하지 않음
- iOS / Simulator / Device: 사용하지 않음
- Tuist: 버전 미기록 (`tuist generate` 성공)

### 기존 경고와 새 경고

- Existing: 없음
- New: 없음

## 🚨 Breaking Changes

- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes

- PostHog 오류 수신과 symbolication이 확인되기 전에는 이 PR을 병합하지 않습니다.
- 오류·로그 속성에 Apple 사용자 식별자, 이메일, 이름, HealthKit 원본 값, 루틴 제목 등 개인정보·건강 데이터를 추가하지 않습니다.
- App Store privacy label의 진단 데이터 수집 주체와 목적을 Release 전 다시 확인해야 합니다.

## 📝 Documentation

- `README.md`
- `Docs/security-privacy.md`

## 👀 Review Checklist

- [x] 코드가 프로젝트의 코딩 컨벤션을 따르고 있나요?
- [x] 새로운 의존성이 필요한가요? (아니오, 기존 의존성 제거)
- [x] 문서 업데이트가 필요한 변경이면 관련 문서를 갱신했나요?
- [x] 데이터베이스 마이그레이션이 필요한가요? (해당 없음)
- [x] 환경 설정 변경이 필요한가요? (추가 변경 없음)

---

<!--
🤖 PR 템플릿 v1.0
💡 Tip: 불필요한 섹션은 삭제하고 사용하세요!
-->
