### PR TITLE
회원 탈퇴·포그라운드·알림 탭 수분 리마인더 후속 동작 추가

### DIFF
--- a/Docs/product-specs/hydration-reminder-priming.md
+++ b/Docs/product-specs/hydration-reminder-priming.md
@@ -24,6 +24,9 @@ Onboarding 완료
 - 사용자가 iOS 설정에서 권한을 회수하면 다음 실행 시 남은 리마인더를 정리한다.
 - 프라이밍 노출 전에 시스템 권한 상태를 먼저 확인한다. 확인이 끝나기 전에는 빈 화면을 유지해, 이미 권한이 결정된 사용자에게 프라이밍이 잠깐이라도 보이지 않게 한다.
 - 로그아웃해도 이미 스케줄된 리마인더는 유지한다. 재방문을 유도하는 의도된 동작이며, 알림을 탭하면 로그인 화면으로 진입한다.
+- 회원 탈퇴가 성공하면 `hydrationReminder.*`로 스케줄된 리마인더를 정리한다.
+- 앱이 포그라운드일 때도 수분 리마인더 배너와 소리를 표시한다.
+- 수분 리마인더를 탭하면 `mulimi://hydration/record`를 `AppCoordinator`에 전달해 메인 기록 화면으로 이동한다.
 
 ## Reminder Schedule
 
@@ -59,9 +62,7 @@ Onboarding 완료
 
 ## Known Limitations
 
-- `UNUserNotificationCenterDelegate`가 없어 앱이 포그라운드일 때는 배너가 보이지 않는다. 포그라운드 표시와 알림 탭 딥링크는 후속 이슈로 다룬다(AppCoordinator 딥링크 이슈 #257과 연계).
 - 리마인더 시간과 문구는 아직 사용자 설정을 제공하지 않는다.
-- 회원 탈퇴 시 리마인더 자동 정리는 아직 없다. 후속 이슈로 다룬다.
 
 ## Related Code
 
@@ -73,6 +74,8 @@ Onboarding 완료
 - `Project/Presentation/Sources/ViewModel/HydrationReminderPermissionViewModel.swift`
 - `Project/Presentation/Sources/View/Authentication/HydrationReminderPermissionGateView.swift`
 - `Project/Presentation/Sources/View/RootView.swift`
+- `Project/Presentation/Sources/Navigation/AppCoordinator.swift`
+- `Project/App/Sources/AppDelegate.swift`
 
 ## Related Docs
 

--- a/Project/App/Sources/AppDelegate.swift
+++ b/Project/App/Sources/AppDelegate.swift
@@ -1,0 +1,43 @@
+import DependencyInjection
+import PresentationLayer
+import UIKit
+import UserNotifications
+
+final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate, @unchecked Sendable {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        guard isHydrationReminder(notification) else {
+            return []
+        }
+
+        return [.banner, .sound]
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        guard isHydrationReminder(response.notification),
+              let url = URL(string: "mulimi://hydration/record") else {
+            return
+        }
+
+        await MainActor.run {
+            DIContainer.shared.resolve(AppCoordinator.self).handleDeepLink(url)
+        }
+    }
+
+    nonisolated private func isHydrationReminder(_ notification: UNNotification) -> Bool {
+        notification.request.identifier.hasPrefix("hydrationReminder.")
+    }
+}

