### PR TITLE
HealthKit 권한 복구 안내와 설정 복귀 추적 개선

### DIFF
--- a/Project/Presentation/Sources/View/Authentication/HealthKitPermissionGateView.swift
+++ b/Project/Presentation/Sources/View/Authentication/HealthKitPermissionGateView.swift
@@ -40,7 +40,7 @@ public struct HealthKitPermissionGateView<Content: View>: View {
                 return
             }
 
-            viewModel.refreshStatus()
+            viewModel.refreshStatusAfterAppActivation()
         }
     }
 

--- a/Project/Presentation/Sources/ViewModel/HealthKitPermissionViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/HealthKitPermissionViewModel.swift
@@ -103,6 +103,16 @@ public final class HealthKitPermissionViewModel {
         trackPermissionOutcomeIfNeeded(source: "healthkit_permission_gate")
     }
 
+    func refreshStatusAfterAppActivation() {
+        refreshStatus()
+
+        guard isAuthorized else {
+            return
+        }
+
+        trackPermissionOutcomeIfNeeded(source: "healthkit_permission_gate")
+    }
+
     public func markSignedOut() {
         errorMessage = nil
         refreshStatus()

--- a/Project/Presentation/Tests/HealthKitPermissionViewModelTests.swift
+++ b/Project/Presentation/Tests/HealthKitPermissionViewModelTests.swift
@@ -101,6 +101,56 @@ struct HealthKitPermissionViewModelTests {
     }
 
     @MainActor
+    @Test("설정 이동과 다시 확인은 복구 이벤트와 권한 상태를 갱신한다")
+    func settingsRecoveryTracksEventsAndRefreshesStatus() {
+        let healthKitUseCase = MockHealthKitUseCase()
+        healthKitUseCase.authorizationStatusValue = .sharingDenied
+        let analyticsUseCase = MockAnalyticsUseCase()
+        let viewModel = HealthKitPermissionViewModel(
+            healthKitUseCase: healthKitUseCase,
+            analyticsUseCase: analyticsUseCase
+        )
+
+        viewModel.trackSettingsTapped()
+        healthKitUseCase.authorizationStatusValue = .sharingAuthorized
+        viewModel.refreshStatusFromSettings()
+
+        #expect(viewModel.authorizationStatus == .sharingAuthorized)
+        #expect(viewModel.isAuthorized == true)
+        #expect(analyticsUseCase.trackedEvents.map(\.name) == [
+            "healthkit_permission_settings_tapped",
+            "healthkit_permission_refresh_tapped",
+            "healthkit_permission_authorized"
+        ])
+    }
+
+    @MainActor
+    @Test("설정 복귀 시 탭 이벤트 없이 복구된 권한 결과만 기록한다")
+    func appActivationTracksRecoveredAuthorization() {
+        let healthKitUseCase = MockHealthKitUseCase()
+        healthKitUseCase.authorizationStatusValue = .sharingDenied
+        let analyticsUseCase = MockAnalyticsUseCase()
+        let viewModel = HealthKitPermissionViewModel(
+            healthKitUseCase: healthKitUseCase,
+            analyticsUseCase: analyticsUseCase
+        )
+
+        viewModel.refreshStatusAfterAppActivation()
+
+        #expect(viewModel.authorizationStatus == .sharingDenied)
+        #expect(analyticsUseCase.trackedEvents.isEmpty)
+
+        healthKitUseCase.authorizationStatusValue = .sharingAuthorized
+        viewModel.refreshStatusAfterAppActivation()
+
+        #expect(viewModel.authorizationStatus == .sharingAuthorized)
+        #expect(viewModel.isAuthorized == true)
+        #expect(analyticsUseCase.trackedEvents.map(\.name) == [
+            "healthkit_permission_authorized"
+        ])
+    }
+
+    @MainActor
     @Test("markSignedOut는 에러 메시지를 초기화한다")
     func markSignedOutClearsErrorMessage() async {
         let healthKitUseCase = MockHealthKitUseCase()

--- a/Project/Shared/Localization/Resources/Localizable.xcstrings
+++ b/Project/Shared/Localization/Resources/Localizable.xcstrings
@@ -4209,7 +4209,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "설정 > 건강 > 데이터 접근 및 기기 > 물리미에서 권한을 다시 켤 수 있어요."
+            "value" : "열린 설정에서 물리미의 건강 접근 권한을 켜 주세요."
           }
         }
       }
@@ -4220,7 +4220,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "건강 권한 다시 켜기"
+            "value" : "1. 설정에서 건강 권한 켜기"
           }
         }
       }
@@ -4231,7 +4231,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "설정 변경 후 물리미로 돌아오면 자동으로 확인하고, 필요하면 다시 확인하기를 누를 수 있어요."
+            "value" : "권한을 켠 뒤 물리미로 돌아오면 자동으로 확인해요. 화면이 그대로면 다시 확인하기를 눌러 주세요."
           }
         }
       }
