### PR TITLE
반복 수분 기록 후 App Store 리뷰 요청 트리거 추가

### DIFF
--- a/Docs/product-specs/analytics-events.md
+++ b/Docs/product-specs/analytics-events.md
@@ -48,6 +48,7 @@
 | `water_logged` | `source`, `serving_type`, `volume_ml`, `daily_goal_ml` | 물 기록 성공 |
 | `water_log_failed` | `source`, `serving_type`, `failure_reason` | 물 기록 권한/입력/목표 초과 차단 또는 HealthKit 저장 실패 |
 | `water_preset_logged` | `source`, `preset`, `volume_ml` | 330ml/500ml 프리셋 기록 성공 |
+| `app_review_request_attempted` | `source`, `context` | 반복 사용 후 목표 달성으로 시스템 리뷰 요청 API 호출 직전 |
 | `routine_created` | `source`, `enabled`, `weekday_count` | 루틴 생성 저장 성공 |
 | `routine_updated` | `source`, `enabled`, `weekday_count` | 루틴 수정 저장 성공 |
 | `routine_deleted` | `source`, `enabled`, `weekday_count` | 루틴 삭제 성공 |
@@ -83,6 +84,10 @@
 - `bottle`
 - `tumbler`
 
+### `context`
+
+- `sustained_goal_achievement`
+
 ### `failure_reason`
 
 - `healthkit_permission_required`
@@ -113,6 +118,7 @@
 - Firebase 퍼널, 대시보드, DebugView QA 기준은 [Analytics Operations](analytics-operations.md)를 따른다.
 - 코드 변경 후 `make lint`와 `make arch-check`를 통과시킨다.
 - ViewModel 단위 테스트에서는 Firebase 대신 Analytics mock으로 이벤트 호출을 확인한다.
+- 시스템 리뷰 요청은 표시나 작성 완료 콜백이 없으므로 `shown` 또는 `completed` 이벤트를 만들지 않는다.
 
 ## Related Code
 

--- a/Docs/product-specs/hydration-logging.md
+++ b/Docs/product-specs/hydration-logging.md
@@ -42,6 +42,17 @@
 
 기본 기록량 개인화가 필요하면 #203 범위를 기능 이슈로 복원하고, App Group에서 앱/Widget/AppIntent/Watch가 함께 읽을 수 있는 사용자 설정으로 설계한다.
 
+## App Store Review Request Policy
+
+- 메인 화면의 성공한 수분 기록으로 오늘 목표를 처음 달성한 순간만 리뷰 요청 후보로 본다.
+- 최근 30일에 물리미 소유 HealthKit 기록일이 3일 이상이고, 가장 이른 소유 기록일이 7일 이상 지난 사용자만 후보가 된다.
+- 수분 기록과 기록일의 원본은 계속 HealthKit으로 유지한다. 로컬에는 요청을 시도한 marketing version과 최근 요청 시각만 저장한다.
+- 같은 marketing version에서는 한 번만 시도하고, 마지막 시도 후 120일이 지나야 하며, 최근 365일 요청 시도는 3회 미만이어야 한다.
+- 기존 기록 성공 피드백이 사라진 뒤 2초를 더 기다리고, 앱이 inactive가 되거나 alert가 나타나거나 사용자가 화면을 벗어나면 후보를 취소한다.
+- StoreKit의 시스템 `RequestReviewAction`만 사용하며 커스텀 사전 리뷰 팝업은 만들지 않는다.
+- 요청 API는 실제 프롬프트 표시나 리뷰 작성 결과를 알려주지 않는다. 개발 빌드에서는 흐름을 확인할 수 있지만 TestFlight에서는 프롬프트가 표시되지 않는다.
+- 로그아웃이나 회원 탈퇴로 리뷰 요청 이력을 초기화하지 않는다.
+
 ## Siri And Shortcuts Policy
 
 - Shortcuts, Siri, Spotlight에는 `LogWaterAppShortcuts`로 기본 물 기록 App Shortcut을 노출한다.

--- a/Project/Data/Sources/DataSource/AppReviewRequestStorageDataSource.swift
+++ b/Project/Data/Sources/DataSource/AppReviewRequestStorageDataSource.swift
@@ -1,0 +1,36 @@
+import DomainLayerInterface
+import Foundation
+import Utils
+
+public protocol AppReviewRequestStorageDataSource: Sendable {
+    func fetchState() -> AppReviewRequestState
+    func saveState(_ state: AppReviewRequestState)
+}
+
+public final class AppReviewRequestStorageDataSourceImpl: AppReviewRequestStorageDataSource,
+                                                          @unchecked Sendable {
+    private let userDefaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+    }
+
+    public func fetchState() -> AppReviewRequestState {
+        guard let data = userDefaults.data(forKey: .appReviewRequestState) else {
+            return .empty
+        }
+
+        return (try? decoder.decode(AppReviewRequestState.self, from: data)) ?? .empty
+    }
+
+    public func saveState(_ state: AppReviewRequestState) {
+        guard let data = try? encoder.encode(state) else {
+            return
+        }
+
+        userDefaults.set(data, forKey: .appReviewRequestState)
+        userDefaults.synchronize()
+    }
+}

--- a/Project/Data/Sources/Repository/AppReviewRequestRepositoryImpl.swift
+++ b/Project/Data/Sources/Repository/AppReviewRequestRepositoryImpl.swift
@@ -1,0 +1,17 @@
+import DomainLayerInterface
+
+public struct AppReviewRequestRepositoryImpl: AppReviewRequestRepository {
+    private let storageDataSource: AppReviewRequestStorageDataSource
+
+    public init(storageDataSource: AppReviewRequestStorageDataSource) {
+        self.storageDataSource = storageDataSource
+    }
+
+    public func fetchState() -> AppReviewRequestState {
+        storageDataSource.fetchState()
+    }
+
+    public func saveState(_ state: AppReviewRequestState) {
+        storageDataSource.saveState(state)
+    }
+}