--- a/Project/App/Sources/ContentView.swift
+++ b/Project/App/Sources/ContentView.swift
@@ -140,6 +140,8 @@ struct ContentView: View {
     @ViewBuilder
     private func destinationView(for route: AppRoute) -> some View {
         switch route {
+        case .hydrationLogging:
+            DrinkWaterView(viewModel: drinkWaterViewModel)
         case .profileRoutine:
             ProfileRoutineView(viewModel: routineViewModel)
         case let .profileRoutineAction(action):

--- a/Project/App/Sources/DrinkWaterApp.swift
+++ b/Project/App/Sources/DrinkWaterApp.swift
@@ -14,6 +14,8 @@ import SwiftUI
 
 @main
 struct DrinkWaterApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
     init() {
         FirebaseApp.configure()
         DIContainer.shared.registerAnalyticsRepository(Self.makeAnalyticsRepository())

--- a/Project/Domain/Interfaces/UseCase/HydrationReminderUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/HydrationReminderUseCase.swift
@@ -4,6 +4,7 @@ public protocol HydrationReminderUseCase: Sendable {
     func authorizationStatus() async -> HydrationReminderAuthorizationStatus
     func requestAuthorizationAndSyncReminders() async throws -> HydrationReminderAuthorizationStatus
     func syncReminders() async
+    func cancelReminders() async
     func hasSeenPermissionPriming() -> Bool
     func markPermissionPrimingSeen()
 }

--- a/Project/Domain/Sources/UseCase/HydrationReminderUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/HydrationReminderUseCaseImpl.swift
@@ -35,6 +35,10 @@ public struct HydrationReminderUseCaseImpl: HydrationReminderUseCase {
         try? await repository.scheduleDailyReminders(for: HydrationReminderSlot.allCases)
     }
 
+    public func cancelReminders() async {
+        await repository.cancelDailyReminders()
+    }
+
     public func hasSeenPermissionPriming() -> Bool {
         repository.hasSeenPermissionPriming()
     }

--- a/Project/Domain/Tests/HydrationReminderUseCaseTests.swift
+++ b/Project/Domain/Tests/HydrationReminderUseCaseTests.swift
@@ -108,6 +108,16 @@ struct HydrationReminderUseCaseTests {
         #expect(repository.cancelDailyRemindersCallCount == 1)
     }
 
+    @Test("cancelReminders는 Repository에 취소를 위임한다")
+    func cancelReminders() async {
+        let repository = MockHydrationReminderRepository()
+        let useCase = HydrationReminderUseCaseImpl(repository: repository)
+
+        await useCase.cancelReminders()
+
+        #expect(repository.cancelDailyRemindersCallCount == 1)
+    }
+
     @Test("프라이밍 노출 여부를 Repository에 위임한다")
     func primingFlagDelegatesToRepository() {
         let repository = MockHydrationReminderRepository()

--- a/Project/Presentation/Sources/Navigation/AppCoordinator.swift
+++ b/Project/Presentation/Sources/Navigation/AppCoordinator.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 
 @Observable
-public final class AppCoordinator: StackRouting {
+public final class AppCoordinator: DeepLinkHandling, StackRouting {
     public var path = NavigationPath()
 
     public init() {}
@@ -12,6 +12,12 @@ public final class AppCoordinator: StackRouting {
     }
 
     public func handleDeepLink(_ url: URL) {
-        // TODO: Map deep links to app routes.
+        guard url.scheme == "mulimi",
+              url.host == "hydration",
+              url.path == "/record" else {
+            return
+        }
+
+        push(.hydrationLogging)
     }
 }

--- a/Project/Presentation/Sources/Navigation/AppRoute.swift
+++ b/Project/Presentation/Sources/Navigation/AppRoute.swift
@@ -2,12 +2,15 @@ import DomainLayerInterface
 import Foundation
 
 public enum AppRoute: NavigationRoute, Sendable {
+    case hydrationLogging
     case profileRoutine
     case profileRoutineAction(RoutineActionIntent)
     case setting(SettingMenu)
 
     public var id: String {
         switch self {
+        case .hydrationLogging:
+            return "hydration_logging"
         case .profileRoutine:
             return "profile_routine"
         case let .profileRoutineAction(action):

--- a/Project/Presentation/Sources/ViewModel/SettingsViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/SettingsViewModel.swift
@@ -13,6 +13,7 @@ import DomainLayerInterface
 public final class SettingsViewModel {
     private let userPreferencesUseCase: UserPreferencesUseCase
     private let signInUseCase: SignInUseCase
+    private let hydrationReminderUseCase: HydrationReminderUseCase
     private let appSession: AppSession
     private let widgetTimelineReloader: any WidgetTimelineReloading
     private let analyticsUseCase: AnalyticsUseCase
@@ -29,6 +30,7 @@ public final class SettingsViewModel {
     public init(
         userPreferencesUseCase: UserPreferencesUseCase,
         signInUseCase: SignInUseCase,
+        hydrationReminderUseCase: HydrationReminderUseCase,
         appSession: AppSession,
         widgetTimelineReloader: any WidgetTimelineReloading,
         appInfoProvider: any AppInfoProviding,
@@ -36,6 +38,7 @@ public final class SettingsViewModel {
     ) {
         self.userPreferencesUseCase = userPreferencesUseCase
         self.signInUseCase = signInUseCase
+        self.hydrationReminderUseCase = hydrationReminderUseCase
         self.appSession = appSession
         self.widgetTimelineReloader = widgetTimelineReloader
         self.analyticsUseCase = analyticsUseCase
@@ -109,6 +112,7 @@ public final class SettingsViewModel {
 
         do {
             try await signInUseCase.deleteAccount()
+            await hydrationReminderUseCase.cancelReminders()
             analyticsUseCase.reset()
             showWithdrawalConfirmation = false
 

--- a/Project/Presentation/Tests/AppCoordinatorTests.swift
+++ b/Project/Presentation/Tests/AppCoordinatorTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+
+@testable import PresentationLayer
+
+@Suite("AppCoordinator Tests")
+struct AppCoordinatorTests {
+    @Test("수분 기록 딥링크를 기록 화면으로 연결한다")
+    func hydrationLoggingDeepLink() throws {
+        let coordinator = AppCoordinator()
+        let url = try #require(URL(string: "mulimi://hydration/record"))
+
+        coordinator.handleDeepLink(url)
+
+        #expect(coordinator.path.count == 1)
+    }
+
+    @Test("지원하지 않는 딥링크는 무시한다")
+    func unsupportedDeepLink() throws {
+        let coordinator = AppCoordinator()
+        let url = try #require(URL(string: "mulimi://hydration/unknown"))
+
+        coordinator.handleDeepLink(url)
+
+        #expect(coordinator.path.isEmpty)
+    }
+}

--- a/Project/Presentation/Tests/Mock/MockHydrationReminderUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockHydrationReminderUseCase.swift
@@ -7,6 +7,7 @@ final class MockHydrationReminderUseCase: HydrationReminderUseCase, @unchecked S
     var hasSeenPermissionPrimingValue = false
     private(set) var requestAuthorizationCallCount = 0
     private(set) var syncRemindersCallCount = 0
+    private(set) var cancelRemindersCallCount = 0
     private(set) var markPermissionPrimingSeenCallCount = 0
 
     func authorizationStatus() async -> HydrationReminderAuthorizationStatus {
@@ -27,6 +28,10 @@ final class MockHydrationReminderUseCase: HydrationReminderUseCase, @unchecked S
 
     func syncReminders() async {
         syncRemindersCallCount += 1
+    }
+
+    func cancelReminders() async {
+        cancelRemindersCallCount += 1
     }
 
     func hasSeenPermissionPriming() -> Bool {

--- a/Project/Presentation/Tests/SettingsViewModelTests.swift
+++ b/Project/Presentation/Tests/SettingsViewModelTests.swift
@@ -37,6 +37,7 @@ struct SettingsViewModelTests {
         let viewModel = SettingsViewModel(
             userPreferencesUseCase: userPreferencesUseCase,
             signInUseCase: signInUseCase,
+            hydrationReminderUseCase: MockHydrationReminderUseCase(),
             appSession: appSession,
             widgetTimelineReloader: NoOpWidgetTimelineReloader(),
             appInfoProvider: StaticAppInfoProvider(appVersion: "1.2.0", appBuildNumber: "15")
@@ -61,6 +62,7 @@ struct SettingsViewModelTests {
         let viewModel = SettingsViewModel(
             userPreferencesUseCase: userPreferencesUseCase,
             signInUseCase: MockSignInUseCase(),
+            hydrationReminderUseCase: MockHydrationReminderUseCase(),
             appSession: AppSession(),
             widgetTimelineReloader: SpyWidgetTimelineReloader {
                 counter.count += 1
@@ -87,6 +89,7 @@ struct SettingsViewModelTests {
         let viewModel = SettingsViewModel(
             userPreferencesUseCase: userPreferencesUseCase,
             signInUseCase: MockSignInUseCase(),
+            hydrationReminderUseCase: MockHydrationReminderUseCase(),
             appSession: AppSession(),
             widgetTimelineReloader: SpyWidgetTimelineReloader {
                 counter.count += 1
@@ -108,6 +111,7 @@ struct SettingsViewModelTests {
         let viewModel = SettingsViewModel(
             userPreferencesUseCase: MockUserPreferencesUseCase(),
             signInUseCase: MockSignInUseCase(),
+            hydrationReminderUseCase: MockHydrationReminderUseCase(),
             appSession: AppSession(),
             widgetTimelineReloader: NoOpWidgetTimelineReloader(),
             appInfoProvider: StaticAppInfoProvider(appVersion: "1.2.0", appBuildNumber: "15")
@@ -128,10 +132,12 @@ struct SettingsViewModelTests {
         let signInUseCase = MockSignInUseCase()
         signInUseCase.isAuthenticatedValue = true
         let analyticsUseCase = MockAnalyticsUseCase()
+        let hydrationReminderUseCase = MockHydrationReminderUseCase()
         let appSession = AppSession(isAuthenticated: true)
         let viewModel = SettingsViewModel(
             userPreferencesUseCase: MockUserPreferencesUseCase(),
             signInUseCase: signInUseCase,
+            hydrationReminderUseCase: hydrationReminderUseCase,
             appSession: appSession,
             widgetTimelineReloader: NoOpWidgetTimelineReloader(),
             appInfoProvider: StaticAppInfoProvider(appVersion: "1.2.0", appBuildNumber: "15"),
@@ -142,6 +148,7 @@ struct SettingsViewModelTests {
         await viewModel.confirmWithdrawal()
 
         #expect(signInUseCase.deleteAccountCallCount == 1)
+        #expect(hydrationReminderUseCase.cancelRemindersCallCount == 1)
         #expect(analyticsUseCase.resetCallCount == 1)
         #expect(viewModel.isWithdrawing == false)
         #expect(viewModel.showWithdrawalConfirmation == false)
@@ -154,10 +161,12 @@ struct SettingsViewModelTests {
     func confirmWithdrawalFailure() async {
         let signInUseCase = MockSignInUseCase()
         signInUseCase.deleteAccountError = MockError.deleteFailed
+        let hydrationReminderUseCase = MockHydrationReminderUseCase()
         let appSession = AppSession(isAuthenticated: true)
         let viewModel = SettingsViewModel(
             userPreferencesUseCase: MockUserPreferencesUseCase(),
             signInUseCase: signInUseCase,
+            hydrationReminderUseCase: hydrationReminderUseCase,
             appSession: appSession,
             widgetTimelineReloader: NoOpWidgetTimelineReloader(),
             appInfoProvider: StaticAppInfoProvider(appVersion: "1.2.0", appBuildNumber: "15")
@@ -167,6 +176,7 @@ struct SettingsViewModelTests {
         await viewModel.confirmWithdrawal()
 
         #expect(signInUseCase.deleteAccountCallCount == 1)
+        #expect(hydrationReminderUseCase.cancelRemindersCallCount == 0)
         #expect(viewModel.isWithdrawing == false)
         #expect(viewModel.showWithdrawalConfirmation == true)
         #expect(viewModel.withdrawalError == MockError.deleteFailed.localizedDescription)

--- a/Project/Shared/DependencyInjection/Sources/Preview/MockHydrationReminderUseCase.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/MockHydrationReminderUseCase.swift
@@ -30,6 +30,8 @@ public final class MockHydrationReminderUseCase: HydrationReminderUseCase, @unch
 
     public func syncReminders() async {}
 
+    public func cancelReminders() async {}
+
     public func hasSeenPermissionPriming() -> Bool {
         hasSeenPriming
     }

--- a/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Preview/PreviewAssembly.swift
@@ -201,6 +201,7 @@ public final class PreviewAssembly: Assembly {
             SettingsViewModel(
                 userPreferencesUseCase: resolver.resolve(UserPreferencesUseCase.self)!,
                 signInUseCase: resolver.resolve(SignInUseCase.self)!,
+                hydrationReminderUseCase: resolver.resolve(HydrationReminderUseCase.self)!,
                 appSession: resolver.resolve(AppSession.self)!,
                 widgetTimelineReloader: resolver.resolve((any WidgetTimelineReloading).self)!,
                 appInfoProvider: resolver.resolve((any AppInfoProviding).self)!

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -192,6 +192,7 @@ public final class PresentationAssembly: Assembly {
             SettingsViewModel(
                 userPreferencesUseCase: resolver.resolve(UserPreferencesUseCase.self)!,
                 signInUseCase: resolver.resolve(SignInUseCase.self)!,
+                hydrationReminderUseCase: resolver.resolve(HydrationReminderUseCase.self)!,
                 appSession: resolver.resolve(AppSession.self)!,
                 widgetTimelineReloader: resolver.resolve((any WidgetTimelineReloading).self)!,
                 appInfoProvider: resolver.resolve((any AppInfoProviding).self)!,

--- a/Project/Shared/DependencyInjection/Sources/Testing/MockHydrationReminderUseCaseForTesting.swift
+++ b/Project/Shared/DependencyInjection/Sources/Testing/MockHydrationReminderUseCaseForTesting.swift
@@ -18,6 +18,8 @@ public final class MockHydrationReminderUseCaseForTesting: HydrationReminderUseC
 
     public func syncReminders() async {}
 
+    public func cancelReminders() async {}
+
     public func hasSeenPermissionPriming() -> Bool {
         hasSeenPriming
     }


### PR DESCRIPTION
## 📝 Summary

- 회원 탈퇴 성공 시 스케줄된 `hydrationReminder.*` 로컬 알림을 정리합니다.
- 앱 포그라운드 상태에서도 수분 리마인더 배너와 소리를 표시합니다.
- 수분 리마인더 탭을 `mulimi://hydration/record` 딥링크로 연결해 메인 기록 화면으로 이동합니다.

## 🎯 Type of Change

- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [x] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues

- Closes #272
- Related to #271, #257

## 📋 Changes Made

### Added

- `UNUserNotificationCenterDelegate` 기반 AppDelegate 알림 처리
- `hydrationLogging` AppRoute와 수분 기록 딥링크 라우팅 테스트
- 리마인더 취소 UseCase 및 회원 탈퇴 성공/실패 테스트

### Changed

- `SettingsViewModel`이 회원 탈퇴 성공 후에만 수분 리마인더를 취소하도록 변경
- DI Production/Preview/Testing 구성에 `HydrationReminderUseCase` 의존성 반영
- 수분 리마인더 제품 스펙에 탈퇴 정리, 포그라운드 표시, 탭 라우팅 정책 반영

### Fixed

- 없음

### Removed

- 제품 스펙의 해결된 Known Limitations 2건

## 🔍 Technical Details

- 기존 `hydrationReminder.*` 식별자만 delegate에서 처리해 다른 알림 동작에는 영향을 주지 않습니다.
- `UNUserNotificationCenterDelegate` 콜백은 Swift 6 요구에 맞게 `nonisolated`로 두고, `AppCoordinator` 경로 변경만 `MainActor.run`에서 수행합니다.
- 계정 삭제가 실패하면 리마인더를 유지합니다. 로그아웃 시 리마인더를 유지하는 기존 재방문 정책도 변경하지 않았습니다.
- 알림 탭은 내부 딥링크 `mulimi://hydration/record`를 기존 `ContentView + AppCoordinator` 전역 push 구조로 전달합니다.

## 📸 Screenshots / Videos

### Before

- 첨부 없음: 포그라운드에서는 수분 리마인더 배너가 표시되지 않았습니다.

### After

- 첨부 없음: 시스템 알림 배너 동작으로 별도 앱 UI 변경은 없습니다.

## ✅ Testing

### 실행한 로컬 검증

- [x] `git diff --check`
- [x] `make lint`
- [x] `make arch-check`
- [x] `tuist generate`
- [x] `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer ...`
- [ ] `xcodebuild test -workspace Mulimi.xcworkspace -scheme DataLayer ...`
- [x] `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer ...`
- [x] `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi ...`

### 실행하지 않은 검증과 이유

- DataLayer 테스트: Data 구현 변경 없음
- 실기기 알림 발화/탭: 로컬 자동 검증 범위 밖
- Watch/Widget 테스트: 해당 타깃 변경 없음

### 자동화 결과

- GitHub Actions: PR 생성 후 확인 예정
- Xcode Cloud: PR 생성 후 확인 예정

### 검증 환경

- Xcode: 26.6 (17F113)
- iOS / Simulator / Device: iOS 26.5 / iPhone 17 Pro Simulator
- Tuist: 4.88.0

### 기존 경고와 새 경고

- Existing: DomainLayer `HealthKitUseCaseTests.swift`의 미사용 반환값 경고, full build의 `dummy.o`/AccentColor/PostHog script phase 경고
- New: 없음

## 🚨 Breaking Changes

- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes

- 전체 외부 URL scheme 등록과 route table 확장은 #257 범위로 유지했습니다. 이번 변경은 수분 리마인더 탭의 내부 라우팅만 추가합니다.
- 시스템 배너와 실제 알림 탭 동작은 실기기 QA가 필요합니다.

## 📝 Documentation

- `Docs/product-specs/hydration-reminder-priming.md`

## 👀 Review Checklist

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다.
- [x] 새로운 의존성이 필요하지 않습니다.
- [x] 관련 제품 스펙을 갱신했습니다.
- [x] 데이터베이스 마이그레이션이 필요하지 않습니다.
- [x] 환경 설정 변경이 필요하지 않습니다.