@@ -4242,7 +4242,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "돌아온 뒤 상태 확인"
+            "value" : "2. 물리미로 돌아와 다시 확인"
           }
         }
       }
@@ -4253,7 +4253,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "권한을 다시 켜는 방법"
+            "value" : "권한을 다시 켜는 순서"
           }
         }
       }


### PR DESCRIPTION
## 📝 Summary

HealthKit 권한을 거부한 사용자가 설정 이동과 복귀 후 재확인 순서를 바로 이해할 수 있도록 복구 안내를 2단계 행동 카피로 정리합니다.

설정 앱에서 복귀할 때 권한이 실제로 복구되면 `healthkit_permission_authorized`를 기록하되, 사용자가 누르지 않은 `healthkit_permission_refresh_tapped` 이벤트는 발생시키지 않습니다.

## 🎯 Type of Change

- [ ] ✨ New feature (새로운 기능 추가)
- [x] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [ ] 📝 Documentation (문서 수정)
- [x] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues

- Closes #260

## 📋 Changes Made

### Added

- 앱 활성화 시 복구된 HealthKit authorization 결과를 추적하는 ViewModel 경로
- 설정 이동/수동 재확인/자동 설정 복귀 이벤트 흐름 테스트 2건

### Changed

- 권한 복구 카피를 설정 이동과 앱 복귀의 1·2단계 순서로 정리
- OS 버전에 따라 달라질 수 있는 구체적인 설정 경로를 행동 중심 문구로 교체
- 설정 복귀 시 권한 상태와 authorization 이벤트를 함께 갱신

### Fixed

- 설정에서 권한을 복구하고 앱으로 돌아왔을 때 `healthkit_permission_authorized`가 누락될 수 있던 흐름

### Removed

- 없음

## 🔍 Technical Details

기존 `HealthKitPermissionGateView`의 recovery card와 primary/secondary CTA를 그대로 재사용했습니다. scene phase가 active로 바뀌면 ViewModel이 권한 상태를 갱신하고, authorized 상태일 때만 기존 authorization 이벤트를 중복 방지 플래그와 함께 기록합니다.

자동 복귀 갱신은 사용자 탭이 아니므로 `healthkit_permission_refresh_tapped`를 발생시키지 않습니다. 수동 `다시 확인하기`는 기존 `refreshStatusFromSettings()` 흐름을 유지합니다.

## 📸 Screenshots / Videos

### Before

- 첨부 없음: 기존 recovery card의 카피 변경

### After

- 첨부 없음: `sharingDenied` 상태에서 1·2단계 안내로 확인 가능

## ✅ Testing

### 실행한 로컬 검증

- [x] `git diff --check`
- [x] `make lint` — 276 files, 0 violations
- [x] `make arch-check` — passed
- [ ] `tuist generate`
- [ ] `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer ...`
- [ ] `xcodebuild test -workspace Mulimi.xcworkspace -scheme DataLayer ...`
- [x] `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -sdk iphonesimulator -derivedDataPath /tmp/MulimiIssue260Tests` — 120 tests / 12 suites passed
- [x] `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -derivedDataPath /tmp/MulimiIssue260Build` — BUILD SUCCEEDED
- [x] 관련 집중 검증: `HealthKitPermissionViewModelTests` — 8 tests passed

### 실행하지 않은 검증과 이유

- `tuist generate`: 새 파일, 타깃, 의존성 변경 없음
- DomainLayer / DataLayer 테스트: Presentation, Localization 리소스만 변경

### 자동화 결과

- GitHub Actions: PR 생성 후 확인 예정
- Xcode Cloud: 해당 없음 (릴리스 브랜치 아님)

### 검증 환경

- Xcode: 26.6 (17F113)
- iOS / Simulator / Device: iPhone 17 Pro, iOS 26.5 Simulator
- Tuist: 4.88.0

### 기존 경고와 새 경고

- Existing: 앱 빌드 중 AppIntents SSU artifact archive 비차단 로그가 있었으나 `BUILD SUCCEEDED`
- New: 없음

## 🚨 Breaking Changes

- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes

- HealthKit 권한 우회, 설정 앱 내부 화면 deep link, 새 분석 이벤트 또는 A/B 테스트 인프라는 추가하지 않았습니다.
- 기존 `HealthKitPermissionGate -> ContentView` 루트 흐름을 유지합니다.

## 📝 Documentation

- 문서 변경 없음: 기존 `Docs/product-specs/onboarding-healthkit-conversion-experiments.md`의 Experiment B와 현재 구현 범위가 일치합니다.

## 👀 Review Checklist

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다.
- [x] 새로운 의존성이 없습니다.
- [x] 기존 제품 스펙과 정렬되어 추가 문서 변경이 필요하지 않습니다.
- [x] 데이터베이스 마이그레이션이 필요하지 않습니다.
- [x] 환경 설정 변경이 필요하지 않습니다.