--- a/Project/Data/Tests/AppReviewRequestStorageDataSourceTests.swift
+++ b/Project/Data/Tests/AppReviewRequestStorageDataSourceTests.swift
@@ -1,0 +1,47 @@
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@testable import DataLayer
+
+@Suite("AppReviewRequestStorageDataSource Tests")
+struct AppReviewRequestStorageDataSourceTests {
+    @Test("리뷰 요청 상태를 저장하고 다시 읽는다")
+    func saveAndFetchState() {
+        let suiteName = "AppReviewRequestStorageDataSourceTests.\(UUID().uuidString)"
+        let userDefaults = makeIsolatedUserDefaults(suiteName: suiteName)
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+        let dataSource = AppReviewRequestStorageDataSourceImpl(userDefaults: userDefaults)
+        let state = AppReviewRequestState(
+            attemptedMarketingVersions: ["1.0.0", "2.0.0"],
+            attemptDates: [
+                Date(timeIntervalSince1970: 1_710_000_000),
+                Date(timeIntervalSince1970: 1_720_000_000)
+            ]
+        )
+
+        dataSource.saveState(state)
+
+        #expect(dataSource.fetchState() == state)
+    }
+
+    @Test("저장값이 없거나 손상되면 빈 상태를 반환한다")
+    func emptyAndCorruptState() {
+        let suiteName = "AppReviewRequestStorageDataSourceTests.\(UUID().uuidString)"
+        let userDefaults = makeIsolatedUserDefaults(suiteName: suiteName)
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+        let dataSource = AppReviewRequestStorageDataSourceImpl(userDefaults: userDefaults)
+
+        #expect(dataSource.fetchState() == .empty)
+
+        userDefaults.set(Data("invalid".utf8), forKey: .appReviewRequestState)
+
+        #expect(dataSource.fetchState() == .empty)
+    }
+
+    private func makeIsolatedUserDefaults(suiteName: String) -> UserDefaults {
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+}

--- a/Project/Domain/Interfaces/Entity/AppReviewRequestState.swift
+++ b/Project/Domain/Interfaces/Entity/AppReviewRequestState.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct AppReviewRequestState: Codable, Equatable, Sendable {
+    public let attemptedMarketingVersions: Set<String>
+    public let attemptDates: [Date]
+
+    public init(
+        attemptedMarketingVersions: Set<String>,
+        attemptDates: [Date]
+    ) {
+        self.attemptedMarketingVersions = attemptedMarketingVersions
+        self.attemptDates = attemptDates
+    }
+
+    public static let empty = AppReviewRequestState(
+        attemptedMarketingVersions: [],
+        attemptDates: []
+    )
+}

--- a/Project/Domain/Interfaces/Entity/ProductAnalyticsEvent.swift
+++ b/Project/Domain/Interfaces/Entity/ProductAnalyticsEvent.swift
@@ -235,6 +235,19 @@ public extension ProductAnalyticsEvent {
         )
     }
 
+    static func appReviewRequestAttempted(
+        source: String,
+        context: String
+    ) -> ProductAnalyticsEvent {
+        ProductAnalyticsEvent(
+            name: "app_review_request_attempted",
+            parameters: [
+                AnalyticsParameterName.source: .string(source),
+                AnalyticsParameterName.context: .string(context)
+            ]
+        )
+    }
+
     static func routineCreated(
         source: String,
         enabled: Bool,

--- a/Project/Domain/Interfaces/Repository/AppReviewRequestRepository.swift
+++ b/Project/Domain/Interfaces/Repository/AppReviewRequestRepository.swift
@@ -1,0 +1,4 @@
+public protocol AppReviewRequestRepository: Sendable {
+    func fetchState() -> AppReviewRequestState
+    func saveState(_ state: AppReviewRequestState)
+}

--- a/Project/Domain/Interfaces/UseCase/AppReviewRequestUseCase.swift
+++ b/Project/Domain/Interfaces/UseCase/AppReviewRequestUseCase.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public protocol AppReviewRequestUseCase: Sendable {
+    func shouldRequestAfterSuccessfulHydrationRecord(
+        previousIntakeML: Double,
+        currentIntakeML: Double,
+        marketingVersion: String,
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> Bool
+
+    func recordRequestAttempt(
+        marketingVersion: String,
+        referenceDate: Date,
+        calendar: Calendar
+    )
+}
+
+public struct NoOpAppReviewRequestUseCase: AppReviewRequestUseCase {
+    public init() {}
+
+    public func shouldRequestAfterSuccessfulHydrationRecord(
+        previousIntakeML: Double,
+        currentIntakeML: Double,
+        marketingVersion: String,
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> Bool {
+        false
+    }
+
+    public func recordRequestAttempt(
+        marketingVersion: String,
+        referenceDate: Date,
+        calendar: Calendar
+    ) {}
+}

--- a/Project/Domain/Sources/UseCase/AppReviewRequestUseCaseImpl.swift
+++ b/Project/Domain/Sources/UseCase/AppReviewRequestUseCaseImpl.swift
@@ -1,0 +1,158 @@
+import DomainLayerInterface
+import Foundation
+
+public struct AppReviewRequestUseCaseImpl: AppReviewRequestUseCase {
+    private enum Policy {
+        static let historyDayCount = 30
+        static let minimumOwnedRecordDayCount = 3
+        static let minimumUsageDayCount = 7
+        static let requestCooldownDayCount = 120
+        static let annualWindowDayCount = 365
+        static let annualRequestLimit = 3
+    }
+
+    private let drinkWaterRepository: DrinkWaterRepository
+    private let userPreferencesRepository: UserPreferencesRepository
+    private let appReviewRequestRepository: AppReviewRequestRepository
+
+    public init(
+        drinkWaterRepository: DrinkWaterRepository,
+        userPreferencesRepository: UserPreferencesRepository,
+        appReviewRequestRepository: AppReviewRequestRepository
+    ) {
+        self.drinkWaterRepository = drinkWaterRepository
+        self.userPreferencesRepository = userPreferencesRepository
+        self.appReviewRequestRepository = appReviewRequestRepository
+    }
+
+    public func shouldRequestAfterSuccessfulHydrationRecord(
+        previousIntakeML: Double,
+        currentIntakeML: Double,
+        marketingVersion: String,
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> Bool {
+        let normalizedVersion = marketingVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedVersion.isEmpty, normalizedVersion != "-" else {
+            return false
+        }
+
+        let dailyGoalML = userPreferencesRepository.getDailyWaterLimit()
+        guard dailyGoalML > 0,
+              previousIntakeML.rounded() < dailyGoalML.rounded(),
+              currentIntakeML.rounded() >= dailyGoalML.rounded() else {
+            return false
+        }
+
+        let state = appReviewRequestRepository.fetchState()
+        let annualAttemptCount = recentAttemptCount(
+            state.attemptDates,
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+        guard !state.attemptedMarketingVersions.contains(normalizedVersion),
+              isOutsideCooldown(state.attemptDates, referenceDate: referenceDate, calendar: calendar),
+              annualAttemptCount < Policy.annualRequestLimit,
+              let historyInterval = historyInterval(referenceDate: referenceDate, calendar: calendar),
+              let minimumUsageDate = calendar.date(
+                  byAdding: .day,
+                  value: -Policy.minimumUsageDayCount,
+                  to: referenceDate
+              ) else {
+            return false
+        }
+
+        let ownedEvents = await drinkWaterRepository.hydrationEvents(in: historyInterval)
+            .filter(\.isOwnedByCurrentApp)
+        let distinctOwnedRecordDays = Set(
+            ownedEvents.map { calendar.startOfDay(for: $0.consumedAt) }
+        )
+        guard distinctOwnedRecordDays.count >= Policy.minimumOwnedRecordDayCount,
+              let earliestOwnedRecordDate = ownedEvents.map(\.consumedAt).min() else {
+            return false
+        }
+
+        return earliestOwnedRecordDate <= minimumUsageDate
+    }
+
+    public func recordRequestAttempt(
+        marketingVersion: String,
+        referenceDate: Date,
+        calendar: Calendar
+    ) {
+        let normalizedVersion = marketingVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedVersion.isEmpty, normalizedVersion != "-",
+              let annualCutoffDate = calendar.date(
+                  byAdding: .day,
+                  value: -Policy.annualWindowDayCount,
+                  to: referenceDate
+              ) else {
+            return
+        }
+
+        let currentState = appReviewRequestRepository.fetchState()
+        var attemptedVersions = currentState.attemptedMarketingVersions
+        attemptedVersions.insert(normalizedVersion)
+
+        let recentAttemptDates = currentState.attemptDates
+            .filter { $0 >= annualCutoffDate }
+            + [referenceDate]
+
+        appReviewRequestRepository.saveState(
+            AppReviewRequestState(
+                attemptedMarketingVersions: attemptedVersions,
+                attemptDates: recentAttemptDates.sorted()
+            )
+        )
+    }
+
+    private func isOutsideCooldown(
+        _ attemptDates: [Date],
+        referenceDate: Date,
+        calendar: Calendar
+    ) -> Bool {
+        guard let latestAttemptDate = attemptDates.max(),
+              let cooldownCutoffDate = calendar.date(
+                  byAdding: .day,
+                  value: -Policy.requestCooldownDayCount,
+                  to: referenceDate
+              ) else {
+            return true
+        }
+
+        return latestAttemptDate <= cooldownCutoffDate
+    }
+
+    private func recentAttemptCount(
+        _ attemptDates: [Date],
+        referenceDate: Date,
+        calendar: Calendar
+    ) -> Int {
+        guard let annualCutoffDate = calendar.date(
+            byAdding: .day,
+            value: -Policy.annualWindowDayCount,
+            to: referenceDate
+        ) else {
+            return attemptDates.count
+        }
+
+        return attemptDates.count { $0 >= annualCutoffDate }
+    }
+
+    private func historyInterval(
+        referenceDate: Date,
+        calendar: Calendar
+    ) -> DateInterval? {
+        let referenceDay = calendar.startOfDay(for: referenceDate)
+        guard let start = calendar.date(
+            byAdding: .day,
+            value: -(Policy.historyDayCount - 1),
+            to: referenceDay
+        ),
+        let end = calendar.date(byAdding: .day, value: 1, to: referenceDay) else {
+            return nil
+        }
+
+        return DateInterval(start: start, end: end)
+    }
+}

--- a/Project/Domain/Tests/AppReviewRequestUseCaseTests.swift
+++ b/Project/Domain/Tests/AppReviewRequestUseCaseTests.swift
@@ -1,0 +1,241 @@
+import DomainLayer
+import DomainLayerInterface
+import Foundation
+import Testing
+
+@Suite("AppReviewRequestUseCase Tests")
+struct AppReviewRequestUseCaseTests {
+    @Test("정확히 3일 기록하고 첫 기록 후 7일이면 리뷰를 요청한다")
+    func eligibleAtUsageBoundaries() async {
+        let (useCase, _) = makeUseCase(ownedRecordDayOffsets: [-7, -2, 0])
+
+        let shouldRequest = await shouldRequest(useCase)
+
+        #expect(shouldRequest)
+    }
+
+    @Test("첫 기록 후 7일에서 1분이 부족하면 리뷰를 요청하지 않는다")
+    func rejectsUsageShorterThanSevenFullDays() async {
+        let almostSevenDaysAgo = date(dayOffset: -7).addingTimeInterval(60)
+        let (useCase, _) = makeUseCase(
+            ownedRecordDayOffsets: [-2, 0],
+            additionalOwnedRecordDates: [almostSevenDaysAgo]
+        )
+
+        #expect(await shouldRequest(useCase) == false)
+    }
+
+    @Test("앱 소유 기록일이나 사용 기간이 부족하면 요청하지 않는다")
+    func rejectsInsufficientUsage() async {
+        let (twoRecordDaysUseCase, _) = makeUseCase(ownedRecordDayOffsets: [-7, 0])
+        let (sixUsageDaysUseCase, _) = makeUseCase(ownedRecordDayOffsets: [-6, -2, 0])
+
+        #expect(await shouldRequest(twoRecordDaysUseCase) == false)
+        #expect(await shouldRequest(sixUsageDaysUseCase) == false)
+    }
+
+    @Test("다른 앱의 HealthKit 기록은 사용일 계산에서 제외한다")
+    func ignoresExternallyOwnedRecords() async {
+        let (useCase, _) = makeUseCase(
+            ownedRecordDayOffsets: [-7],
+            externalRecordDayOffsets: [-2, 0]
+        )
+
+        #expect(await shouldRequest(useCase) == false)
+    }
+
+    @Test("이번 기록으로 목표를 처음 달성한 경우에만 요청한다")
+    func requiresFirstGoalAchievementTransition() async {
+        let (useCase, _) = makeUseCase(ownedRecordDayOffsets: [-7, -2, 0])
+
+        let belowGoal = await shouldRequest(
+            useCase,
+            previousIntakeML: 500,
+            currentIntakeML: 750
+        )
+        let alreadyReached = await shouldRequest(
+            useCase,
+            previousIntakeML: 1_000,
+            currentIntakeML: 1_250
+        )
+
+        #expect(belowGoal == false)
+        #expect(alreadyReached == false)
+    }
+
+    @Test("이미 시도한 marketing version에서는 요청하지 않는다")
+    func rejectsAttemptedMarketingVersion() async {
+        let state = AppReviewRequestState(
+            attemptedMarketingVersions: ["2.0.0"],
+            attemptDates: []
+        )
+        let (useCase, _) = makeUseCase(
+            state: state,
+            ownedRecordDayOffsets: [-7, -2, 0]
+        )
+
+        #expect(await shouldRequest(useCase) == false)
+    }
+
+    @Test("마지막 시도 후 정확히 120일이면 허용하고 119일이면 차단한다")
+    func enforcesRequestCooldownBoundary() async {
+        let blockedState = AppReviewRequestState(
+            attemptedMarketingVersions: ["1.0.0"],
+            attemptDates: [date(dayOffset: -119)]
+        )
+        let allowedState = AppReviewRequestState(
+            attemptedMarketingVersions: ["1.0.0"],
+            attemptDates: [date(dayOffset: -120)]
+        )
+        let (blockedUseCase, _) = makeUseCase(
+            state: blockedState,
+            ownedRecordDayOffsets: [-7, -2, 0]
+        )
+        let (allowedUseCase, _) = makeUseCase(
+            state: allowedState,
+            ownedRecordDayOffsets: [-7, -2, 0]
+        )
+
+        #expect(await shouldRequest(blockedUseCase) == false)
+        #expect(await shouldRequest(allowedUseCase))
+    }
+
+    @Test("최근 365일 요청 시도가 3회면 차단하고 만료된 시도는 제외한다")
+    func enforcesAnnualAttemptLimit() async {
+        let blockedState = AppReviewRequestState(
+            attemptedMarketingVersions: ["1.0.0"],
+            attemptDates: [-130, -200, -365].map { date(dayOffset: $0) }
+        )
+        let allowedState = AppReviewRequestState(
+            attemptedMarketingVersions: ["1.0.0"],
+            attemptDates: [-366, -500].map { date(dayOffset: $0) }
+        )
+        let (blockedUseCase, _) = makeUseCase(
+            state: blockedState,
+            ownedRecordDayOffsets: [-7, -2, 0]
+        )
+        let (allowedUseCase, _) = makeUseCase(
+            state: allowedState,
+            ownedRecordDayOffsets: [-7, -2, 0]
+        )
+
+        #expect(await shouldRequest(blockedUseCase) == false)
+        #expect(await shouldRequest(allowedUseCase))
+    }
+
+    @Test("요청 시도는 버전을 유지하고 365일이 지난 날짜만 정리한다")
+    func recordsAttemptAndPrunesExpiredDates() {
+        let initialState = AppReviewRequestState(
+            attemptedMarketingVersions: ["1.0.0"],
+            attemptDates: [date(dayOffset: -366), date(dayOffset: -120)]
+        )
+        let (useCase, repository) = makeUseCase(
+            state: initialState,
+            ownedRecordDayOffsets: []
+        )
+
+        useCase.recordRequestAttempt(
+            marketingVersion: "2.0.0",
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        #expect(repository.state.attemptedMarketingVersions == ["1.0.0", "2.0.0"])
+        #expect(repository.state.attemptDates == [date(dayOffset: -120), referenceDate])
+        #expect(repository.saveCallCount == 1)
+    }
+
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private var referenceDate: Date {
+        calendar.date(
+            from: DateComponents(
+                year: 2026,
+                month: 8,
+                day: 9,
+                hour: 12
+            )
+        )!
+    }
+
+    private func date(dayOffset: Int) -> Date {
+        calendar.date(byAdding: .day, value: dayOffset, to: referenceDate)!
+    }
+
+    private func makeUseCase(
+        state: AppReviewRequestState = .empty,
+        ownedRecordDayOffsets: [Int],
+        additionalOwnedRecordDates: [Date] = [],
+        externalRecordDayOffsets: [Int] = []
+    ) -> (AppReviewRequestUseCaseImpl, MockAppReviewRequestRepository) {
+        let drinkWaterRepository = MockDrinkWaterRepository()
+        let ownedRecordDates = ownedRecordDayOffsets.map { date(dayOffset: $0) }
+            + additionalOwnedRecordDates
+        let ownedEvents = ownedRecordDates.map { consumedAt in
+            HydrationEvent(
+                id: UUID(),
+                consumedAt: consumedAt,
+                volumeML: HydrationServing.defaultGlassVolumeML
+            )
+        }
+        let externalEvents = externalRecordDayOffsets.map { dayOffset in
+            HydrationEvent(
+                id: UUID(),
+                consumedAt: date(dayOffset: dayOffset),
+                volumeML: HydrationServing.defaultGlassVolumeML,
+                isOwnedByCurrentApp: false
+            )
+        }
+        drinkWaterRepository.setHydrationEvents(ownedEvents + externalEvents)
+
+        let userPreferencesRepository = MockUserPreferencesRepository()
+        userPreferencesRepository.setDailyWaterLimit(1_000)
+        let appReviewRequestRepository = MockAppReviewRequestRepository(state: state)
+
+        return (
+            AppReviewRequestUseCaseImpl(
+                drinkWaterRepository: drinkWaterRepository,
+                userPreferencesRepository: userPreferencesRepository,
+                appReviewRequestRepository: appReviewRequestRepository
+            ),
+            appReviewRequestRepository
+        )
+    }
+
+    private func shouldRequest(
+        _ useCase: AppReviewRequestUseCaseImpl,
+        previousIntakeML: Double = 750,
+        currentIntakeML: Double = 1_000
+    ) async -> Bool {
+        await useCase.shouldRequestAfterSuccessfulHydrationRecord(
+            previousIntakeML: previousIntakeML,
+            currentIntakeML: currentIntakeML,
+            marketingVersion: "2.0.0",
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+    }
+}
+
+private final class MockAppReviewRequestRepository: AppReviewRequestRepository,
+                                                    @unchecked Sendable {
+    private(set) var state: AppReviewRequestState
+    private(set) var saveCallCount = 0
+
+    init(state: AppReviewRequestState) {
+        self.state = state
+    }
+
+    func fetchState() -> AppReviewRequestState {
+        state
+    }
+
+    func saveState(_ state: AppReviewRequestState) {
+        saveCallCount += 1
+        self.state = state
+    }
+}

--- a/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
+++ b/Project/Presentation/Sources/View/DrinkWater/DrinkWaterView.swift
@@ -8,6 +8,7 @@
 import DesignSystem
 import DomainLayerInterface
 import Localization
+import StoreKit
 import SwiftUI
 import UIKit
 
@@ -15,8 +16,16 @@ public struct DrinkWaterView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.openURL) private var openURL
+    @Environment(\.requestReview) private var requestReview
+    @Environment(\.scenePhase) private var scenePhase
     private var viewModel: DrinkWaterViewModel
     @State private var isResetConfirmationPresented = false
+
+    private struct AppReviewRequestTaskID: Equatable {
+        let requestID: UUID?
+        let isSuccessFeedbackVisible: Bool
+        let isBlocked: Bool
+    }
 
     public init(viewModel: DrinkWaterViewModel) {
         self.viewModel = viewModel
@@ -67,6 +76,9 @@ public struct DrinkWaterView: View {
 
             try? await Task.sleep(nanoseconds: 1_400_000_000)
             viewModel.clearRecordSuccessFeedback()
+        }
+        .task(id: appReviewRequestTaskID) {
+            await requestAppReviewIfReady()
         }
         .alert(
             L10n.tr("drinkWaterResetConfirmationTitle"),
@@ -126,6 +138,58 @@ public struct DrinkWaterView: View {
         } message: {
             Text(viewModel.undoErrorMessage ?? "")
         }
+        .onDisappear {
+            viewModel.cancelPendingAppReviewRequest()
+        }
+    }
+
+    private var appReviewRequestTaskID: AppReviewRequestTaskID {
+        AppReviewRequestTaskID(
+            requestID: viewModel.pendingAppReviewRequestID,
+            isSuccessFeedbackVisible: viewModel.recordSuccessFeedbackMessage != nil,
+            isBlocked: isAppReviewRequestBlocked
+        )
+    }
+
+    private var isAppReviewRequestBlocked: Bool {
+        scenePhase != .active ||
+        isResetConfirmationPresented ||
+        viewModel.recordFailureAlert != nil ||
+        viewModel.undoErrorMessage != nil
+    }
+
+    private func requestAppReviewIfReady() async {
+        let taskID = appReviewRequestTaskID
+        guard let requestID = taskID.requestID else {
+            return
+        }
+
+        guard !taskID.isBlocked else {
+            viewModel.cancelPendingAppReviewRequest(id: requestID)
+            return
+        }
+
+        guard !taskID.isSuccessFeedbackVisible else {
+            return
+        }
+
+        do {
+            try await Task.sleep(for: .seconds(2))
+        } catch {
+            return
+        }
+
+        guard !isAppReviewRequestBlocked,
+              viewModel.recordSuccessFeedbackMessage == nil else {
+            viewModel.cancelPendingAppReviewRequest(id: requestID)
+            return
+        }
+
+        guard viewModel.consumePendingAppReviewRequest(id: requestID) else {
+            return
+        }
+
+        requestReview()
     }
 
     private var progressAccessibilityLabel: String {

--- a/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
+++ b/Project/Presentation/Sources/ViewModel/DrinkWaterViewModel.swift
@@ -53,6 +53,7 @@ public final class DrinkWaterViewModel {
     private(set) var undoErrorMessage: String?
     private(set) var recordFailureAlert: HydrationRecordFailureAlertModel?
     private(set) var recordSuccessFeedbackMessage: String?
+    private(set) var pendingAppReviewRequestID: UUID?
     private(set) var isRecording = false
 
     private let waterUseCase: DrinkWaterUseCase
@@ -60,6 +61,8 @@ public final class DrinkWaterViewModel {
     private let nextActionGuideUseCase: HydrationNextActionGuideUseCase
     private let widgetTimelineReloader: any WidgetTimelineReloading
     private let analyticsUseCase: AnalyticsUseCase
+    private let appReviewRequestUseCase: AppReviewRequestUseCase
+    private let appInfoProvider: any AppInfoProviding
     private let calendar: Calendar
     private let nowProvider: @Sendable () -> Date
     private(set) var nextActionGuide: HydrationNextActionGuide
@@ -169,6 +172,11 @@ public final class DrinkWaterViewModel {
         nextActionGuideUseCase: HydrationNextActionGuideUseCase,
         widgetTimelineReloader: any WidgetTimelineReloading,
         analyticsUseCase: AnalyticsUseCase = NoOpAnalyticsUseCase(),
+        appReviewRequestUseCase: AppReviewRequestUseCase = NoOpAppReviewRequestUseCase(),
+        appInfoProvider: any AppInfoProviding = StaticAppInfoProvider(
+            appVersion: "-",
+            appBuildNumber: "-"
+        ),
         calendar: Calendar = .current,
         nowProvider: @escaping @Sendable () -> Date = { .now }
     ) {
@@ -177,6 +185,8 @@ public final class DrinkWaterViewModel {
         self.nextActionGuideUseCase = nextActionGuideUseCase
         self.widgetTimelineReloader = widgetTimelineReloader
         self.analyticsUseCase = analyticsUseCase
+        self.appReviewRequestUseCase = appReviewRequestUseCase
+        self.appInfoProvider = appInfoProvider
         self.calendar = calendar
         self.nowProvider = nowProvider
         let initialWaterIntakeML = 0.0
@@ -263,6 +273,7 @@ public final class DrinkWaterViewModel {
         }
 
         recordSuccessFeedbackMessage = nil
+        cancelPendingAppReviewRequest()
 
         guard isRecordable(volumeML: volumeML) else {
             return false
@@ -273,6 +284,7 @@ public final class DrinkWaterViewModel {
             isRecording = false
         }
 
+        let previousIntakeML = currentWaterIntakeML
         let writeResult = await waterUseCase.drinkWater(volumeML: volumeML)
         guard writeResult.isSuccess else {
             recordFailureAlert = makeRecordFailureAlert(
@@ -296,6 +308,10 @@ public final class DrinkWaterViewModel {
             volumeML: volumeML,
             servingType: servingType,
             preset: preset
+        )
+        await prepareAppReviewRequest(
+            previousIntakeML: previousIntakeML,
+            currentIntakeML: currentWaterIntakeML
         )
         return true
     }
@@ -360,6 +376,7 @@ public final class DrinkWaterViewModel {
     }
 
     func reset() async {
+        cancelPendingAppReviewRequest()
         let writeResult = await waterUseCase.reset()
         guard writeResult.isSuccess else {
             recordFailureAlert = makeResetFailureAlert(
@@ -378,6 +395,7 @@ public final class DrinkWaterViewModel {
 
     @discardableResult
     func undoRecentRecord() async -> Bool {
+        cancelPendingAppReviewRequest()
         guard let recentRecordUndo else {
             return false
         }
@@ -406,6 +424,34 @@ public final class DrinkWaterViewModel {
 
     func clearRecordSuccessFeedback() {
         recordSuccessFeedbackMessage = nil
+    }
+
+    func consumePendingAppReviewRequest(id: UUID) -> Bool {
+        guard pendingAppReviewRequestID == id else {
+            return false
+        }
+
+        pendingAppReviewRequestID = nil
+        appReviewRequestUseCase.recordRequestAttempt(
+            marketingVersion: appInfoProvider.appVersion,
+            referenceDate: nowProvider(),
+            calendar: calendar
+        )
+        analyticsUseCase.track(
+            .appReviewRequestAttempted(
+                source: "drink_water_main",
+                context: "sustained_goal_achievement"
+            )
+        )
+        return true
+    }
+
+    func cancelPendingAppReviewRequest(id: UUID? = nil) {
+        guard id == nil || pendingAppReviewRequestID == id else {
+            return
+        }
+
+        pendingAppReviewRequestID = nil
     }
 
     public func refreshState() async {
@@ -440,6 +486,33 @@ public final class DrinkWaterViewModel {
             ),
             actionTitle: L10n.tr("drinkWaterUndoRecordActionTitle")
         )
+    }
+
+    private func prepareAppReviewRequest(
+        previousIntakeML: Double,
+        currentIntakeML: Double
+    ) async {
+        guard previousIntakeML.rounded() < dailyLimit.rounded(),
+              currentIntakeML.rounded() >= dailyLimit.rounded(),
+              pendingAppReviewRequestID == nil else {
+            return
+        }
+
+        let shouldRequest = await appReviewRequestUseCase
+            .shouldRequestAfterSuccessfulHydrationRecord(
+                previousIntakeML: previousIntakeML,
+                currentIntakeML: currentIntakeML,
+                marketingVersion: appInfoProvider.appVersion,
+                referenceDate: nowProvider(),
+                calendar: calendar
+            )
+
+        if shouldRequest,
+           currentWaterIntakeML.rounded() == currentIntakeML.rounded(),
+           isLimitReached,
+           recordFailureAlert == nil {
+            pendingAppReviewRequestID = UUID()
+        }
     }
 
     private func servingTitle(for preset: HydrationServingPreset) -> String {

--- a/Project/Presentation/Tests/DrinkWaterViewModelTests.swift
+++ b/Project/Presentation/Tests/DrinkWaterViewModelTests.swift
@@ -642,6 +642,189 @@ struct DrinkWaterViewModelTests {
         )
     }
 
+    @MainActor
+    @Test("성공한 목표 달성 기록은 리뷰 요청 one-shot을 만든다")
+    func goalAchievementCreatesAppReviewRequest() async {
+        let now = Date.now
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.currentWaterIntakeMLValue = 750
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 1_000
+        let appReviewRequestUseCase = MockAppReviewRequestUseCase()
+        appReviewRequestUseCase.shouldRequestValue = true
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            nextActionGuideUseCase: StubHydrationNextActionGuideUseCase(),
+            widgetTimelineReloader: NoOpWidgetTimelineReloader(),
+            appReviewRequestUseCase: appReviewRequestUseCase,
+            appInfoProvider: StaticAppInfoProvider(
+                appVersion: "2.0.0",
+                appBuildNumber: "1"
+            ),
+            nowProvider: { now }
+        )
+
+        await viewModel.loadInitialState()
+        await viewModel.drinkWater()
+
+        #expect(appReviewRequestUseCase.eligibilityCallCount == 1)
+        #expect(appReviewRequestUseCase.previousIntakeML == 750)
+        #expect(appReviewRequestUseCase.currentIntakeML == 1_000)
+        #expect(appReviewRequestUseCase.eligibilityMarketingVersion == "2.0.0")
+        #expect(appReviewRequestUseCase.eligibilityReferenceDate == now)
+        #expect(viewModel.pendingAppReviewRequestID != nil)
+    }
+
+    @MainActor
+    @Test("목표 미달 또는 기록 실패에서는 리뷰 자격을 확인하지 않는다")
+    func ineligibleRecordDoesNotCreateAppReviewRequest() async {
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 1_000
+        let appReviewRequestUseCase = MockAppReviewRequestUseCase()
+        appReviewRequestUseCase.shouldRequestValue = true
+        let belowGoalWaterUseCase = MockDrinkWaterUseCase()
+        belowGoalWaterUseCase.currentWaterIntakeMLValue = 500
+        let belowGoalViewModel = DrinkWaterViewModel(
+            waterUseCase: belowGoalWaterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            nextActionGuideUseCase: StubHydrationNextActionGuideUseCase(),
+            widgetTimelineReloader: NoOpWidgetTimelineReloader(),
+            appReviewRequestUseCase: appReviewRequestUseCase,
+            appInfoProvider: StaticAppInfoProvider(
+                appVersion: "2.0.0",
+                appBuildNumber: "1"
+            )
+        )
+
+        await belowGoalViewModel.loadInitialState()
+        await belowGoalViewModel.drinkWater()
+
+        #expect(appReviewRequestUseCase.eligibilityCallCount == 0)
+        #expect(belowGoalViewModel.pendingAppReviewRequestID == nil)
+
+        let failedWaterUseCase = MockDrinkWaterUseCase()
+        failedWaterUseCase.currentWaterIntakeMLValue = 750
+        failedWaterUseCase.drinkWaterResult = .failure(.systemError)
+        let failedViewModel = DrinkWaterViewModel(
+            waterUseCase: failedWaterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            nextActionGuideUseCase: StubHydrationNextActionGuideUseCase(),
+            widgetTimelineReloader: NoOpWidgetTimelineReloader(),
+            appReviewRequestUseCase: appReviewRequestUseCase,
+            appInfoProvider: StaticAppInfoProvider(
+                appVersion: "2.0.0",
+                appBuildNumber: "1"
+            )
+        )
+
+        await failedViewModel.loadInitialState()
+        await failedViewModel.drinkWater()
+
+        #expect(appReviewRequestUseCase.eligibilityCallCount == 0)
+        #expect(failedViewModel.pendingAppReviewRequestID == nil)
+    }
+
+    @MainActor
+    @Test("리뷰 요청 one-shot은 한 번만 소비하고 시도 이벤트를 남긴다")
+    func appReviewRequestIsConsumedOnce() async {
+        let now = Date.now
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.currentWaterIntakeMLValue = 750
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 1_000
+        let appReviewRequestUseCase = MockAppReviewRequestUseCase()
+        appReviewRequestUseCase.shouldRequestValue = true
+        let analyticsUseCase = MockAnalyticsUseCase()
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            nextActionGuideUseCase: StubHydrationNextActionGuideUseCase(),
+            widgetTimelineReloader: NoOpWidgetTimelineReloader(),
+            analyticsUseCase: analyticsUseCase,
+            appReviewRequestUseCase: appReviewRequestUseCase,
+            appInfoProvider: StaticAppInfoProvider(
+                appVersion: "2.0.0",
+                appBuildNumber: "1"
+            ),
+            nowProvider: { now }
+        )
+
+        await viewModel.loadInitialState()
+        await viewModel.drinkWater()
+        let requestID = viewModel.pendingAppReviewRequestID!
+
+        let firstConsumption = viewModel.consumePendingAppReviewRequest(id: requestID)
+        let secondConsumption = viewModel.consumePendingAppReviewRequest(id: requestID)
+
+        #expect(firstConsumption)
+        #expect(secondConsumption == false)
+        #expect(viewModel.pendingAppReviewRequestID == nil)
+        #expect(appReviewRequestUseCase.recordAttemptCallCount == 1)
+        #expect(appReviewRequestUseCase.attemptedMarketingVersion == "2.0.0")
+        #expect(appReviewRequestUseCase.attemptReferenceDate == now)
+        #expect(analyticsUseCase.trackedEvents.map(\.name) == [
+            "water_logged",
+            "app_review_request_attempted"
+        ])
+        #expect(
+            analyticsUseCase.trackedEvents.last?.parameters["source"] ==
+            .string("drink_water_main")
+        )
+        #expect(
+            analyticsUseCase.trackedEvents.last?.parameters["context"] ==
+            .string("sustained_goal_achievement")
+        )
+    }
+
+    @MainActor
+    @Test("취소하거나 목표 달성 기록을 되돌리거나 초기화하면 리뷰 요청을 폐기한다")
+    func appReviewRequestCancellationPaths() async {
+        let waterUseCase = MockDrinkWaterUseCase()
+        waterUseCase.currentWaterIntakeMLValue = 750
+        let userPreferencesUseCase = MockUserPreferencesUseCase()
+        userPreferencesUseCase.dailyWaterLimitValue = 1_000
+        let appReviewRequestUseCase = MockAppReviewRequestUseCase()
+        appReviewRequestUseCase.shouldRequestValue = true
+        let viewModel = DrinkWaterViewModel(
+            waterUseCase: waterUseCase,
+            userPreferencesUseCase: userPreferencesUseCase,
+            nextActionGuideUseCase: StubHydrationNextActionGuideUseCase(),
+            widgetTimelineReloader: NoOpWidgetTimelineReloader(),
+            appReviewRequestUseCase: appReviewRequestUseCase,
+            appInfoProvider: StaticAppInfoProvider(
+                appVersion: "2.0.0",
+                appBuildNumber: "1"
+            )
+        )
+
+        await viewModel.loadInitialState()
+        await viewModel.drinkWater()
+        let undoneRequestID = viewModel.pendingAppReviewRequestID!
+
+        await viewModel.undoRecentRecord()
+
+        #expect(viewModel.consumePendingAppReviewRequest(id: undoneRequestID) == false)
+        #expect(appReviewRequestUseCase.recordAttemptCallCount == 0)
+
+        await viewModel.drinkWater()
+        let cancelledRequestID = viewModel.pendingAppReviewRequestID!
+
+        viewModel.cancelPendingAppReviewRequest(id: cancelledRequestID)
+
+        #expect(viewModel.consumePendingAppReviewRequest(id: cancelledRequestID) == false)
+        #expect(appReviewRequestUseCase.recordAttemptCallCount == 0)
+
+        await viewModel.undoRecentRecord()
+        await viewModel.drinkWater()
+        #expect(viewModel.pendingAppReviewRequestID != nil)
+
+        await viewModel.reset()
+
+        #expect(viewModel.pendingAppReviewRequestID == nil)
+        #expect(appReviewRequestUseCase.recordAttemptCallCount == 0)
+    }
+
 }
 
 private final class SpyWidgetTimelineReloader: WidgetTimelineReloading, @unchecked Sendable {

--- a/Project/Presentation/Tests/Mock/MockAppReviewRequestUseCase.swift
+++ b/Project/Presentation/Tests/Mock/MockAppReviewRequestUseCase.swift
@@ -1,0 +1,39 @@
+import DomainLayerInterface
+import Foundation
+
+final class MockAppReviewRequestUseCase: AppReviewRequestUseCase, @unchecked Sendable {
+    var shouldRequestValue = false
+    private(set) var eligibilityCallCount = 0
+    private(set) var recordAttemptCallCount = 0
+    private(set) var previousIntakeML: Double?
+    private(set) var currentIntakeML: Double?
+    private(set) var eligibilityMarketingVersion: String?
+    private(set) var eligibilityReferenceDate: Date?
+    private(set) var attemptedMarketingVersion: String?
+    private(set) var attemptReferenceDate: Date?
+
+    func shouldRequestAfterSuccessfulHydrationRecord(
+        previousIntakeML: Double,
+        currentIntakeML: Double,
+        marketingVersion: String,
+        referenceDate: Date,
+        calendar: Calendar
+    ) async -> Bool {
+        eligibilityCallCount += 1
+        self.previousIntakeML = previousIntakeML
+        self.currentIntakeML = currentIntakeML
+        eligibilityMarketingVersion = marketingVersion
+        eligibilityReferenceDate = referenceDate
+        return shouldRequestValue
+    }
+
+    func recordRequestAttempt(
+        marketingVersion: String,
+        referenceDate: Date,
+        calendar: Calendar
+    ) {
+        recordAttemptCallCount += 1
+        attemptedMarketingVersion = marketingVersion
+        attemptReferenceDate = referenceDate
+    }
+}

--- a/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DataAssembly.swift
@@ -37,6 +37,18 @@ public final class DataAssembly: Assembly {
             )
         }
 
+        // MARK: - AppReviewRequest
+        container.register(AppReviewRequestStorageDataSource.self) { _ in
+            AppReviewRequestStorageDataSourceImpl(userDefaults: .standard)
+        }
+        .inObjectScope(.container)
+
+        container.register(AppReviewRequestRepository.self) { resolver in
+            AppReviewRequestRepositoryImpl(
+                storageDataSource: resolver.resolve(AppReviewRequestStorageDataSource.self)!
+            )
+        }
+
         // MARK: - Analytics
         container.register(AnalyticsRepository.self) { _ in
             NoOpAnalyticsRepository()

--- a/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/DomainAssembly.swift
@@ -24,6 +24,13 @@ public final class DomainAssembly: Assembly {
                 repository: resolver.resolve(DrinkWaterRepository.self)!
             )
         }
+        container.register(AppReviewRequestUseCase.self) { resolver in
+            AppReviewRequestUseCaseImpl(
+                drinkWaterRepository: resolver.resolve(DrinkWaterRepository.self)!,
+                userPreferencesRepository: resolver.resolve(UserPreferencesRepository.self)!,
+                appReviewRequestRepository: resolver.resolve(AppReviewRequestRepository.self)!
+            )
+        }
         container.register(HydrationProgressUseCase.self) { resolver in
             HydrationProgressUseCaseImpl(
                 drinkWaterRepository: resolver.resolve(DrinkWaterRepository.self)!,

--- a/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
+++ b/Project/Shared/DependencyInjection/Sources/Production/PresentationAssembly.swift
@@ -38,6 +38,8 @@ public final class PresentationAssembly: Assembly {
             let nextActionGuideUseCase = resolver.resolve(HydrationNextActionGuideUseCase.self)!
             let widgetTimelineReloader = resolver.resolve((any WidgetTimelineReloading).self)!
             let analyticsUseCase = resolver.resolve(AnalyticsUseCase.self)!
+            let appReviewRequestUseCase = resolver.resolve(AppReviewRequestUseCase.self)!
+            let appInfoProvider = resolver.resolve((any AppInfoProviding).self)!
 
             return MainActor.assumeIsolated {
                 DrinkWaterViewModel(
@@ -45,7 +47,9 @@ public final class PresentationAssembly: Assembly {
                     userPreferencesUseCase: userPreferencesUseCase,
                     nextActionGuideUseCase: nextActionGuideUseCase,
                     widgetTimelineReloader: widgetTimelineReloader,
-                    analyticsUseCase: analyticsUseCase
+                    analyticsUseCase: analyticsUseCase,
+                    appReviewRequestUseCase: appReviewRequestUseCase,
+                    appInfoProvider: appInfoProvider
                 )
             }
         }

--- a/Project/Shared/Utils/Sources/String+Extensions.swift
+++ b/Project/Shared/Utils/Sources/String+Extensions.swift
@@ -31,4 +31,5 @@ public extension String {
     static let hasSeenHydrationReminderPriming: String = "hasSeenHydrationReminderPriming"
     static let hydrationChallengeStates: String = "hydrationChallengeStates"
     static let hydrationChallengeBadgeHistories: String = "hydrationChallengeBadgeHistories"
+    static let appReviewRequestState: String = "appReviewRequestState"
 }


### PR DESCRIPTION
## 📝 Summary

- 반복 사용자가 성공한 수분 기록으로 오늘 목표를 처음 달성했을 때 시스템 App Store 리뷰 요청을 시도합니다.
- 최근 앱 소유 HealthKit 기록일, 사용 기간, 앱 버전, 120일 cooldown, 365일 요청 횟수를 함께 검사합니다.
- 요청 시도 메타데이터 저장, one-shot UI 트리거, analytics와 제품 스펙 및 경계 테스트를 추가했습니다.

## 🎯 Type of Change

- [x] ✨ New feature (새로운 기능 추가)
- [ ] 🐛 Bug fix (버그 수정)
- [ ] 🔧 Configuration (설정 변경)
- [ ] ♻️ Refactoring (코드 리팩토링)
- [x] 📝 Documentation (문서 수정)
- [ ] 🎨 UI/UX (디자인 변경)
- [ ] ⚡ Performance (성능 개선)
- [ ] 🛡️ Security (보안 강화)
- [x] 🧪 Test (테스트 추가/수정)
- [ ] 🔨 Build (빌드 시스템 수정)

## 🔗 Related Issues

- Closes #282

## 📋 Changes Made

### Added

- 리뷰 요청 자격과 빈도 제한을 판단하는 Domain UseCase/Repository interface
- 요청한 marketing version과 최근 시도 시각을 저장하는 UserDefaults 기반 Data 구현
- `RequestReviewAction` one-shot 소비와 `app_review_request_attempted` analytics
- 3일·7일·120일·365일 경계, 저장 round-trip, ViewModel 소비/취소 테스트

### Changed

- 성공한 목표 달성 기록 이후 리뷰 후보를 생성하도록 `DrinkWaterViewModel`과 DI 조립을 확장
- 성공 피드백 종료 2초 후 active·alert 상태를 확인하도록 `DrinkWaterView` 흐름을 확장
- 수분 기록과 analytics 제품 스펙에 리뷰 요청 정책을 반영

### Fixed

- 없음

### Removed

- 없음

## 🔍 Technical Details

- 수분 기록일과 섭취량은 계속 HealthKit을 SSOT로 사용하며, 리뷰 저장소에는 요청 제어 메타데이터만 보관합니다.
- 자격 조건은 최근 30일 중 물리미 소유 기록일 3일 이상, 해당 기간의 가장 이른 기록 후 실제 7일 경과, 버전당 1회, 마지막 시도 후 120일, 최근 365일 3회 미만입니다.
- ViewModel은 StoreKit과 UserDefaults를 직접 알지 않으며, SwiftUI View가 one-shot ID를 원자적으로 소비한 직후 시스템 `requestReview()`를 호출합니다.
- 앱이 inactive가 되거나 alert가 표시되거나 사용자가 화면을 벗어나거나 목표 달성 기록을 되돌리면 대기 중 요청을 취소합니다.
- 시스템 API는 실제 프롬프트 표시나 리뷰 작성 결과를 제공하지 않으므로 analytics는 `attempted`까지만 기록합니다.

## 📸 Screenshots / Videos

### Before

- 첨부 없음: App Store 리뷰 요청 통합이 없었습니다.

### After

- 첨부 없음: 커스텀 UI 없이 시스템 `RequestReviewAction`만 사용합니다.

## ✅ Testing

### 실행한 로컬 검증

- [x] `git diff --check`
- [x] `make lint`
- [x] `make arch-check`
- [x] `tuist generate`
- [x] `xcodebuild test -workspace Mulimi.xcworkspace -scheme DomainLayer ...`
- [x] `xcodebuild test -workspace Mulimi.xcworkspace -scheme DataLayer ...`
- [x] `xcodebuild test -workspace Mulimi.xcworkspace -scheme PresentationLayer ...`
- [x] `xcodebuild build -workspace Mulimi.xcworkspace -scheme Mulimi ...`

### 실행하지 않은 검증과 이유

- 시스템 리뷰 프롬프트 수동 표시: 표시 여부는 StoreKit이 결정하며 실제 3일·7일 사용 이력이 필요한 시스템 UI입니다.
- TestFlight 리뷰 프롬프트: `RequestReviewAction`이 TestFlight 빌드에서는 프롬프트를 표시하지 않습니다.
- Watch/Widget 개별 테스트: 해당 타깃 동작 변경 없음

### 자동화 결과

- GitHub Actions: PR 생성 후 확인 예정
- Xcode Cloud: PR 생성 후 확인 예정

### 검증 환경

- Xcode: 26.6 (17F113)
- iOS / Simulator / Device: iOS 26.5 / iPhone 17 Pro Simulator
- Tuist: 4.88.0

### 기존 경고와 새 경고

- Existing: DomainLayer `HealthKitUseCaseTests.swift` 미사용 반환값, 앱 빌드의 `dummy.o`/AccentColor/PostHog script phase 경고
- New: 없음

## 🚨 Breaking Changes

- [ ] Yes (아래에 설명)
- [x] No

## 📌 Additional Notes

- 요청 이력은 계정이 아닌 설치된 앱 단위이며 로그아웃/회원 탈퇴 때 초기화하지 않습니다.
- SwiftUI task의 실제 시스템 프롬프트 노출은 수동 QA 대상으로 남기고, 자격·one-shot·undo/reset 취소 상태는 단위 테스트로 검증했습니다.

## 📝 Documentation

- `Docs/product-specs/hydration-logging.md`
- `Docs/product-specs/analytics-events.md`

## 👀 Review Checklist

- [x] 코드가 프로젝트의 코딩 컨벤션을 따릅니다.
- [x] 새로운 의존성이 필요하지 않습니다.
- [x] 관련 제품 스펙을 갱신했습니다.
- [x] 데이터베이스 마이그레이션이 필요하지 않습니다.
- [x] 환경 설정 변경이 필요하지 않습니다.
